### PR TITLE
fix k8s install issue

### DIFF
--- a/integrations/k8s-using-daemonset/README.md
+++ b/integrations/k8s-using-daemonset/README.md
@@ -32,6 +32,7 @@ k8s-using-daemonset$
 The Daemon Set also relies on a Kubernetes ConfigMap to store the Falco configuration and make the configuration available to the Falco Pods. This allows you to manage custom configuration without rebuilding and redeploying the underlying Pods. In order to create the ConfigMap you'll need to first need to copy the required configuration from their location in this GitHub repo to the `k8s-with-rbac/falco-config/` directory (please note that you will need to create the /falco-config directory). Any modification of the configuration should be performed on these copies rather than the original files.
 
 ```
+k8s-using-daemonset$ mkdir -p k8s-with-rbac/falco-config
 k8s-using-daemonset$ cp ../../falco.yaml k8s-with-rbac/falco-config/
 k8s-using-daemonset$ cp ../../rules/falco_rules.* k8s-with-rbac/falco-config/
 k8s-using-daemonset$ cp ../../rules/k8s_audit_rules.yaml k8s-with-rbac/falco-config/
@@ -70,6 +71,24 @@ If you are running Kubernetes with Legacy Authorization enabled, you can use `ku
 ```
 k8s-using-daemonset$ kubectl create -f k8s-without-rbac/falco-daemonset.yaml
 ```
+
+When running falco via a container, you might see error messages like the following:
+```
+mkdir: cannot create directory '/lib/modules/3.10.0-693.el7.centos.test.x86_64/kernel/extra': Read-only file system
+cp: cannot create regular file '/lib/modules/3.10.0-693.el7.centos.test.x86_64/kernel/extra/falco-probe.ko.xz': No such file or directory
+```
+
+These error messages are innocuous, but if you would like to remove them you can change the /host/lib/modules mount to read-write, by doing below change in `k8s-with-rbac/falco
+daemonset-configmap.yaml`:
+
+```
+             - mountPath: /host/lib/modules
+               name: lib-modules
+-              readOnly: true
++              #readOnly: true
+```
+
+However, note that this will result in the `falco-probe.ko.xz` file being saved to `/lib/modules` on the host, even after the falco container is removed.
 
 
 ## Verifying the installation


### PR DESCRIPTION
Fix below issue when os does not have falco ko:
```
* Setting up /usr/src links from host
* Unloading falco-probe, if present
* Running dkms install for falco

Kernel preparation unnecessary for this kernel.  Skipping...

Building module:
cleaning build area...
make -j8 KERNELRELEASE=3.10.0-693.el7.centos.test.x86_64 -C /lib/modules/3.10.0-693.el7.centos.test.x86_64/build M=/var/lib/dkms/falco/0.1.2611dev/build...
cleaning build area...

DKMS: build completed.

falco-probe.ko.xz:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/3.10.0-693.el7.centos.test.x86_64/kernel/extra/
mkdir: cannot create directory '/lib/modules/3.10.0-693.el7.centos.test.x86_64/kernel/extra': Read-only file system
cp: cannot create regular file '/lib/modules/3.10.0-693.el7.centos.test.x86_64/kernel/extra/falco-probe.ko.xz': No such file or directory

depmod....

DKMS: install completed.
* Trying to load a dkms falco-probe, if present
falco-probe found and loaded in dkms (xz)
Tue Jan 29 06:24:38 2019: Falco initialized with configuration file /etc/falco/falco.yaml
Tue Jan 29 06:24:38 2019: Loading rules from file /etc/falco/falco_rules.yaml:
Tue Jan 29 06:24:38 2019: Loading rules from file /etc/falco/falco_rules.local.yaml:
Tue Jan 29 06:24:38 2019: Loading rules from file /etc/falco/k8s_audit_rules.yaml:
Tue Jan 29 06:24:39 2019: Starting internal webserver, listening on port 8765
```
