### PR TITLE
! Fix the prometheus_conf_writing_conf macro

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -885,7 +885,7 @@
     (proc.name = calico-node and fd.name startswith /etc/calico)
 
 - macro: prometheus_conf_writing_conf
-  condition: proc.name=prometheus-conf and fd.name startswith /etc/prometheus/config_out
+  condition: (proc.name=prometheus-conf and fd.name startswith /etc/prometheus/config_out)
 
 - macro: openshift_writing_conf
   condition: (proc.name=oc and fd.name=/etc/origin/node/node.kubeconfig)

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -885,7 +885,7 @@
     (proc.name = calico-node and fd.name startswith /etc/calico)
 
 - macro: prometheus_conf_writing_conf
-  condition: (proc.name=prometheus-conf and fd.directory=/etc/prometheus/config_out)
+  condition: proc.name=prometheus-conf and fd.name startswith /etc/prometheus/config_out
 
 - macro: openshift_writing_conf
   condition: (proc.name=oc and fd.name=/etc/origin/node/node.kubeconfig)


### PR DESCRIPTION
Greetings!

`prometheus-conf` started to appear in Falco events as "Write below etc" after an upgrade:
```JSON
{
    "container.id": "2d3204ad6f6a",
    "evt.time": 1552573221328947059,
    "fd.name": "/etc/prometheus/config_out/rules.tmp/rules-0/system.rules",
    "k8s.ns.name": "monitoring",
    "k8s.pod.name": "prometheus-prometheus-1",
    "proc.aname[2]": "docker-containe",
    "proc.aname[3]": "dockerd",
    "proc.aname[4]": "systemd",
    "proc.cmdline": "prometheus-conf --reload-url=http://localhost:9090/-/reload --config-file=/etc/prometheus/config/prometheus.yaml --rule-list-file=/etc/prometheus/config/configmaps.json --config-envsubst-file=/etc/prometheus/config_out/prometheus.env.yaml --rule-dir=/etc/prometheus/config_out/rules",
    "proc.name": "prometheus-conf",
    "proc.pcmdline": "docker-containe 2d3204ad6f6a8b49d2194c2a8def43034e30f208a2f3525539fd382ce2a0360f /var/run/docker/libcontainerd/2d3204ad6f6a8b49d2194c2a8def43034e30f208a2f3525539fd382ce2a0360f docker-runc",
    "proc.pname": "docker-containe",
    "user.name": "root"
}
```

This PR updates the existing `prometheus_conf_writing_conf` macro and fixes the problem.

Enjoy!