### PR TITLE
Run falco by default in containers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Falco can then be run with:
 
 ```
 docker pull sysdig/falco
-docker run -i -t --name falco --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro sysdig/falco falco
+docker run -i -t --name falco --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro sysdig/falco
 ```
 
 ##### Container install (CoreOS)
@@ -206,7 +206,7 @@ Falco is intended to be run as a service. But for experimentation and designing/
 
 #### Running Falco in a container
 
-`docker run -i -t --name falco --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro sysdig/falco falco`
+`docker run -i -t --name falco --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro sysdig/falco`
 
 #### Running Falco manually
 

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -46,4 +46,4 @@ COPY ./docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-CMD ["bash"]
+CMD ["/usr/bin/falco"]

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -46,4 +46,4 @@ COPY ./docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-CMD ["bash"]
+CMD ["/usr/bin/falco"]

--- a/falco.yaml
+++ b/falco.yaml
@@ -6,7 +6,7 @@ json_output: false
 
 # Send information logs to stderr and/or syslog Note these are *not* security
 # notification logs! These are just Falco lifecycle (and possibly error) logs.
-log_stderr: false
+log_stderr: true
 log_syslog: true
 
 
@@ -21,5 +21,5 @@ file_output:
   filename: ./events.txt
 
 stdout_output:
-  enabled: false
+  enabled: true
 


### PR DESCRIPTION
Instead of running bash as the sysdig container does, run falco. This
makes sense as falco doesn't have a general purpose use like sysdig
does.

To make it easier to run both in docker and as a daemon using the
default command line, enable both syslog and stdout/stderr output by
default. Now that falco dups stdout/stderr to /dev/null when
daemonizing, the stdout/stderr is just thrown away. And when running in
docker, the syslog output will just be discarded unless someone plumbs
the container's syslog output.

Update README.md to reflect that specifying the falco command is not
necessary.

@henridf 
