### PR TITLE
Add sensitive mount of mouting to /var/lib/kubelet*

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1374,6 +1374,7 @@
 - macro: sensitive_mount
   condition: (container.mount.dest[/proc*] != "N/A" or
               container.mount.dest[/var/run/docker.sock] != "N/A" or
+              container.mount.dest[/var/lib/kubelet*] != "N/A" or
               container.mount.dest[/] != "N/A" or
               container.mount.dest[/etc] != "N/A" or
               container.mount.dest[/root*] != "N/A")


### PR DESCRIPTION
In the /var/lib/kubelet folder, there are kubeconfig file used by kubelet to talke to k8s api server, and kubelet secrets. It should be considered as sensitive mount when a pod is mounting on folder /var/lib/kubelet.