### PR TITLE
Add optional support for -Wextra and -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ cmake_minimum_required(VERSION 2.8.2)
 
 project(falco)
 
+option(BUILD_WARNINGS_AS_ERRORS "Enable building with -Wextra -Werror flags")
+
 if(NOT DEFINED FALCO_VERSION)
 	set(FALCO_VERSION "0.1.1dev")
 endif()
@@ -35,8 +37,15 @@ if(NOT DRAIOS_DEBUG_FLAGS)
 	set(DRAIOS_DEBUG_FLAGS "-D_DEBUG")
 endif()
 
-set(CMAKE_C_FLAGS "-Wall -ggdb ${DRAIOS_FEATURE_FLAGS}")
-set(CMAKE_CXX_FLAGS "-Wall -ggdb --std=c++0x ${DRAIOS_FEATURE_FLAGS}")
+set(CMAKE_COMMON_FLAGS "-Wall -ggdb ${DRAIOS_FEATURE_FLAGS}")
+
+if(BUILD_WARNINGS_AS_ERRORS)
+	set(CMAKE_SUPPRESSED_WARNINGS "-Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare -Wno-type-limits -Wno-implicit-fallthrough -Wno-format-truncation")
+	set(CMAKE_COMMON_FLAGS "${CMAKE_COMMON_FLAGS} -Wextra -Werror ${CMAKE_SUPPRESSED_WARNINGS}")
+endif()
+
+set(CMAKE_C_FLAGS "${CMAKE_COMMON_FLAGS}")
+set(CMAKE_CXX_FLAGS "--std=c++0x ${CMAKE_COMMON_FLAGS}")
 
 set(CMAKE_C_FLAGS_DEBUG "${DRAIOS_DEBUG_FLAGS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${DRAIOS_DEBUG_FLAGS}")


### PR DESCRIPTION
The -Wextra compile-time option will enable additional diagnostic
warnigns.  The -Werror option will cause the compiler to treat warnings
as errors.  This change adds a build time option,
BUILD_WARNINGS_AS_ERRORS, to conditionally enable those flags.  Note
that depending on the compiler you're using, if you enable this option,
compilation may fail (some compiler version have additional warnings
that have not yet been resolved).

Testing with these options in place identified a destructor that was
throwing an exception.  C++11 doesn't allow destructors to throw
exceptions, so those throw's would have resulted in calls to
terminate().  I replace them with an error log and a call to assert().