### PR TITLE
Allow missing output fields.

### DIFF
--- a/userspace/falco/lua/output.lua
+++ b/userspace/falco/lua/output.lua
@@ -5,7 +5,7 @@ levels = {"Emergency", "Alert", "Critical", "Error", "Warning", "Notice", "Infor
 local outputs = {}
 
 function mod.stdout(evt, level, format)
-   format = "%evt.time: "..levels[level+1].." "..format
+   format = "*%evt.time: "..levels[level+1].." "..format
    formatter = falco.formatter(format)
    msg = falco.format_event(evt, formatter)
    print (msg)


### PR DESCRIPTION
Add a leading \* to the format string so output with missing fields is
just displayed with '<NA>' values instead of being aborted.

This fixes #42.

@henridf 
