### PR TITLE
Allow that sysdig/capturer used in Kubernetes Response Engine uses volumes

### DIFF
--- a/integrations/kubernetes-response-engine/sysdig-capturer/Dockerfile
+++ b/integrations/kubernetes-response-engine/sysdig-capturer/Dockerfile
@@ -21,4 +21,6 @@ ENV CAPTURE_DURATION 120
 
 COPY ./docker-entrypoint.sh /
 
+RUN mkdir -p /captures
+
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/integrations/kubernetes-response-engine/sysdig-capturer/Makefile
+++ b/integrations/kubernetes-response-engine/sysdig-capturer/Makefile
@@ -1,0 +1,7 @@
+all: build push
+
+build:
+	docker build -t sysdig/capturer .
+
+push:
+	docker push sysdig/capturer

--- a/integrations/kubernetes-response-engine/sysdig-capturer/docker-entrypoint.sh
+++ b/integrations/kubernetes-response-engine/sysdig-capturer/docker-entrypoint.sh
@@ -11,5 +11,8 @@ done
 
 /usr/bin/sysdig-probe-loader
 
-sysdig -S -M $CAPTURE_DURATION -pk -z -w $CAPTURE_FILE_NAME.scap.gz
-s3cmd --access_key=$AWS_ACCESS_KEY_ID --secret_key=$AWS_SECRET_ACCESS_KEY put $CAPTURE_FILE_NAME.scap.gz $AWS_S3_BUCKET
+sysdig -S -M $CAPTURE_DURATION -pk -z -w /captures/$CAPTURE_FILE_NAME.scap.gz
+
+s3cmd --access_key=$AWS_ACCESS_KEY_ID \
+      --secret_key=$AWS_SECRET_ACCESS_KEY \
+      put /captures/$CAPTURE_FILE_NAME.scap.gz $AWS_S3_BUCKET

--- a/integrations/kubernetes-response-engine/sysdig-capturer/docker-entrypoint.sh
+++ b/integrations/kubernetes-response-engine/sysdig-capturer/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -exuo
+set -eo
 
 echo "* Setting up /usr/src links from host"
 
@@ -13,6 +13,8 @@ done
 
 sysdig -S -M $CAPTURE_DURATION -pk -z -w /captures/$CAPTURE_FILE_NAME.scap.gz
 
-s3cmd --access_key=$AWS_ACCESS_KEY_ID \
-      --secret_key=$AWS_SECRET_ACCESS_KEY \
-      put /captures/$CAPTURE_FILE_NAME.scap.gz $AWS_S3_BUCKET
+if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ] && [ -n "$AWS_S3_BUCKET" ]; then
+  s3cmd --access_key=$AWS_ACCESS_KEY_ID \
+        --secret_key=$AWS_SECRET_ACCESS_KEY \
+        put /captures/$CAPTURE_FILE_NAME.scap.gz $AWS_S3_BUCKET
+fi


### PR DESCRIPTION
This is useful for dropping captures in host, without need of an AWS account.

For example, in some workshops.