### PR TITLE
Add additional k8s rbac resources

### DIFF
--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-account.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-account.yaml
@@ -15,7 +15,7 @@ metadata:
     role: security
 rules:
   - apiGroups: ["extensions",""]
-    resources: ["nodes","namespaces","pods","replicationcontrollers","services","events","configmaps"]
+    resources: ["nodes","namespaces","pods","replicationcontrollers","replicasets","services","daemonsets","deployments","events","configmaps"]
     verbs: ["get","list","watch"]
   - nonResourceURLs: ["/healthz", "/healthz/*"]
     verbs: ["get"]


### PR DESCRIPTION
Falco also needs to list/watch replicasets, daemonsets, and deployments,
so add them to the resources list.