### PR TITLE
Update rules to use more reliable container image predicates

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -600,7 +600,7 @@
   condition: (proc.pname=run-openldap.sh and fd.name startswith /etc/openldap)
 
 - macro: ucpagent_writing_conf
-  condition: (proc.name=apiserver and container.image startswith docker/ucp-agent and fd.name=/etc/authorization_config.cfg)
+  condition: (proc.name=apiserver and container.image.repository=docker/ucp-agent and fd.name=/etc/authorization_config.cfg)
 
 - macro: iscsi_writing_conf
   condition: (proc.name=iscsiadm and fd.name startswith /etc/iscsi)
@@ -822,7 +822,7 @@
   condition: (proc.name=rabbitmq-server and fd.directory=/etc/rabbitmq)
 
 - macro: rook_writing_conf
-  condition: (proc.name=toolbox.sh and container.image startswith rook/toolbox
+  condition: (proc.name=toolbox.sh and container.image.repository=rook/toolbox
               and fd.directory=/etc/ceph)
 
 - macro: httpd_writing_conf_logs
@@ -1347,50 +1347,43 @@
 
 - macro: allowed_openshift_registry_root
   condition: >
-    (container.image startswith openshift3/ or
-     container.image startswith registry.access.redhat.com/openshift3/)
+    (container.image.repository startswith openshift3/ or
+     container.image.repository startswith registry.access.redhat.com/openshift3/)
 
 # Source: https://docs.openshift.com/enterprise/3.2/install_config/install/disconnected_install.html
 - macro: openshift_image
   condition: >
     (allowed_openshift_registry_root and
-      (container.image contains logging-deployment or
-       container.image contains logging-elasticsearch or
-       container.image contains logging-kibana or
-       container.image contains logging-fluentd or
-       container.image contains logging-auth-proxy or
-       container.image contains metrics-deployer or
-       container.image contains metrics-hawkular-metrics or
-       container.image contains metrics-cassandra or
-       container.image contains metrics-heapster or
-       container.image contains ose-haproxy-router or
-       container.image contains ose-deployer or
-       container.image contains ose-sti-builder or
-       container.image contains ose-docker-builder or
-       container.image contains ose-pod or
-       container.image contains ose-docker-registry or
-       container.image contains image-inspector))
+      (container.image.repository contains logging-deployment or
+       container.image.repository contains logging-elasticsearch or
+       container.image.repository contains logging-kibana or
+       container.image.repository contains logging-fluentd or
+       container.image.repository contains logging-auth-proxy or
+       container.image.repository contains metrics-deployer or
+       container.image.repository contains metrics-hawkular-metrics or
+       container.image.repository contains metrics-cassandra or
+       container.image.repository contains metrics-heapster or
+       container.image.repository contains ose-haproxy-router or
+       container.image.repository contains ose-deployer or
+       container.image.repository contains ose-sti-builder or
+       container.image.repository contains ose-docker-builder or
+       container.image.repository contains ose-pod or
+       container.image.repository contains ose-docker-registry or
+       container.image.repository contains image-inspector))
+
+- list: trusted_images
+  items: [
+    sysdig/agent, sysdig/falco, sysdig/sysdig, gcr.io/google_containers/hyperkube,
+    quay.io/coreos/flannel, gcr.io/google_containers/kube-proxy, calico/node,
+    rook/toolbox, cloudnativelabs/kube-router, consul, mesosphere/mesos-slave,
+    datadog/docker-dd-agent, datadog/agent, docker/ucp-agent, gliderlabs/logspout
+    ]
 
 - macro: trusted_containers
-  condition: (container.image startswith sysdig/agent or
-              (container.image startswith sysdig/falco and
-               not container.image startswith sysdig/falco-event-generator) or
-              container.image startswith quay.io/sysdig or
-              container.image startswith sysdig/sysdig or
-              container.image startswith gcr.io/google_containers/hyperkube or
-              container.image startswith quay.io/coreos/flannel or
-              container.image startswith gcr.io/google_containers/kube-proxy or
-              container.image startswith calico/node or
-              container.image startswith rook/toolbox or
-              openshift_image or
-              container.image startswith cloudnativelabs/kube-router or
-              container.image startswith "consul:" or
-              container.image startswith mesosphere/mesos-slave or
-              container.image startswith istio/proxy_ or
-              container.image startswith datadog/docker-dd-agent or
-              container.image startswith datadog/agent or
-              container.image startswith docker/ucp-agent or
-              container.image startswith gliderlabs/logspout)
+  condition: (openshift_image or
+              container.image.repository in (trusted_images) or
+              container.image.repository startswith istio/proxy_ or
+              container.image.repository startswith quay.io/sysdig)
 
 # Add conditions to this macro (probably in a separate file,
 # overwriting this macro) to specify additional containers that are
@@ -1399,7 +1392,7 @@
 # In this file, it just takes one of the images in trusted_containers
 # and repeats it.
 - macro: user_trusted_containers
-  condition: (container.image startswith sysdig/agent)
+  condition: (container.image.repository=sysdig/agent)
 
 # Add conditions to this macro (probably in a separate file,
 # overwriting this macro) to specify additional containers that are
@@ -1408,7 +1401,7 @@
 # In this file, it just takes one of the images in trusted_containers
 # and repeats it.
 - macro: user_sensitive_mount_containers
