### PR TITLE
Add cri to long_options, fix typo

### DIFF
--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -84,7 +84,7 @@ static void usage()
 	   " -A                            Monitor all events, including those with EF_DROP_FALCO flag.\n"
 	   " -b, --print-base64            Print data buffers in base64. This is useful for encoding\n"
 	   "                               binary data that needs to be used over media designed to\n"
-	   " --cri <path>                  Path to CRI socket for container meatadata\n"
+	   " --cri <path>                  Path to CRI socket for container metadata\n"
 	   "                               Use the specified socket to fetch data from a CRI-compatible runtime\n"
 	   " -d, --daemon                  Run as a daemon\n"
 	   " -D <pattern>                  Disable any rules matching the regex <pattern>. Can be specified multiple times.\n"
@@ -465,7 +465,7 @@ int falco_init(int argc, char **argv)
 		{"validate", required_argument, 0, 'V' },
 		{"writefile", required_argument, 0, 'w' },
 		{"ignored-events", no_argument, 0, 'i'},
-
+		{"cri", required_argument, 0},
 		{0, 0, 0, 0}
 	};
 


### PR DESCRIPTION
Added `cri` to `long_options` else you can't use the `--cri` flag. Also fixed a typo in the usage description for the `--cri` flag.