### PR TITLE
Make k8s-audit rules and main rules compatible

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -31,6 +31,7 @@
 rules_file:
  - /etc/falco/falco_rules.yaml
  - /etc/falco/falco_rules.local.yaml
+ - /etc/falco/k8s_audit_rules.yaml
  - /etc/falco/rules.d
 
 # Whether to output events in json or text

--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -38,13 +38,13 @@
 - macro: response_successful
   condition: (ka.response.code startswith 2)
 
-- macro: create
+- macro: kcreate
   condition: ka.verb=create
 
-- macro: modify
+- macro: kmodify
   condition: (ka.verb in (create,update,patch))
 
-- macro: delete
+- macro: kdelete
   condition: ka.verb=delete
 
 - macro: pod
@@ -83,7 +83,7 @@
 - rule: Create Disallowed Pod
   desc: >
     Detect an attempt to start a pod with a container image outside of a list of allowed images.
-  condition: kevt and pod and create and not allowed_k8s_containers
+  condition: kevt and pod and kcreate and not allowed_k8s_containers
   output: Pod started with container not in allowed list (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace image=%ka.req.container.image)
   priority: WARNING
   source: k8s_audit
@@ -107,7 +107,7 @@
 - rule: Create Privileged Pod
   desc: >
     Detect an attempt to start a pod with a privileged container
-  condition: kevt and pod and create and ka.req.container.privileged=true and not ka.req.container.image.repository in (trusted_k8s_containers)
+  condition: kevt and pod and kcreate and ka.req.container.privileged=true and not ka.req.container.image.repository in (trusted_k8s_containers)
   output: Pod started with privileged container (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace image=%ka.req.container.image)
   priority: WARNING
   source: k8s_audit
@@ -125,7 +125,7 @@
   desc: >
     Detect an attempt to start a pod with a volume from a sensitive host directory (i.e. /proc).
     Exceptions are made for known trusted images.
-  condition: kevt and pod and create and sensitive_vol_mount and not ka.req.container.image.repository in (trusted_k8s_containers)
+  condition: kevt and pod and kcreate and sensitive_vol_mount and not ka.req.container.image.repository in (trusted_k8s_containers)
   output: Pod started with sensitive mount (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace image=%ka.req.container.image mounts=%jevt.value[/requestObject/spec/volumes])
   priority: WARNING
   source: k8s_audit
@@ -134,7 +134,7 @@
 # Corresponds to K8s CIS Benchmark 1.7.4
 - rule: Create HostNetwork Pod
   desc: Detect an attempt to start a pod using the host network.
-  condition: kevt and pod and create and ka.req.container.host_network=true and not ka.req.container.image.repository in (trusted_k8s_containers)
+  condition: kevt and pod and kcreate and ka.req.container.host_network=true and not ka.req.container.image.repository in (trusted_k8s_containers)
   output: Pod started using host network (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace image=%ka.req.container.image)
   priority: WARNING
   source: k8s_audit
@@ -143,7 +143,7 @@
 - rule: Create NodePort Service
   desc: >
     Detect an attempt to start a service with a NodePort service type
-  condition: kevt and service and create and ka.req.service.type=NodePort
+  condition: kevt and service and kcreate and ka.req.service.type=NodePort
   output: NodePort Service Created (user=%ka.user.name service=%ka.target.name ns=%ka.target.namespace ports=%ka.req.service.ports)
   priority: WARNING
   source: k8s_audit
@@ -161,7 +161,7 @@
 - rule: Create/Modify Configmap With Private Credentials
   desc: >
      Detect creating/modifying a configmap containing a private credential (aws key, password, etc.)
-  condition: kevt and configmap and modify and contains_private_credentials
+  condition: kevt and configmap and kmodify and contains_private_credentials
   output: K8s configmap with private credential (user=%ka.user.name verb=%ka.verb configmap=%ka.req.configmap.name config=%ka.req.configmap.obj)
   priority: WARNING
   source: k8s_audit
@@ -189,7 +189,7 @@
 - rule: Attach/Exec Pod
   desc: >
     Detect any attempt to attach/exec to a pod
-  condition: kevt_started and pod_subresource and create and ka.target.subresource in (exec,attach)
+  condition: kevt_started and pod_subresource and kcreate and ka.target.subresource in (exec,attach)
   output: Attach/Exec to pod (user=%ka.user.name pod=%ka.target.name ns=%ka.target.namespace action=%ka.target.subresource command=%ka.uri.param[command])
   priority: NOTICE
   source: k8s_audit
@@ -201,7 +201,7 @@
 
 - rule: Create Disallowed Namespace
   desc: Detect any attempt to create a namespace outside of a set of known namespaces
-  condition: kevt and namespace and create and not ka.target.name in (allowed_namespaces)
+  condition: kevt and namespace and kcreate and not ka.target.name in (allowed_namespaces)
   output: Disallowed namespace created (user=%ka.user.name ns=%ka.target.name)
   priority: WARNING
   source: k8s_audit
