### PR TITLE
Puppet write below /etc and new user_known_x macros!

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -909,7 +909,7 @@
                           gen_resolvconf., update-ca-certi, certbot, runsv,
                           qualys-cloud-ag, locales.postins, nomachine_binaries,
                           adclient, certutil, crlutil, pam-auth-update, parallels_insta,
-                          openshift-launc, update-rc.d)
+                          openshift-launc, update-rc.d, puppet)
     and not proc.pname in (sysdigcloud_binaries, mail_config_binaries, hddtemp.postins, sshkit_script_binaries, locales.postins, deb_binaries, dhcp_binaries)
     and not fd.name pmatch (safe_etc_dirs)
     and not fd.name in (/etc/container_environment.sh, /etc/container_environment.json, /etc/motd, /etc/motd.svc)
@@ -1038,6 +1038,16 @@
               or fd.name startswith /root/jvm
               or fd.name startswith /root/.node-gyp)
 
+# Add conditions to this macro (probably in a separate file,
+# overwriting this macro) to allow for specific combinations of
+# programs writing below specific directories below
+# / or /root.
+#
+# In this file, it just takes one of the condition in the base macro
+# and repeats it.
+- macro: user_known_write_root_conditions
+  condition: fd.name=/root/.bash_history
+
 - rule: Write below root
   desc: an attempt to write to any file directly below / or /root
   condition: >
@@ -1055,6 +1065,7 @@
     and not kubectl_writing_state
     and not cassandra_writing_state
     and not known_root_conditions
+    and not user_known_write_root_conditions
   output: "File below / or /root opened for writing (user=%user.name command=%proc.cmdline parent=%proc.pname file=%fd.name program=%proc.name)"
   priority: ERROR
   tags: [filesystem]
@@ -1657,6 +1668,15 @@
 - macro: known_user_in_container
   condition: (container and user.name != "N/A")
 
+# Add conditions to this macro (probably in a separate file,
+# overwriting this macro) to allow for specific combinations of
+# programs changing users by calling setuid.
+#
+# In this file, it just takes one of the condition in the base macro
+# and repeats it.
+- macro: user_known_non_sudo_setuid_conditions
+  condition: user.name=root
+
 # sshd, mail programs attempt to setuid to root even when running as non-root. Excluding here to avoid meaningless FPs
 - rule: Non sudo setuid
   desc: >
@@ -1665,11 +1685,13 @@
   condition: >
     evt.type=setuid and evt.dir=>
     and (known_user_in_container or not container)
-    and not user.name=root and not somebody_becoming_themself
+    and not user.name=root
+    and not somebody_becoming_themself
     and not proc.name in (known_setuid_binaries, userexec_binaries, mail_binaries, docker_binaries,
                           nomachine_binaries)
     and not java_running_sdjagent
     and not nrpe_becoming_nagios
+    and not user_known_non_sudo_setuid_conditions
   output: >
     Unexpected setuid call by non-sudo, non-root program (user=%user.name cur_uid=%user.uid parent=%proc.pname
     command=%proc.cmdline uid=%evt.arg.uid)


### PR DESCRIPTION
Greetings!

Falco is currently whitelisting multiple processes to write below `/etc` and Puppet was not one of them. Adding Puppet to the list of allowed `proc.name` will remove multiple false positives.

On top of that, I added the `user_known_write_root_conditions` and the `user_known_non_sudo_setuid_conditions` macros, so users can add their own condition without overriding the official Falco rules file.

Changes:
+ Add "puppet" in the list of known `proc.name` writing below etc because Puppet often manages configurations
+ Add the user_known_write_root_conditions macro to allow custom conditions in the "Write below root" rule
+ Add the user_known_non_sudo_setuid_conditions to allow custom conditions in the "Non sudo setuid" rule

falco-CLA-1.0-contributing-entity: Coveo Solutions Inc.
falco-CLA-1.0-signed-off-by: Jean-Philippe Lachance <jplachance@coveo.com>