-  condition: (container.image startswith sysdig/agent)
+  condition: (container.image.repository=sysdig/agent)
 
 - rule: Launch Privileged Container
   desc: Detect the initial process started in a privileged container. Exceptions are made for known trusted images.
@@ -1417,7 +1410,7 @@
     and container.privileged=true
     and not trusted_containers
     and not user_trusted_containers
-  output: Privileged container started (user=%user.name command=%proc.cmdline %container.info image=%container.image)
+  output: Privileged container started (user=%user.name command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)
   priority: INFO
   tags: [container, cis]
 
@@ -1457,7 +1450,7 @@
     and sensitive_mount
     and not trusted_containers
     and not user_sensitive_mount_containers
-  output: Container with sensitive mount started (user=%user.name command=%proc.cmdline %container.info image=%container.image mounts=%container.mounts)
+  output: Container with sensitive mount started (user=%user.name command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag mounts=%container.mounts)
   priority: INFO
   tags: [container, cis]
 
@@ -1468,8 +1461,8 @@
 # alllowed, by using a filter that is guaranteed to evaluate to true
 # (the same proc.vpid=1 that's in the Launch Disallowed Container
 # rule). In the overridden macro, the condition would look something
-# like (container.image startswith vendor/container-1 or
-# container.image startswith vendor/container-2 or ...)
+# like (container.image.repository = vendor/container-1 or
+# container.image.repository = vendor/container-2 or ...)
 
 - macro: allowed_containers
   condition: (proc.vpid=1)
@@ -1478,7 +1471,7 @@
   desc: >
     Detect the initial process started by a container that is not in a list of allowed containers.
   condition: evt.type=execve and proc.vpid=1 and container and not allowed_containers
-  output: Container started and not in allowed list (user=%user.name command=%proc.cmdline %container.info image=%container.image)
+  output: Container started and not in allowed list (user=%user.name command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)
   priority: WARNING
   tags: [container]
 
@@ -1720,8 +1713,8 @@
 # any way to know all the containers that should have access, so any
 # container is alllowed, by repeating the "container" macro. In the
 # overridden macro, the condition would look something like
-# (container.image startswith vendor/container-1 or container.image
-# startswith vendor/container-2 or ...)
+# (container.image.repository = vendor/container-1 or
+# container.image.repository = vendor/container-2 or ...)
 - macro: ec2_metadata_containers
   condition: container
 
@@ -1731,7 +1724,7 @@
 - rule: Contact EC2 Instance Metadata Service From Container
   desc: Detect attempts to contact the EC2 Instance Metadata Service from a container
   condition: outbound and fd.sip="169.254.169.254" and container and not ec2_metadata_containers
-  output: Outbound connection to EC2 instance metadata service (command=%proc.cmdline connection=%fd.name %container.info image=%container.image)
+  output: Outbound connection to EC2 instance metadata service (command=%proc.cmdline connection=%fd.name %container.info image=%container.image.repository:%container.image.tag)
   priority: NOTICE
   tags: [network, aws, container]
 
@@ -1747,16 +1740,14 @@
 # within a container.
 - macro: k8s_containers
   condition: >
-    (container.image startswith gcr.io/google_containers/hyperkube-amd64 or
-     container.image startswith gcr.io/google_containers/kube2sky or
-     container.image startswith sysdig/agent or
-     container.image startswith sysdig/falco or
-     container.image startswith sysdig/sysdig)
+    (container.image.repository in (gcr.io/google_containers/hyperkube-amd64,
+     gcr.io/google_containers/kube2sky, sysdig/agent, sysdig/falco,
+     sysdig/sysdig))
 
 - rule: Contact K8S API Server From Container
   desc: Detect attempts to contact the K8S API Server from a container
   condition: outbound and k8s_api_server and container and not k8s_containers
-  output: Unexpected connection to K8s API Server from container (command=%proc.cmdline %container.info image=%container.image connection=%fd.name)
+  output: Unexpected connection to K8s API Server from container (command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag connection=%fd.name)
   priority: NOTICE
   tags: [network, k8s, container]
 
@@ -1789,7 +1780,7 @@
     spawned_process and container and user.name != "_apt" and package_mgmt_procs and not package_mgmt_ancestor_procs
   output: >
     Package management process launched in container (user=%user.name
-    command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image)
+    command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority: ERROR
   tags: [process]
 
@@ -1802,7 +1793,7 @@
     )
   output: >
     Netcat runs inside container that allows remote code execution (user=%user.name
-    command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image)
+    command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority: WARNING
   tags: [network, process]
 
@@ -1812,7 +1803,7 @@
     spawned_process and container and network_tool_procs
   output: >
     Network tool launched in container (user=%user.name
-    command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image)
+    command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority: NOTICE
   tags: [network, process]
 


### PR DESCRIPTION
Instead of using `container.image`, that always reports the raw string used to spawn the container, switch to the more reliable `container.image.`{`repository`,`tag`}, since they are guaranteed to report the actual repository/tag of the container image.

This also give a little performance improvement (and better looking rules) since a single 'in' predicate can now be used instead of a sequence of startswith.

I've avoided to refactor user macros like `user_trusted_containers` to a single `in` predicate with a list ready to be overridden because, based on the specific use case, additional predicates might be needed (e.g. checking for additional repositories/registry just by prefix) but @mstemm let me know if you think otherwise and it's worth to simplify them.