### PR TITLE
Add docker files to create images using apt-get.

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,0 +1,49 @@
+FROM debian:unstable
+
+MAINTAINER Sysdig <support@sysdig.com>
+
+ENV FALCO_REPOSITORY dev
+
+LABEL RUN="docker run -i -t -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --name NAME IMAGE"
+
+ENV SYSDIG_HOST_ROOT /host
+
+ENV HOME /root
+
+RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
+
+ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+	bash-completion \
+	curl \
+	ca-certificates \
+	gcc \
+	gcc-4.9 && rm -rf /var/lib/apt/lists/*
+
+# Terribly terrible hacks: since our base Debian image ships with GCC 5.0 which breaks older kernels,
+# revert the default to gcc-4.9. Also, since some customers use some very old distributions whose kernel
+# makefile is hardcoded for gcc-4.6 or so (e.g. Debian Wheezy), we pretend to have gcc 4.6/4.7 by symlinking
+# it to 4.9
+
+RUN rm -rf /usr/bin/gcc \
+ && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc \
+ && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.8 \
+ && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.7 \
+ && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.6
+
+RUN curl -s https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public | apt-key add - \
+ && curl -s -o /etc/apt/sources.list.d/draios.list http://download.draios.com/$FALCO_REPOSITORY/deb/draios.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends falco \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN ln -s $SYSDIG_HOST_ROOT/lib/modules /lib/modules
+
+COPY ./docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["bash"]

--- a/docker/dev/docker-entrypoint.sh
+++ b/docker/dev/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#set -e
+
+echo "* Setting up /usr/src links from host"
+
+for i in $(ls $SYSDIG_HOST_ROOT/usr/src)
+do 
+	ln -s $SYSDIG_HOST_ROOT/usr/src/$i /usr/src/$i
+done
+
+/usr/bin/sysdig-probe-loader
+
+exec "$@"

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -1,0 +1,49 @@
+FROM debian:unstable
+
+MAINTAINER Sysdig <support@sysdig.com>
+
+ENV FALCO_REPOSITORY stable
+
+LABEL RUN="docker run -i -t -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --name NAME IMAGE"
+
+ENV SYSDIG_HOST_ROOT /host
+
+ENV HOME /root
+
+RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
+
+ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+	bash-completion \
+	curl \
+	ca-certificates \
+	gcc \
+	gcc-4.9 && rm -rf /var/lib/apt/lists/*
+
+# Terribly terrible hacks: since our base Debian image ships with GCC 5.0 which breaks older kernels,
+# revert the default to gcc-4.9. Also, since some customers use some very old distributions whose kernel
+# makefile is hardcoded for gcc-4.6 or so (e.g. Debian Wheezy), we pretend to have gcc 4.6/4.7 by symlinking
+# it to 4.9
+
+RUN rm -rf /usr/bin/gcc \
+ && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc \
+ && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.8 \
+ && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.7 \
+ && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc-4.6
+
+RUN curl -s https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public | apt-key add - \
+ && curl -s -o /etc/apt/sources.list.d/draios.list http://download.draios.com/$FALCO_REPOSITORY/deb/draios.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends falco \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN ln -s $SYSDIG_HOST_ROOT/lib/modules /lib/modules
+
+COPY ./docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["bash"]

--- a/docker/stable/docker-entrypoint.sh
+++ b/docker/stable/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#set -e
+
+echo "* Setting up /usr/src links from host"
+
+for i in $(ls $SYSDIG_HOST_ROOT/usr/src)
+do 
+	ln -s $SYSDIG_HOST_ROOT/usr/src/$i /usr/src/$i
+done
+
+/usr/bin/sysdig-probe-loader
+
+exec "$@"


### PR DESCRIPTION
Based on the Dockerfiles from the sysdig repository. The only change
from the sysdig versions is to use environment variable FALCO_REPOSITORY
and to install falco instead of sysdig.

Note that the entrypoint still uses sysdig-probe-loader and
SYSDIG_HOST_ROOT, as it's building the kernel module for sysdig.

I verified I could create and run an image using the dev and stable versions using
"docker build ." from docker/dev, and run it using:

```
docker run -i -t --name falco --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:r\o sysdig/falco:{dev,stable} falco
```

@henridf 
