### PR TITLE
Docker-based way to build falco

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,0 +1,52 @@
+FROM centos:6
+
+ENV FALCO_VERSION 0.1.1dev
+ENV BUILD_TYPE Release
+ENV BUILD_DRIVER OFF
+ENV BUILD_BPF OFF
+ENV BUILD_WARNINGS_AS_ERRORS ON
+ENV MAKE_JOBS 4
+
+# copied from builder script
+RUN curl -o /etc/yum.repos.d/devtools-2.repo https://people.centos.org/tru/devtools-2/devtools-2.repo && \
+    rpm -i http://mirror.pnl.gov/epel/6/i386/epel-release-6-8.noarch.rpm && \
+    sed -e 's,$basearch,i386,' -e 's,$releasever\],$releasever-i686\],' /etc/yum.repos.d/devtools-2.repo > /etc/yum.repos.d/devtools-2-i686.repo && \
+    yum -y install \
+        createrepo \
+        devtoolset-2-toolchain \
+        dpkg \
+        dpkg-devel \
+        expect \
+        gcc \
+        gcc-c++ \
+        git \
+        glibc-static \
+	libcurl-devel \
+        make \
+	curl \
+	libcurl-devel \
+	zlib-devel \
+        pkg-config \
+        rpm-build \
+        unzip \
+        wget \
+        tar \
+        autoconf \
+        automake \
+        libtool && \
+    yum -y install \
+        glibc-devel.i686 \
+        devtoolset-2-libstdc++-devel.i686 \
+        devtoolset-2-elfutils-libelf-devel && \
+    yum clean all
+RUN curl -o docker.tgz https://get.docker.com/builds/Linux/x86_64/docker-1.11.0.tgz && \
+    tar xfz docker.tgz docker/docker && \
+    mv docker/docker /usr/local/bin/docker && \
+    chmod +x /usr/local/bin/docker && \
+    rm -fr docker.tgz docker/
+
+# TEMPORARY until dependencies in CMakeLists.txt are fixed
+RUN yum -y install libyaml-devel
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/builder/entrypoint.sh
+++ b/docker/builder/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+SOURCE_DIR=/source
+BUILD_DIR=/build
+TASK=${1:-all}
+
+MANPATH=
+
+. /opt/rh/devtoolset-2/enable
+
+# Download and install cmake if not downloaded
+CMAKE_DIR=$BUILD_DIR/cmake
+if [ ! -e $CMAKE_DIR ]; then
+    cd $BUILD_DIR
+    mkdir -p $BUILD_DIR/cmake
+    wget -nv https://s3.amazonaws.com/download.draios.com/dependencies/cmake-3.3.2.tar.gz
+    tar -C $CMAKE_DIR --strip-components 1 -xzf cmake-3.3.2.tar.gz 
+    cd $CMAKE_DIR
+    ./bootstrap --system-curl
+    make -j$MAKE_JOBS
+fi
+
+if [ $TASK == "cmake" ]; then
+    mkdir -p $BUILD_DIR/$BUILD_TYPE
+    cd $BUILD_DIR/$BUILD_TYPE
+    $CMAKE_DIR/bin/cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFALCO_VERSION=$FALCO_VERSION -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DRIVER=${BUILD_DRIVER} -DBUILD_BPF=${BUILD_BPF} -DBUILD_WARNINGS_AS_ERRORS=${BUILD_WARNINGS_AS_ERRORS} $SOURCE_DIR/falco
+    exit 0
+fi
+
+if [ $TASK == "bash" ]; then
+    exec /bin/bash
+fi
+
+cd $BUILD_DIR/$BUILD_TYPE
+make -j$MAKE_JOBS $TASK
+
+
+


### PR DESCRIPTION
To allow for a more portable build environment, create a builder image
that is based on centos 6 with devtoolset-2 for a refrence g++.

In that image, install all required packages and run a script that can
either run cmake or make.

The image depends on the following parameters:

FALCO_VERSION: the version to give any built packages
BUILD_TYPE: Debug or Release
BUILD_DRIVER/BPF: whether or not to build the kernel module/bpf program when
   building. This should usually be OFF, as the kernel module would be
   built for the files in the centos image, not the host.
BUILD_WARNINGS_AS_ERRORS: consider all build warnings fatal
MAKE_JOBS: passed to the -j argument of make

A typical way to run this builder is the following. Assumes you have
checked out falco and sysdig to directories below /home/user/src, and
want to use a build directory of /home/user/build/falco:

$ docker run --user $(id -u):$(id -g) -v /etc/passwd:/etc/passwd:ro -e MAKE_JOBS=4 -it -v /home/user/src:/source -v /home/user/build/falco:/build falco-builder cmake
$ docker run --user $(id -u):$(id -g) -v /etc/passwd:/etc/passwd:ro -e MAKE_JOBS=4 -it -v /home/user/src:/source -v /home/user/build/falco:/build falcosecurity/falco-builder package