### PR TITLE
Add Stale Issue Probot

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - cncf
+  - roadmap
+  - enhancement
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
We have lots of issues that linger because we don't hear anything from the community member after we respond. In order to have these issues automatically closed, many projects use the Probot/Stale bot to close stale issues. This PR enables the bot to treat issues with no activity after 60 days as stale, and closes issues after 67 days if no activity has occurred on them. 