### PR TITLE
This apiGroup is not needed on the CNCF flavor deployment

### DIFF
--- a/integrations/kubernetes-response-engine/deployment/cncf/cluster-role-binding.yaml
+++ b/integrations/kubernetes-response-engine/deployment/cncf/cluster-role-binding.yaml
@@ -10,4 +10,3 @@ subjects:
 - kind: ServiceAccount
   name: default
   namespace: default
-  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
I remove it for avoiding breaking stuff.