### PR TITLE
Unbuffer outputs by default

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -60,8 +60,8 @@ log_level: info
 priority: debug
 
 # Whether or not output to any of the output channels below is
-# buffered. Defaults to true
-buffered_outputs: true
+# buffered. Defaults to false
+buffered_outputs: false
 
 # A throttling mechanism implemented as a token bucket limits the
 # rate of falco notifications. This throttling is controlled by the following configuration

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -30,7 +30,7 @@ limitations under the License.
 using namespace std;
 
 falco_configuration::falco_configuration()
-	: m_buffered_outputs(true),
+	: m_buffered_outputs(false),
 	  m_webserver_enabled(false),
 	  m_webserver_listen_port(8765),
 	  m_webserver_k8s_audit_endpoint("/k8s_audit"),
@@ -155,7 +155,7 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 	}
 	m_min_priority = (falco_common::priority_type) (it - falco_common::priority_names.begin());
 
-	m_buffered_outputs = m_config->get_scalar<bool>("buffered_outputs", true);
+	m_buffered_outputs = m_config->get_scalar<bool>("buffered_outputs", false);
 
 	falco_logger::log_stderr = m_config->get_scalar<bool>("log_stderr", false);
 	falco_logger::log_syslog = m_config->get_scalar<bool>("log_syslog", true);


### PR DESCRIPTION
In the common case, falco doesn't generate much output, so it's
desirable to not buffer it in case you're tail -fing some logs.

So change the default for buffered outputs to false.