### PR TITLE
Clean up handling cmdline options wrt config file.

### DIFF
--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -7,17 +7,21 @@ using namespace std;
 
 
 // If we don't have a configuration file, we just use stdout output and all other defaults
-void falco_configuration::init()
+void falco_configuration::init(std::list<std::string> &cmdline_options)
 {
+	init_cmdline_options(cmdline_options);
+
 	output_config stdout_output;
 	stdout_output.name = "stdout";
 	m_outputs.push_back(stdout_output);
 }
 
-void falco_configuration::init(string conf_filename)
+void falco_configuration::init(string conf_filename, std::list<std::string> &cmdline_options)
 {
 	string m_config_file = conf_filename;
 	m_config = new yaml_configuration(m_config_file);
+
+	init_cmdline_options(cmdline_options);
 
 	m_rules_filename = m_config->get_scalar<string>("rules_file", "/etc/falco_rules.yaml");
 	m_json_output = m_config->get_scalar<bool>("json_output", false);
@@ -57,4 +61,41 @@ void falco_configuration::init(string conf_filename)
 
 	falco_logger::log_stderr = m_config->get_scalar<bool>("log_stderr", false);
 	falco_logger::log_syslog = m_config->get_scalar<bool>("log_syslog", true);
+}
+
+static bool split(const string &str, char delim, pair<string,string> &parts)
+{
+	size_t pos;
+
+	if ((pos = str.find_first_of(delim)) == string::npos) {
+		return false;
+	}
+	parts.first = str.substr(0, pos);
+	parts.second = str.substr(pos + 1);
+
+	return true;
+}
+
+void falco_configuration::init_cmdline_options(std::list<std::string> &cmdline_options)
+{
+	for(const string &option : cmdline_options)
+	{
+		set_cmdline_option(option);
+	}
+}
+
+void falco_configuration::set_cmdline_option(const std::string &opt)
+{
+	pair<string,string> keyval;
+	pair<string,string> subkey;
+
+	if (! split(opt, '=', keyval)) {
+		throw sinsp_exception("Error parsing config option \"" + opt + "\". Must be of the form key=val or key.subkey=val");
+	}
+
+	if (split(keyval.first, '.', subkey)) {
+		m_config->set_scalar(subkey.first, subkey.second, keyval.second);
+	} else {
+		m_config->set_scalar(keyval.first, keyval.second);
+	}
 }

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -57,6 +57,19 @@ public:
 	}
 
 	/**
+	 * Set the top-level node identified by key to value
+	 */
+	template<typename T>
+	void set_scalar(const std::string &key, const T& value)
+	{
+		auto node = m_root;
+		if (node.IsDefined())
+		{
+			node[key] = value;
+		}
+	}
+
+	/**
 	* Get a scalar value defined inside a 2 level nested structure like:
 	* file_output:
 	*   enabled: true
@@ -84,6 +97,19 @@ public:
 		return default_value;
 	}
 
+	/**
+	 * Set the second-level node identified by key[key][subkey] to value.
+	 */
+	template<typename T>
+	void set_scalar(const std::string& key, const std::string& subkey, const T& value)
+	{
+		auto node = m_root;
+		if (node.IsDefined())
+		{
+			node[key][subkey] = value;
+		}
+	}
+
 private:
 	YAML::Node m_root;
 };
@@ -92,12 +118,23 @@ private:
 class falco_configuration
 {
  public:
-	void init(std::string conf_filename);
-	void init();
+	void init(std::string conf_filename, std::list<std::string> &cmdline_options);
+	void init(std::list<std::string> &cmdline_options);
+
 	std::string m_rules_filename;
 	bool m_json_output;
 	std::vector<output_config> m_outputs;
  private:
+	void init_cmdline_options(std::list<std::string> &cmdline_options);
+
+	/**
+	 * Given a <key>=<value> specifier, set the appropriate option
+	 * in the underlying yaml config. <key> can contain '.'
+	 * characters for nesting. Currently only 1- or 2- level keys
+	 * are supported and only scalar values are supported.
+	 */
+	void set_cmdline_option(const std::string &spec);
+
 	yaml_configuration* m_config;
 };
 


### PR DESCRIPTION
Remove the old use of the '-o' command line option, it wasn't being
used.

Allow any config file option to be overridden on the command line, via
--option/-o. These options are applied to the configuration object after
reading the file, ensuring the command line options override anything in
the config file.

To support this, add some methods to yaml_configuration that allows you
to set the value for a top level key or key + subkey, and methods to
falco_configuration that allow providing a set of command line arguments
alongside the config file.

Ensure that any fatal error is always printed to stderr even if stderr
logging is not enabled. This makes sure that falco won't silently exit
on an error. This is especially important when daemonizing and when an
initial fatal error occurs first.

As a part of this, change all fatal errors to throw exceptions instead,
so all fatal errors get routed through the exception handler.

Improve daemonization by reopening stdin/stdout/stderr to /dev/null so
you don't have to worry about writing to a closed stderr on exit.

@henridf 
