### PR TITLE
Remove kubernetes-response-engine from system:masters

### DIFF
--- a/integrations/kubernetes-response-engine/deployment/aws/outputs.tf
+++ b/integrations/kubernetes-response-engine/deployment/aws/outputs.tf
@@ -1,9 +1,7 @@
 locals {
   patch_for_aws_auth = <<CONFIGMAPAWSAUTH
     - rolearn: ${aws_iam_role.iam-for-lambda.arn}\n
-     username: kubernetes-response-engine\n
-     groups:\n
-       - system:masters
+     username: kubernetes-response-engine
 CONFIGMAPAWSAUTH
 }
 


### PR DESCRIPTION
As long as we are using rbac for allowing actions on several resources,
we can restrict this a bit more.