### PR TITLE
Update version to 0.3.0

### DIFF
--- a/integrations/puppet-module/sysdig-falco/metadata.json
+++ b/integrations/puppet-module/sysdig-falco/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "sysdig-falco",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "sysdig",
   "summary": "Sysdig Falco: Behavioral Activity Monitoring With Container Support",
   "license": "Apache-2.0",


### PR DESCRIPTION
0.2.0 was released as a part of testing an early version in
https://github.com/falcosecurity/falco/pull/537, and can't be
overwritten, so publish as 0.3.0.