### PR TITLE
Improved inbound/outbound macros

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -858,6 +858,9 @@
 - macro: prometheus_conf_writing_conf
   condition: (proc.name=prometheus-conf and fd.directory=/etc/prometheus/config_out)
 
+- macro: openshift_writing_conf
+  condition: (proc.name=oc and fd.name=/etc/origin/node/node.kubeconfig)
+
 # Add conditions to this macro (probably in a separate file,
 # overwriting this macro) to allow for specific combinations of
 # programs writing below specific directories below
@@ -962,6 +965,7 @@
     and not ufw_writing_conf
     and not calico_writing_conf
     and not prometheus_conf_writing_conf
+    and not openshift_writing_conf
 
 - rule: Write below etc
   desc: an attempt to write to any file below /etc


### PR DESCRIPTION
Improved versions of inbound/outbound macros that add coverage for
recvfrom/recvmsg, sendto/sendmsg and also ignore non-blocking syscalls
in a different way.