### PR TITLE
Include addl info to syscall event drop alerts

### DIFF
--- a/userspace/falco/event_drops.h
+++ b/userspace/falco/event_drops.h
@@ -55,14 +55,14 @@ public:
 	// event drops, and performing any actions.
 	//
 	// Returns whether event processing should continue or stop (with an error).
-	bool process_event(sinsp_evt *evt);
+	bool process_event(sinsp *inspector, sinsp_evt *evt);
 
 	void print_stats();
 
 protected:
 
 	// Perform all configured actions.
-	bool perform_actions(uint64_t now, scap_stats &delta);
+	bool perform_actions(uint64_t now, scap_stats &delta, bool bpf_enabled);
 
 	uint64_t m_num_syscall_evt_drops;
 	uint64_t m_num_actions;

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -300,7 +300,7 @@ uint64_t do_inspect(falco_engine *engine,
 			}
 		}
 
-		if(!sdropmgr.process_event(ev))
+		if(!sdropmgr.process_event(inspector, ev))
 		{
 			result = EXIT_FAILURE;
 			break;


### PR DESCRIPTION
When creating syscall event drop alerts, instead of including just the
total and dropped event count, include all possible causes of drops as
well as whether bpf is enabled.