### PR TITLE
Allow exe_running_docker_save in the "Write below rpm database" rule

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1116,7 +1116,12 @@
 # Only let rpm-related programs write to the rpm database
 - rule: Write below rpm database
   desc: an attempt to write to the rpm database by any non-rpm related program
-  condition: fd.name startswith /var/lib/rpm and open_write and not rpm_procs and not ansible_running_python and not python_running_chef
+  condition: >
+    fd.name startswith /var/lib/rpm and open_write
+    and not rpm_procs
+    and not ansible_running_python
+    and not python_running_chef
+    and not exe_running_docker_save
   output: "Rpm database opened for writing by a non-rpm program (command=%proc.cmdline file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline)"
   priority: ERROR
   tags: [filesystem, software_mgmt]


### PR DESCRIPTION
Greetings!

When building a Docker container image from a Jenkins container running in Kubernetes, we get:
```JSON
{
  "container.id": "host",
  "evt.time": 1551362688881207853,
  "fd.name": "/var/lib/rpm/Sigmd5",
  "k8s.ns.name": null,
  "k8s.pod.name": null,
  "proc.cmdline": "exe /var/lib/docker/overlay2/67a775b844bc804f5e268e08c1e0bbc67fd4f2e4c23b3edaf2a2ef9043e49982/diff",
  "proc.pcmdline": "dockerd -H fd:// --ip-masq=false --iptables=false --log-driver=json-file --log-level=warn --log-opt=max-file=5 --log-opt=max-size=10m --storage-driver=overlay2",
  "proc.pname": "dockerd"
}
```

That alert is confusing because it says `exe` is writhing in `/var/lib/rpm` on the `host`. What is really happening is Docker building an image.

Adding `and not exe_running_docker_save` in the `Write below rpm database` rule fixes the alert. I've been running with that rule for over a week, it works! :)