### PR TITLE
Add Sematext Monitoring & Logging agents to trusted k8s containers

### DIFF
--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -118,10 +118,16 @@
     registry.access.redhat.com/openshift3/ose-sti-builder,
     registry.access.redhat.com/openshift3/ose-docker-builder,
     registry.access.redhat.com/openshift3/image-inspector,
+    registry.access.redhat.com/sematext/sematext-agent-docker,
+    registry.access.redhat.com/sematext/agent,
+    registry.access.redhat.com/sematext/logagent,
     cloudnativelabs/kube-router, istio/proxy,
     datadog/docker-dd-agent, datadog/agent,
     docker/ucp-agent,
-    gliderlabs/logspout]
+    gliderlabs/logspout
+    sematext/agent
+    sematext/logagent
+    sematext/sematext-agent-docker]
 
 - rule: Create Privileged Pod
   desc: >


### PR DESCRIPTION
Please note
registry.access.redhat.com/sematext/agent,
registry.access.redhat.com/sematext/logagent
are not available yet, but we are in the process of certification ...