### PR TITLE
kh: improve kubelet mount rule

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1413,7 +1413,8 @@
 - macro: sensitive_mount
   condition: (container.mount.dest[/proc*] != "N/A" or
               container.mount.dest[/var/run/docker.sock] != "N/A" or
-              container.mount.dest[/var/lib/kubelet*] != "N/A" or
+              container.mount.dest[/var/lib/kubelet] != "N/A" or
+              container.mount.dest[/var/lib/kubelet/pki] != "N/A" or
               container.mount.dest[/] != "N/A" or
               container.mount.dest[/etc] != "N/A" or
               container.mount.dest[/root*] != "N/A")


### PR DESCRIPTION
care for /var/lib/kubelet folder and /var/lib/kubelet/pki folder mount only, ignore the other folders as they're used by kubelet process internally.