### PR TITLE
Allow SSL for k8s audit endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ docker/event-generator/mysqld
 docker/event-generator/httpd
 docker/event-generator/sha1sum
 docker/event-generator/vipw
+.vscode/*

--- a/falco.yaml
+++ b/falco.yaml
@@ -109,6 +109,8 @@ webserver:
   enabled: true
   listen_port: 8765
   k8s_audit_endpoint: /k8s_audit
+  ssl_enabled: false
+  ssl_certificate: /etc/falco/falco.pem
 
 # Possible additional things you might want to do with program output:
 #   - send to a slack webhook:

--- a/falco.yaml
+++ b/falco.yaml
@@ -104,7 +104,14 @@ stdout_output:
 # Falco contains an embedded webserver that can be used to accept K8s
 # Audit Events. These config options control the behavior of that
 # webserver. (By default, the webserver is disabled).
-#  enabled: false
+#
+# The ssl_certificate is a combination SSL Certificate and corresponding
+# key contained in a single file. You can generate a key/cert as follows:
+#
+# $ openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 365 -out certificate.pem
+# $ cat certificate.pem key.pem > falco.pem
+# $ sudo cp falco.pem /etc/falco/falco.pem
+
 webserver:
   enabled: true
   listen_port: 8765

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -34,6 +34,7 @@ falco_configuration::falco_configuration()
 	  m_webserver_enabled(false),
 	  m_webserver_listen_port(8765),
 	  m_webserver_k8s_audit_endpoint("/k8s_audit"),
+	  m_webserver_ssl_enabled(false),
 	  m_config(NULL)
 {
 }
@@ -162,7 +163,9 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 
 	m_webserver_enabled = m_config->get_scalar<bool>("webserver", "enabled", false);
 	m_webserver_listen_port = m_config->get_scalar<uint32_t>("webserver", "listen_port", 8765);
-	m_webserver_k8s_audit_endpoint = m_config->get_scalar<string>("websever", "k8s_audit_endpoint", "/k8s_audit");
+	m_webserver_k8s_audit_endpoint = m_config->get_scalar<string>("webserver", "k8s_audit_endpoint", "/k8s_audit");
+	m_webserver_ssl_enabled = m_config->get_scalar<bool>("webserver", "ssl_enabled", false);
+	m_webserver_ssl_certificate = m_config->get_scalar<string>("webserver", "ssl_certificate","/etc/falco/falco.pem");
 }
 
 void falco_configuration::read_rules_file_directory(const string &path, list<string> &rules_filenames)

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -182,6 +182,8 @@ class falco_configuration
 	bool m_webserver_enabled;
 	uint32_t m_webserver_listen_port;
 	std::string m_webserver_k8s_audit_endpoint;
+	bool m_webserver_ssl_enabled;
+	std::string m_webserver_ssl_certificate;
 
  private:
 	void init_cmdline_options(std::list<std::string> &cmdline_options);

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -1024,7 +1024,8 @@ int falco_init(int argc, char **argv)
 
 		if(trace_filename.empty() && config.m_webserver_enabled)
 		{
-			falco_logger::log(LOG_INFO, "Starting internal webserver, listening on port " + to_string(config.m_webserver_listen_port) + "\n");
+			std::string ssl_option = (config.m_webserver_ssl_enabled ? " (SSL)" : "");
+			falco_logger::log(LOG_INFO, "Starting internal webserver, listening on port " + to_string(config.m_webserver_listen_port) + ssl_option + "\n");
 			webserver.init(&config, engine, outputs);
 			webserver.start();
 		}

--- a/userspace/falco/webserver.cpp
+++ b/userspace/falco/webserver.cpp
@@ -189,9 +189,19 @@ void falco_webserver::start()
 	}
 
 	std::vector<std::string> cpp_options = {
-		"listening_ports", to_string(m_config->m_webserver_listen_port),
 		"num_threads", to_string(1)
 	};
+
+	if (m_config->m_webserver_ssl_enabled)
+	{
+		cpp_options.push_back("listening_ports");
+		cpp_options.push_back(to_string(m_config->m_webserver_listen_port) + "s");
+		cpp_options.push_back("ssl_certificate");
+		cpp_options.push_back(m_config->m_webserver_ssl_certificate);
+	} else {
+		cpp_options.push_back("listening_ports");
+		cpp_options.push_back(to_string(m_config->m_webserver_listen_port));
+	}
 
 	try {
 		m_server = make_unique<CivetServer>(cpp_options);


### PR DESCRIPTION
Allow enabling SSL for the Kubernetes audit log web server. This required adding two new configuration options: `webserver.ssl_enabled` and `webserver.ssl_certificate`. To enable SSL add the below to the `webserver` section of the `falco.yaml` config:
```
webserver:
  enabled: true
  listen_port: 8765s
  k8s_audit_endpoint: /k8s_audit
  ssl_enabled: true
  ssl_certificate: /etc/falco/falco.pem
```
Note that the port number has an `s` appended to indicate SSL for the port which is how civetweb expects SSL ports be denoted. We could change this to dynamically add the `s` if `ssl_enabled: true`.

The `ssl_certificate` is a combination SSL Certificate and corresponding key contained in a single file. You can generate a key/cert as follows:
```
$ openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 365 -out certificate.pem
$ cat certificate.pem key.pem > falco.pem
$ sudo cp falco.pem /etc/falco/falco.pem
```

