### PR TITLE
WIP: Modify jenkins slave macros

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -300,8 +300,9 @@
 
 - macro: parent_java_running_jenkins
   condition: >
-    (proc.pname=java and proc.pcmdline contains jenkins.war
-    or proc.pcmdline contains slave.jar)
+    (proc.pname=java and proc.pcmdline contains jenkins.war or
+    proc.pcmdline contains slave.jar or
+    proc.pcmdline contains jenkins-slave)
 
 # As a part of kernel upgrades, dpkg will spawn a perl script with the
 # name linux-image-N.N. This macro matches that.

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -301,7 +301,7 @@
 - macro: parent_java_running_jenkins
   condition: >
     (proc.pname=java and proc.pcmdline contains jenkins.war
-    or proc.pcmdline contains /tmp/slave.jar)
+    or proc.pcmdline contains slave.jar)
 
 # As a part of kernel upgrades, dpkg will spawn a perl script with the
 # name linux-image-N.N. This macro matches that.
@@ -512,6 +512,7 @@
 # as a packaging mechanism more than for a dedicated microservice.
 - macro: shell_spawning_containers
   condition: (container.image startswith jenkins or
+              container.image startswith jenkinsci/jnlp-slave or
               container.image startswith gitlab/gitlab-ce)
 
 - rule: Launch Privileged Container


### PR DESCRIPTION
Remove /tmp from slave.jar commandline as this will not always match (eg jenkinsci/jnlp-slave). Add jenkinsci/jnlp-slave to list of shell spawning containers.
