### PR TITLE
Add HTTP output handler

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -138,3 +138,7 @@ program_output:
   enabled: false
   keep_alive: false
   program: mail -s "Falco Notification" someone@example.com
+
+http_output:
+  enabled: false
+  url: http://some.url

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -131,6 +131,22 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 		m_outputs.push_back(program_output);
 	}
 
+	falco_outputs::output_config http_output;
+	http_output.name = "http";
+	if (m_config->get_scalar<bool>("http_output", "enabled", false))
+	{
+		string url;
+		url = m_config->get_scalar<string>("http_output", "url", "");
+
+		if (url == string(""))
+		{
+			throw sinsp_exception("Error reading config file (" + m_config_file + "): http output enabled but no url in configuration block");
+		}
+		http_output.options["url"] = url;
+
+		m_outputs.push_back(http_output);
+	}
+
 	if (m_outputs.size() == 0)
 	{
 		throw invalid_argument("Error reading config file (" + m_config_file + "): No outputs configured. Please configure at least one output file output enabled but no filename in configuration block");

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -21,6 +21,12 @@ limitations under the License.
 
 #include <memory>
 
+extern "C" {
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
+}
+
 #include "gen_filter.h"
 #include "json_evt.h"
 #include "falco_common.h"
@@ -61,6 +67,8 @@ public:
 			  falco_common::priority_type priority, std::string &format);
 
 	void reopen_outputs();
+
+	static int handle_http(lua_State *ls);
 
 private:
 

--- a/userspace/falco/lua/output.lua
+++ b/userspace/falco/lua/output.lua
@@ -142,6 +142,16 @@ function mod.program_reopen(options)
    end
 end
 
+function mod.http(priority, priority_num, msg, options)
+   c_outputs.handle_http(options.url, msg)
+end
+
+function mod.http_cleanup()
+end
+
+function mod.http_reopen()
+end
+
 function output_event(event, rule, source, priority, priority_num, format)
    -- If format starts with a *, remove it, as we're adding our own
    -- prefix here.


### PR DESCRIPTION
Adding a simple HTTP handler that allows you to post JSON output directly to a HTTP endpoint instead of the current method of using the program output and curl. 

This was implemented in C++ and the outputs.lua calls back into C++ to handle the the http post using libcurl. 

This can be enabled by setting the `http_output` option in `falco.yaml` to `enabled: true`.
```
http_output:
  enabled: true
  url: http://some.url/you/post/to
```