### PR TITLE
fix regression that broke json output

### DIFF
--- a/userspace/engine/formats.cpp
+++ b/userspace/engine/formats.cpp
@@ -180,6 +180,8 @@ int falco_formats::format_event (lua_State *ls)
 				{
 					json_line.erase(0, 1);
 				}
+
+				s_inspector->set_buffer_format(sinsp_evt::PF_NORMAL);
 			}
 		}
 		catch (sinsp_exception& e)


### PR DESCRIPTION
This should fix #560. Tested and confirmed json output doesn't get escaped after multiple alerts.