### PR TITLE
Skip incomplete container info for container start

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -338,7 +338,10 @@
   condition: container.id != host
 
 - macro: container_started
-  condition: (evt.type = container or (evt.type=execve and evt.dir=< and proc.vpid=1))
+  condition: >
+    ((evt.type = container or
+     (evt.type=execve and evt.dir=< and proc.vpid=1)) and
+     container.image.repository != incomplete)
 
 - macro: interactive
   condition: >

--- a/test/falco_traces.yaml.in
+++ b/test/falco_traces.yaml.in
@@ -34,14 +34,14 @@ traces: !mux
     detect: True
     detect_level: INFO
     detect_counts:
-      - "Launch Privileged Container": 1
+      - "Launch Privileged Container": 2
 
   container-sensitive-mount:
     trace_file: traces-positive/container-sensitive-mount.scap
     detect: True
     detect_level: INFO
     detect_counts:
-      - "Launch Sensitive Mount Container": 1
+      - "Launch Sensitive Mount Container": 2
 
   create-files-below-dev:
     trace_file: traces-positive/create-files-below-dev.scap


### PR DESCRIPTION
In the container_started macro, ensure that the container metadata is
complete after either the container event (very unlikely) or after the
exec of the first process into the container (very likely now that
container metadata fetches are async).

When using these rules with older falco versions, this macro will still
work as the synchronous container metadata fetch will result in a
repository that isn't "incomplete".