### PR TITLE
feat: add weave-net to the list of k8s_binaries

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -136,7 +136,7 @@
   items: [docker, dockerd, exe, docker-compose, docker-entrypoi, docker-runc-cur, docker-current]
 
 - list: k8s_binaries
-  items: [hyperkube, skydns, kube2sky, exechealthz]
+  items: [hyperkube, skydns, kube2sky, exechealthz, weave-net]
 
 - list: lxd_binaries
   items: [lxd, lxcfs]


### PR DESCRIPTION
Add weave-net (https://www.weave.works/oss/net/) to the list of k8s_binaries

falco-CLA-1.0-signed-off-by: Guido García <palmerabollo@gmail.com>