### PR TITLE
Add support bundle

### DIFF
--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -144,6 +144,13 @@ void falco_engine::list_fields(bool names_only)
 
 void falco_engine::load_rules(const string &rules_content, bool verbose, bool all_events)
 {
+	uint64_t dummy;
+
+	return load_rules(rules_content, verbose, all_events, dummy);
+}
+
+void falco_engine::load_rules(const string &rules_content, bool verbose, bool all_events, uint64_t &required_engine_version)
+{
 	// The engine must have been given an inspector by now.
 	if(! m_inspector)
 	{
@@ -171,10 +178,17 @@ void falco_engine::load_rules(const string &rules_content, bool verbose, bool al
 	bool json_include_output_property = false;
 	falco_formats::init(m_inspector, this, m_ls, json_output, json_include_output_property);
 
-	m_rules->load_rules(rules_content, verbose, all_events, m_extra, m_replace_container_info, m_min_priority);
+	m_rules->load_rules(rules_content, verbose, all_events, m_extra, m_replace_container_info, m_min_priority, required_engine_version);
 }
 
 void falco_engine::load_rules_file(const string &rules_filename, bool verbose, bool all_events)
+{
+	uint64_t dummy;
+
+	return load_rules_file(rules_filename, verbose, all_events, dummy);
+}
+
+void falco_engine::load_rules_file(const string &rules_filename, bool verbose, bool all_events, uint64_t &required_engine_version)
 {
 	ifstream is;
 
@@ -189,7 +203,7 @@ void falco_engine::load_rules_file(const string &rules_filename, bool verbose, b
 	string rules_content((istreambuf_iterator<char>(is)),
 			     istreambuf_iterator<char>());
 
-	load_rules(rules_content, verbose, all_events);
+	load_rules(rules_content, verbose, all_events, required_engine_version);
 }
 
 void falco_engine::enable_rule(const string &pattern, bool enabled, const string &ruleset)

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -69,6 +69,13 @@ public:
 	void load_rules(const std::string &rules_content, bool verbose, bool all_events);
 
 	//
+	// Identical to above, but also returns the required engine version for the file/content.
+	// (If no required engine version is specified, returns 0).
+	//
+	void load_rules_file(const std::string &rules_filename, bool verbose, bool all_events, uint64_t &required_engine_version);
+	void load_rules(const std::string &rules_content, bool verbose, bool all_events, uint64_t &required_engine_version);
+
+	//
 	// Enable/Disable any rules matching the provided pattern
 	// (regex). When provided, enable/disable these rules in the
 	// context of the provided ruleset. The ruleset (id) can later

--- a/userspace/engine/lua/rule_loader.lua
+++ b/userspace/engine/lua/rule_loader.lua
@@ -195,10 +195,11 @@ function load_rules(sinsp_lua_parser,
 		    min_priority)
 
    local rules = yaml.load(rules_content)
+   local required_engine_version = 0
 
    if rules == nil then
       -- An empty rules file is acceptable
-      return
+      return required_engine_version
    end
 
    if type(rules) ~= "table" then
@@ -216,6 +217,7 @@ function load_rules(sinsp_lua_parser,
       end
 
       if (v['required_engine_version']) then
+	 required_engine_version = v['required_engine_version']
 	 if falco_rules.engine_version(rules_mgr) < v['required_engine_version'] then
 	    error("Rules require engine version "..v['required_engine_version']..", but engine version is "..falco_rules.engine_version(rules_mgr))
 	 end
@@ -549,6 +551,8 @@ function load_rules(sinsp_lua_parser,
    end
 
    io.flush()
+
+   return required_engine_version
 end
 
 local rule_fmt = "%-50s %s"

--- a/userspace/engine/rules.h
+++ b/userspace/engine/rules.h
@@ -41,7 +41,8 @@ class falco_rules
 	~falco_rules();
 	void load_rules(const string &rules_content, bool verbose, bool all_events,
 			std::string &extra, bool replace_container_info,
-			falco_common::priority_type min_priority);
+			falco_common::priority_type min_priority,
+			uint64_t &required_engine_version);
 	void describe_rule(string *rule);
 
 	static void init(lua_State *ls);


### PR DESCRIPTION
Add the ability to dump required support information with a `--support` commandline argument.