@@ -210,7 +210,7 @@
 # Detect any new pod created in the kube-system namespace
 - rule: Pod Created in Kube Namespace
   desc: Detect any attempt to create a pod in the kube-system or kube-public namespaces
-  condition: kevt and pod and create and ka.target.namespace in (kube-system, kube-public)
+  condition: kevt and pod and kcreate and ka.target.namespace in (kube-system, kube-public)
   output: Pod created in kube namespace (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace image=%ka.req.container.image)
   priority: WARNING
   source: k8s_audit
@@ -219,7 +219,7 @@
 # Detect creating a service account in the kube-system/kube-public namespace
 - rule: Service Account Created in Kube Namespace
   desc: Detect any attempt to create a serviceaccount in the kube-system or kube-public namespaces
-  condition: kevt and serviceaccount and create and ka.target.namespace in (kube-system, kube-public)
+  condition: kevt and serviceaccount and kcreate and ka.target.namespace in (kube-system, kube-public)
   output: Service account created in kube namespace (user=%ka.user.name serviceaccount=%ka.target.name ns=%ka.target.namespace)
   priority: WARNING
   source: k8s_audit
@@ -230,7 +230,7 @@
 # normal operation.
 - rule: System ClusterRole Modified/Deleted
   desc: Detect any attempt to modify/delete a ClusterRole/Role starting with system
-  condition: kevt and (role or clusterrole) and (modify or delete) and (ka.target.name startswith "system:") and ka.target.name!="system:coredns"
+  condition: kevt and (role or clusterrole) and (kmodify or kdelete) and (ka.target.name startswith "system:") and ka.target.name!="system:coredns"
   output: System ClusterRole/Role modified or deleted (user=%ka.user.name role=%ka.target.name ns=%ka.target.namespace action=%ka.verb)
   priority: WARNING
   source: k8s_audit
@@ -240,7 +240,7 @@
 # (exapand this to any built-in cluster role that does "sensitive" things)
 - rule: Attach to cluster-admin Role
   desc: Detect any attempt to create a ClusterRoleBinding to the cluster-admin user
-  condition: kevt and clusterrolebinding and create and ka.req.binding.role=cluster-admin
+  condition: kevt and clusterrolebinding and kcreate and ka.req.binding.role=cluster-admin
   output: Cluster Role Binding to cluster-admin role (user=%ka.user.name subject=%ka.req.binding.subjects)
   priority: WARNING
   source: k8s_audit
@@ -248,7 +248,7 @@
 
 - rule: ClusterRole With Wildcard Created
   desc: Detect any attempt to create a Role/ClusterRole with wildcard resources or verbs
-  condition: kevt and (role or clusterrole) and create and (ka.req.role.rules.resources contains '"*"' or ka.req.role.rules.verbs contains '"*"')
+  condition: kevt and (role or clusterrole) and kcreate and (ka.req.role.rules.resources contains '"*"' or ka.req.role.rules.verbs contains '"*"')
   output: Created Role/ClusterRole with wildcard (user=%ka.user.name role=%ka.target.name rules=%ka.req.role.rules)
   priority: WARNING
   source: k8s_audit
@@ -264,7 +264,7 @@
 
 - rule: ClusterRole With Write Privileges Created
   desc: Detect any attempt to create a Role/ClusterRole that can perform write-related actions
-  condition: kevt and (role or clusterrole) and create and writable_verbs
+  condition: kevt and (role or clusterrole) and kcreate and writable_verbs
   output: Created Role/ClusterRole with write privileges (user=%ka.user.name role=%ka.target.name rules=%ka.req.role.rules)
   priority: NOTICE
   source: k8s_audit
@@ -272,7 +272,7 @@
 
 - rule: ClusterRole With Pod Exec Created
   desc: Detect any attempt to create a Role/ClusterRole that can exec to pods
-  condition: kevt and (role or clusterrole) and create and ka.req.role.rules.resources contains "pods/exec"
+  condition: kevt and (role or clusterrole) and kcreate and ka.req.role.rules.resources contains "pods/exec"
   output: Created Role/ClusterRole with pod exec privileges (user=%ka.user.name role=%ka.target.name rules=%ka.req.role.rules)
   priority: WARNING
   source: k8s_audit
@@ -289,7 +289,7 @@
 
 - rule: K8s Deployment Created
   desc: Detect any attempt to create a deployment
