### PR TITLE
Add netcat to docker images

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
 	libc6-dev \
 	libelf-dev \
 	llvm-7 \
+	netcat \
 	xz-utils \
  && rm -rf /var/lib/apt/lists/*
 

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
 	libc6-dev \
 	libelf-dev \
 	llvm-7 \
+	netcat \
 	xz-utils \
  && rm -rf /var/lib/apt/lists/*
 

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
 	libc6-dev \
 	libelf-dev \
 	llvm-7 \
+	netcat \
 	xz-utils \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
It may be useful as a way to enable generic event forwarding.

This fixes https://github.com/falcosecurity/falco/issues/433.