### PR TITLE
update program_output example

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -137,4 +137,4 @@ webserver:
 program_output:
   enabled: false
   keep_alive: false
-  program: mail -s "Falco Notification" someone@example.com
+  program: "jq '{text: .output}' | curl -d @- -X POST https://hooks.slack.com/services/XXX"


### PR DESCRIPTION
Fix below issue:
when config with mail:
```
program_output:
  enabled: true
  keep_alive: false
  program: mail -s "Falco Notification" 764524258@qq.com
```
```
16:07:24.426355331: Informational Container with sensitive mount started (user=root command=runc:[1:CHILD] init k8s.ns=<NA> k8s.pod=<NA> container=95d852f177a5 image=sysdig/falco-event-generator@sha256:8be9e858ed798bb41c22601ba80f552244f50e452505a2eb34c3e1c82369b343 mounts=/var/lib/kubelet/pods/641309ac-25f8-11e9-8f73-1e00130014eb/volumes/kubernetes.io~secret/default-token-bp7qk:/var/run/secrets/kubernetes.io/serviceaccount:ro:false:rprivate,/var/lib/kubelet/pods/641309ac-25f8-11e9-8f73-1e00130014eb/etc-hosts:/etc/hosts::true:rprivate,/var/lib/kubelet/pods/641309ac-25f8-11e9-8f73-1e00130014eb/containers/falco-event-generator/76eff74a:/dev/termination-log::true:rprivate) k8s.ns=<NA> k8s.pod=<NA> container=95d852f177a5
sh: 1: mail: not found

```
If not, falco can not send mail.

falco-CLA-1.0-signed-off-by: Xiang Dai <764524258@qq.com>