### PR TITLE
Sync timezone

### DIFF
--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
@@ -36,6 +36,9 @@ spec:
             - mountPath: /host/usr
               name: usr-fs
               readOnly: true
+            - mountPath: /etc/localtime
+              name: etc-localtime
+              readOnly: true
             - mountPath: /etc/falco
               name: falco-config
       volumes:
@@ -57,6 +60,9 @@ spec:
         - name: usr-fs
           hostPath:
             path: /usr
+        - name: etc-localtime
+          hostPath:
+            path: /etc/localtime
         - name: falco-config
           configMap:
             name: falco-config

--- a/integrations/k8s-using-daemonset/k8s-without-rbac/falco-daemonset.yaml
+++ b/integrations/k8s-using-daemonset/k8s-without-rbac/falco-daemonset.yaml
@@ -36,6 +36,9 @@ spec:
             - mountPath: /host/usr
               name: usr-fs
               readOnly: true
+            - mountPath: /etc/localtime
+              name: etc-localtime
+              readOnly: true
       volumes:
         - name: docker-socket
           hostPath:
@@ -55,3 +58,6 @@ spec:
         - name: usr-fs
           hostPath:
             path: /usr
+        - name: etc-localtime
+          hostPath:
+            path: /etc/localtime


### PR DESCRIPTION
The default timezone is UTC:
```
root@falco-daemonset-k852s:/# ls -l /etc/localtime
lrwxrwxrwx 1 root root 27 Dec 26 00:00 /etc/localtime -> /usr/share/zoneinfo/Etc/UTC
```
If not sync timezone, the output time is always wrong.

falco-CLA-1.0-signed-off-by: Xiang Dai <764524258@qq.com>