### PR TITLE
Kh add process rules

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -178,16 +178,22 @@
 - list: deb_binaries
   items: [dpkg, dpkg-preconfigu, dpkg-reconfigur, dpkg-divert, apt, apt-get, aptitude,
     frontend, preinst, add-apt-reposit, apt-auto-remova, apt-key,
-    apt-listchanges, unattended-upgr, apt-add-reposit
+    apt-listchanges, unattended-upgr, apt-add-reposit, apt-config, apt-cache
     ]
 
 # The truncated dpkg-preconfigu is intentional, process names are
 # truncated at the sysdig level.
 - list: package_mgmt_binaries
-  items: [rpm_binaries, deb_binaries, update-alternat, gem, pip, pip3, sane-utils.post, alternatives, chef-client]
+  items: [rpm_binaries, deb_binaries, update-alternat, gem, pip, pip3, sane-utils.post, alternatives, chef-client, apk]
 
 - macro: package_mgmt_procs
   condition: proc.name in (package_mgmt_binaries)
+
+- macro: package_mgmt_ancestor_procs
+  condition: proc.pname in (package_mgmt_binaries) or
+             proc.aname[2] in (package_mgmt_binaries) or
+             proc.aname[3] in (package_mgmt_binaries) or
+             proc.aname[4] in (package_mgmt_binaries)
 
 - macro: coreos_write_ssh_dir
   condition: (proc.name=update-ssh-keys and fd.name startswith /home/core/.ssh)
@@ -1719,6 +1725,46 @@
   output: Unexpected K8s NodePort Connection (command=%proc.cmdline connection=%fd.name)
   priority: NOTICE
   tags: [network, k8s, container]
+
+- list: network_tool_binaries
+  items: [nc, ncat, nmap]
+
+- macro: network_tool_procs
+  condition: proc.name in (network_tool_binaries)
+
+# Container is supposed to be immutable. Package management should be done in building the image.
+- rule: Launch Package Management Process
+  desc: Package management process ran insdie container
+  condition: >
+    spawned_process and container and user.name != "_apt" and package_mgmt_procs and not package_mgmt_ancestor_procs
+  output: >
+    Package management process launched (user=%user.name
+    command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image)
+  priority: ERROR
+  tags: [process]
+
+- rule: Netcat Remote Code Execution
+  desc: Netcat Program runs inside container that allows remote code execution
+  condition: >
+    spawned_process and container and
+    ((proc.name = "nc" and (proc.args contains "-e" or proc.args contains "-c")) or
+     (proc.name = "ncat" and (proc.args contains "--sh-exec" or proc.args contains "--exec"))
+    )
+  output: >
+    Netcat runs inside container that allows remote code execution (user=%user.name
+    command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image)
+  priority: WARNING
+  tags: [network, process]
+
+- rule: Lauch Suspicious Network Tool
+  desc: Detect network tools launched inside container
+  condition: >
+    spawned_process and container and network_tool_procs
+  output: >
+    Network tool launched (user=%user.name
+    command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image)
+  priority: NOTICE
+  tags: [network, process]
 
 # Application rules have moved to application_rules.yaml. Please look
 # there if you want to enable them by adding to

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1743,7 +1743,7 @@
   priority: ERROR
   tags: [process]
 
-- rule: Netcat Remote Code Execution
+- rule: Netcat Remote Code Execution in Container
   desc: Netcat Program runs inside container that allows remote code execution
   condition: >
     spawned_process and container and
@@ -1756,12 +1756,12 @@
   priority: WARNING
   tags: [network, process]
 
-- rule: Lauch Suspicious Network Tool
+- rule: Lauch Suspicious Network Tool in Container
   desc: Detect network tools launched inside container
   condition: >
     spawned_process and container and network_tool_procs
   output: >
-    Network tool launched (user=%user.name
+    Network tool launched in container (user=%user.name
     command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image)
   priority: NOTICE
   tags: [network, process]

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1733,12 +1733,12 @@
   condition: proc.name in (network_tool_binaries)
 
 # Container is supposed to be immutable. Package management should be done in building the image.
-- rule: Launch Package Management Process
-  desc: Package management process ran insdie container
+- rule: Launch Package Management Process in Container
+  desc: Package management process ran inside container
   condition: >
     spawned_process and container and user.name != "_apt" and package_mgmt_procs and not package_mgmt_ancestor_procs
   output: >
-    Package management process launched (user=%user.name
+    Package management process launched in container (user=%user.name
     command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image)
   priority: ERROR
   tags: [process]


### PR DESCRIPTION
To test this PR:

1. Checkout the branch

2. Launch falco container with the updated falco rule yaml file

3. Run the following script:
```
#!/bin/bash

set -eux 

client=$(docker run -d --name client kaizheh/nginx-docker)

server=$(docker run -d --name server kaizheh/nginx-docker)

docker exec server bash -c "apt-get update && apt-get -y install nmap"

docker exec server bash -c "nc -lp 1234 -c 'cat /etc/passwd'" &

server_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $server)

docker exec client bash -c "nc $server_ip 1234"
```

To verify the output from falco container:

> 18:22:08.037417144: Error Package management process launched (user=root command=apt-get update container_id=7a222f00f4d0 container_name=server image=kaizheh/nginx-docker)
18:22:09.249714486: Error Package management process launched (user=root command=apt-get -y install nmap container_id=7a222f00f4d0 container_name=server image=kaizheh/nginx-docker)
18:22:19.057577326: Warning Netcat runs inside container that allows remote code execution (user=root command=nc -lp 1234 -c cat /etc/passwd container_id=7a222f00f4d0 container_name=server image=kaizheh/nginx-docker)
18:22:19.174572057: Notice Network tool launched (user=root command=nc 172.17.0.4 1234 container_id=1f2800fba7bc container_name=client image=kaizheh/nginx-docker)
> 