### PR TITLE
Load/unload kernel module on start/stop

### DIFF
--- a/scripts/debian/falco
+++ b/scripts/debian/falco
@@ -65,6 +65,9 @@ do_start()
 	#   2 if daemon could not be started
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
 		|| return 1
+	if [ ! -d /sys/module/falco_probe ]; then
+		/sbin/modprobe falco-probe || exit 1
+	fi
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
 		$DAEMON_ARGS \
 		|| return 2
@@ -94,6 +97,7 @@ do_stop()
 	# sleep for some time.
 	start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
 	[ "$?" = 2 ] && return 2
+	/sbin/rmmod falco-probe
 	# Many daemons don't delete their pidfiles when they exit.
 	rm -f $PIDFILE
 	return "$RETVAL"

--- a/scripts/rpm/falco
+++ b/scripts/rpm/falco
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 #
 # Copyright (C) 2016-2018 Draios Inc dba Sysdig.
 #
@@ -16,7 +18,6 @@
 # limitations under the License.
 #
 
-#!/bin/sh
 #
 # falco syscall monitoring agent
 #

--- a/scripts/rpm/falco
+++ b/scripts/rpm/falco
@@ -53,6 +53,9 @@ start() {
     # [ -f $config ] || exit 6
     echo -n $"Starting $prog: "
     daemon $exec --daemon --pidfile=$pidfile
+    if [ ! -d /sys/module/falco_probe ]; then
+        /sbin/modprobe falco-probe || return $?
+    fi
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile
@@ -64,6 +67,7 @@ stop() {
     killproc -p $pidfile
     retval=$?
     echo
+    /sbin/rmmod falco-probe
     [ $retval -eq 0 ] && rm -f $lockfile
     return $retval
 }


### PR DESCRIPTION
When falco is started, load the kernel module. (The falco binary also
will do a modprobe if it can't open the inspector, as a backup).

When falco is stopped, unload the kernel module.

This fixes https://github.com/falcosecurity/falco/issues/418.