-  condition: (kactivity and create and deployment and response_successful)
+  condition: (kactivity and kcreate and deployment and response_successful)
   output: K8s Deployment Created (user=%ka.user.name deployment=%ka.target.name ns=%ka.target.namespace resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
@@ -297,7 +297,7 @@
 
 - rule: K8s Deployment Deleted
   desc: Detect any attempt to delete a deployment
-  condition: (kactivity and delete and deployment and response_successful)
+  condition: (kactivity and kdelete and deployment and response_successful)
   output: K8s Deployment Deleted (user=%ka.user.name deployment=%ka.target.name ns=%ka.target.namespace resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
@@ -305,7 +305,7 @@
 
 - rule: K8s Service Created
   desc: Detect any attempt to create a service
-  condition: (kactivity and create and service and response_successful)
+  condition: (kactivity and kcreate and service and response_successful)
   output: K8s Service Created (user=%ka.user.name service=%ka.target.name ns=%ka.target.namespace resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
@@ -313,7 +313,7 @@
 
 - rule: K8s Service Deleted
   desc: Detect any attempt to delete a service
-  condition: (kactivity and delete and service and response_successful)
+  condition: (kactivity and kdelete and service and response_successful)
   output: K8s Service Deleted (user=%ka.user.name service=%ka.target.name ns=%ka.target.namespace resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
@@ -321,7 +321,7 @@
 
 - rule: K8s ConfigMap Created
   desc: Detect any attempt to create a configmap
-  condition: (kactivity and create and configmap and response_successful)
+  condition: (kactivity and kcreate and configmap and response_successful)
   output: K8s ConfigMap Created (user=%ka.user.name configmap=%ka.target.name ns=%ka.target.namespace resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
@@ -329,7 +329,7 @@
 
 - rule: K8s ConfigMap Deleted
   desc: Detect any attempt to delete a configmap
-  condition: (kactivity and delete and configmap and response_successful)
+  condition: (kactivity and kdelete and configmap and response_successful)
   output: K8s ConfigMap Deleted (user=%ka.user.name configmap=%ka.target.name ns=%ka.target.namespace resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
@@ -337,7 +337,7 @@
 
 - rule: K8s Namespace Created
   desc: Detect any attempt to create a namespace
-  condition: (kactivity and create and namespace and response_successful)
+  condition: (kactivity and kcreate and namespace and response_successful)
   output: K8s Namespace Created (user=%ka.user.name namespace=%ka.target.name resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
@@ -345,7 +345,7 @@
 
 - rule: K8s Namespace Deleted
   desc: Detect any attempt to delete a namespace
-  condition: (kactivity and non_system_user and delete and namespace and response_successful)
+  condition: (kactivity and non_system_user and kdelete and namespace and response_successful)
   output: K8s Namespace Deleted (user=%ka.user.name namespace=%ka.target.name resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
@@ -353,7 +353,7 @@
 
 - rule: K8s Serviceaccount Created
   desc: Detect any attempt to create a service account
-  condition: (kactivity and create and serviceaccount and response_successful)
+  condition: (kactivity and kcreate and serviceaccount and response_successful)
   output: K8s Serviceaccount Created (user=%ka.user.name user=%ka.target.name ns=%ka.target.namespace resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
@@ -361,7 +361,7 @@
 
 - rule: K8s Serviceaccount Deleted
   desc: Detect any attempt to delete a service account
-  condition: (kactivity and delete and serviceaccount and response_successful)
+  condition: (kactivity and kdelete and serviceaccount and response_successful)
   output: K8s Serviceaccount Deleted (user=%ka.user.name user=%ka.target.name ns=%ka.target.namespace resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
@@ -369,7 +369,7 @@
 
 - rule: K8s Role/Clusterrole Created
   desc: Detect any attempt to create a cluster role/role
-  condition: (kactivity and create and (clusterrole or role) and response_successful)
+  condition: (kactivity and kcreate and (clusterrole or role) and response_successful)
   output: K8s Cluster Role Created (user=%ka.user.name role=%ka.target.name rules=%ka.req.role.rules resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
@@ -377,7 +377,7 @@
 
 - rule: K8s Role/Clusterrole Deleted
   desc: Detect any attempt to delete a cluster role/role
-  condition: (kactivity and delete and (clusterrole or role) and response_successful)
+  condition: (kactivity and kdelete and (clusterrole or role) and response_successful)
   output: K8s Cluster Role Deleted (user=%ka.user.name role=%ka.target.name resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
@@ -385,7 +385,7 @@
 
 - rule: K8s Role/Clusterrolebinding Created
   desc: Detect any attempt to create a clusterrolebinding
-  condition: (kactivity and create and clusterrolebinding and response_successful)
+  condition: (kactivity and kcreate and clusterrolebinding and response_successful)
   output: K8s Cluster Role Binding Created (user=%ka.user.name binding=%ka.target.name subjects=%ka.req.binding.subjects role=%ka.req.binding.role resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason foo=%ka.req.binding.subject.has_name[cluster-admin])
   priority: INFO
   source: k8s_audit
@@ -393,7 +393,7 @@
 
 - rule: K8s Role/Clusterrolebinding Deleted
   desc: Detect any attempt to delete a clusterrolebinding
-  condition: (kactivity and delete and clusterrolebinding and response_successful)
+  condition: (kactivity and kdelete and clusterrolebinding and response_successful)
   output: K8s Cluster Role Binding Deleted (user=%ka.user.name binding=%ka.target.name resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit


### PR DESCRIPTION
Add k8s audit rules to falco's config so they are read by default.

Rename some generic macros like modify, create, delete in the k8s audit
rules so they don't overlap with macros in the main rules file.