### PR TITLE
Fix errors when building via docker from MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,8 +241,6 @@ else()
 	message(STATUS "Using bundled yaml-cpp in '${YAMLCPP_SRC}'")
 	set(YAMLCPP_LIB "${YAMLCPP_SRC}/libyaml-cpp.a")
 	set(YAMLCPP_INCLUDE_DIR "${YAMLCPP_SRC}/include")
-	# Once the next version of yaml-cpp is released (first version not requiring
-	# boost), we can switch to that and no longer pull from github.
 	ExternalProject_Add(yamlcpp
 		URL "https://s3.amazonaws.com/download.draios.com/dependencies/yaml-cpp-yaml-cpp-0.6.2.tar.gz"
 		URL_MD5 "5b943e9af0060d0811148b037449ef82"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,8 +244,8 @@ else()
 	# Once the next version of yaml-cpp is released (first version not requiring
 	# boost), we can switch to that and no longer pull from github.
 	ExternalProject_Add(yamlcpp
-		GIT_REPOSITORY "https://github.com/jbeder/yaml-cpp.git"
-		GIT_TAG "7d2873ce9f2202ea21b6a8c5ecbc9fe38032c229"
+		URL "https://s3.amazonaws.com/download.draios.com/dependencies/yaml-cpp-yaml-cpp-0.6.2.tar.gz"
+		URL_MD5 "5b943e9af0060d0811148b037449ef82"
 		BUILD_IN_SOURCE 1
 		INSTALL_COMMAND "")
 endif()

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -89,9 +89,8 @@ private:
 	token_bucket m_notifications_tb;
 
 	bool m_buffered;
-	bool m_time_format_iso_8601;
-
 	bool m_json_output;
+	bool m_time_format_iso_8601;
 
 	std::string m_lua_add_output = "add_output";
 	std::string m_lua_output_event = "output_event";


### PR DESCRIPTION
When using the GitHub CMake integration, it expects a real user to be present via /etc/passwd. There are ways around this when building on a linux host via the Falco docker builder container, but on a Mac it gets a bit harder. Moving cmake to use curl and pull the yamlcpp tarball via S3 removes the dependency on a local user existing. 

Also, when building via the docker builder, I got warnings (which were treated as errors by GCC) about variable initialization order. Reordered the variables in question to get get rid of the errors, however I'm not sure if we need to check the compiler flags we are using in the Falco docker build container as I haven't seen this before.  