### PR TITLE
Remove gcc 6.

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -24,11 +24,12 @@ RUN apt-get update \
 	dkms \
 	gnupg2 \
 	gcc \
-	gcc-6 \
 	gdb \
 	jq \
 	libc6-dev \
+	libcilkrts5 \
 	libelf-dev \
+	libubsan0 \
 	llvm-7 \
 	netcat \
 	xz-utils \

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -24,10 +24,11 @@ RUN apt-get update \
 	dkms \
 	gnupg2 \
 	gcc \
-	gcc-6 \
 	jq \
 	libc6-dev \
+	libcilkrts5 \
 	libelf-dev \
+	libubsan0 \
 	llvm-7 \
 	netcat \
 	xz-utils \

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -24,10 +24,11 @@ RUN apt-get update \
 	dkms \
 	gnupg2 \
 	gcc \
-	gcc-6 \
 	jq \
 	libc6-dev \
+	libcilkrts5 \
 	libelf-dev \
+	libubsan0 \
 	llvm-7 \
 	netcat \
 	xz-utils \


### PR DESCRIPTION
Debian:unstable recently removed gcc 6, so remove it from our Dockerfiles.