### PR TITLE
Add instructions for k8s audit support in >= 1.13

### DIFF
--- a/examples/k8s_audit_config/README.md
+++ b/examples/k8s_audit_config/README.md
@@ -1,8 +1,9 @@
 # Introduction
 
-This page describes how to get K8s Audit Logging working with Falco for either K8s 1.11, using static audit policies/sinks, or 1.13, with dynamic audit policies/sinks using AuditSink objects.
+This page describes how to get [Kubernetes Auditing](https://kubernetes.io/docs/tasks/debug-application-cluster/audit) working with Falco.
+Either using static audit backends in Kubernetes 1.11, or in Kubernetes 1.13 with dynamic sink which configures webhook backends through an AuditSink API object.
 
-## K8s 1.11 Instructions
+## Instructions for Kubernetes 1.11
 
 The main steps are:
 
@@ -56,7 +57,7 @@ $
 
 K8s audit events will then be routed to the falco daemonset within the cluster, which you can observe via `kubectl logs -f $(kubectl get pods -l app=falco-example -o jsonpath={.items[0].metadata.name})`.
 
-## K8s 1.13 Instructions
+## Instructions for Kubernetes 1.13
 
 The main steps are:
 

--- a/examples/k8s_audit_config/README.md
+++ b/examples/k8s_audit_config/README.md
@@ -1,29 +1,29 @@
-# Introduction
-
 This page describes how to get [Kubernetes Auditing](https://kubernetes.io/docs/tasks/debug-application-cluster/audit) working with Falco.
 Either using static audit backends in Kubernetes 1.11, or in Kubernetes 1.13 with dynamic sink which configures webhook backends through an AuditSink API object.
+
+<!-- toc -->
 
 ## Instructions for Kubernetes 1.11
 
 The main steps are:
 
-1. Deploy Falco to your K8s cluster
+1. Deploy Falco to your Kubernetes cluster
 1. Define your audit policy and webhook configuration
 1. Restart the API Server to enable Audit Logging
-1. Observe K8s audit events at falco
+1. Observe Kubernetes audit events at falco
 
-### Deploy Falco to your K8s cluster
+### Deploy Falco to your Kubernetes cluster
 
-Follow the [K8s Using Daemonset](../../integrations/k8s-using-daemonset/README.md) instructions to create a falco service account, service, configmap, and daemonset.
+Follow the [Kubernetes Using Daemonset](../../integrations/k8s-using-daemonset/README.md) instructions to create a falco service account, service, configmap, and daemonset.
 
 ### Define your audit policy and webhook configuration
 
-The files in this directory can be used to configure k8s audit logging. The relevant files are:
+The files in this directory can be used to configure Kubernetes audit logging. The relevant files are:
 
-* [audit-policy.yaml](./audit-policy.yaml): The k8s audit log configuration we used to create the rules in [k8s_audit_rules.yaml](../../rules/k8s_audit_rules.yaml).
-* [webhook-config.yaml.in](./webhook-config.yaml.in): A (templated) webhook configuration that sends audit events to an ip associated with the falco service, port 8765. It is templated in that the *actual* ip is defined in an environment variable `FALCO_SERVICE_CLUSTERIP`, which can be plugged in using a program like `envsubst`.
+* [audit-policy.yaml](./audit-policy.yaml): The Kubernetes audit log configuration we used to create the rules in [k8s_audit_rules.yaml](../../rules/k8s_audit_rules.yaml).
+* [webhook-config.yaml.in](./webhook-config.yaml.in): A (templated) webhook configuration that sends audit events to an ip associated with the falco service, port 8765. It is templated in that the *actual* IP is defined in an environment variable `FALCO_SERVICE_CLUSTERIP`, which can be plugged in using a program like `envsubst`.
 
-Run the following to fill in the template file with the ClusterIP ip address you created with the `falco-service` service above. Although services like `falco-service.default.svc.cluster.local` can not be resolved from the kube-apiserver container within the minikube vm (they're run as pods but not *really* a part of the cluster), the ClusterIPs associated with those services are routable.
+Run the following to fill in the template file with the `ClusterIP` IP address you created with the `falco-service` service above. Although services like `falco-service.default.svc.cluster.local` can not be resolved from the kube-apiserver container within the minikube vm (they're run as pods but not *really* a part of the cluster), the `ClusterIP`s associated with those services are routable.
 
 ```
 FALCO_SERVICE_CLUSTERIP=$(kubectl get service falco-service -o=jsonpath={.spec.clusterIP}) envsubst < webhook-config.yaml.in > webhook-config.yaml
@@ -35,10 +35,10 @@ A script [enable-k8s-audit.sh](./enable-k8s-audit.sh) performs the necessary ste
 
 It is run as `bash ./enable-k8s-audit.sh <variant> static`. `<variant>` can be one of the following:
 
-* "minikube"
-* "kops"
+* `minikube`
+* `kops`
 
-When running with variant="kops", you must either modify the script to specify the kops apiserver hostname or set it via the environment: `APISERVER_HOST=api.my-kops-cluster.com bash ./enable-k8s-audit.sh kops`
+When running with `variant` equal to `kops`, you must either modify the script to specify the kops apiserver hostname or set it via the environment: `APISERVER_HOST=api.my-kops-cluster.com bash ./enable-k8s-audit.sh kops`
 
 Its output looks like this:
 
@@ -53,22 +53,22 @@ webhook-config.yaml                                                             
 ***Done!
 $
 ```
-### Observe K8s audit events at falco
+### Observe Kubernetes audit events at falco
 
-K8s audit events will then be routed to the falco daemonset within the cluster, which you can observe via `kubectl logs -f $(kubectl get pods -l app=falco-example -o jsonpath={.items[0].metadata.name})`.
+Kubernetes audit events will then be routed to the falco daemonset within the cluster, which you can observe via `kubectl logs -f $(kubectl get pods -l app=falco-example -o jsonpath={.items[0].metadata.name})`.
 
 ## Instructions for Kubernetes 1.13
 
 The main steps are:
 
-1. Deploy Falco to your K8s cluster
-1. Restart the API Server to enable Audit Logging
-1. Deploy the AuditSink object for your audit policy and webhook configuration
-1. Observe K8s audit events at falco
+1. Deploy Falco to your Kubernetes cluster
+2. Restart the API Server to enable Audit Logging
+3. Deploy the AuditSink object for your audit policy and webhook configuration
+4. Observe Kubernetes audit events at falco
 
-### Deploy Falco to your K8s cluster
+### Deploy Falco to your Kubernetes cluster
 
-Follow the [K8s Using Daemonset](../../integrations/k8s-using-daemonset/README.md) instructions to create a falco service account, service, configmap, and daemonset.
+Follow the [Kubernetes Using Daemonset](../../integrations/k8s-using-daemonset/README.md) instructions to create a Falco service account, service, configmap, and daemonset.
 
 ### Restart the API Server to enable Audit Logging
 
@@ -76,10 +76,10 @@ A script [enable-k8s-audit.sh](./enable-k8s-audit.sh) performs the necessary ste
 
 It is run as `bash ./enable-k8s-audit.sh <variant> dynamic`. `<variant>` can be one of the following:
 
-* "minikube"
-* "kops"
+* `minikube`
+* `kops`
 
-When running with variant="kops", you must either modify the script to specify the kops apiserver hostname or set it via the environment: `APISERVER_HOST=api.my-kops-cluster.com bash ./enable-k8s-audit.sh kops`
+When running with `variant` equal to `kops`, you must either modify the script to specify the kops apiserver hostname or set it via the environment: `APISERVER_HOST=api.my-kops-cluster.com bash ./enable-k8s-audit.sh kops`
 
 Its output looks like this:
 
@@ -94,21 +94,21 @@ $
 
 ### Deploy AuditSink objects
 
-[audit-sink.yaml.in](./audit-sink.yaml.in), in this directory, is a template audit sink configuration that defines the dynamic audit policy and webhook to route k8s audit events to Falco.
+[audit-sink.yaml.in](./audit-sink.yaml.in), in this directory, is a template audit sink configuration that defines the dynamic audit policy and webhook to route Kubernetes audit events to Falco.
 
-Run the following to fill in the template file with the ClusterIP ip address you created with the `falco-service` service above. Although services like `falco-service.default.svc.cluster.local` can not be resolved from the kube-apiserver container within the minikube vm (they're run as pods but not *really* a part of the cluster), the ClusterIPs associated with those services are routable.
+Run the following to fill in the template file with the `ClusterIP` IP address you created with the `falco-service` service above. Although services like `falco-service.default.svc.cluster.local` can not be resolved from the kube-apiserver container within the minikube vm (they're run as pods but not *really* a part of the cluster), the ClusterIPs associated with those services are routable.
 
 ```
 FALCO_SERVICE_CLUSTERIP=$(kubectl get service falco-service -o=jsonpath={.spec.clusterIP}) envsubst < audit-sink.yaml.in > audit-sink.yaml
 ```
 
-### Observe K8s audit events at falco
+### Observe Kubernetes audit events at falco
 
-K8s audit events will then be routed to the falco daemonset within the cluster, which you can observe via `kubectl logs -f $(kubectl get pods -l app=falco-example -o jsonpath={.items[0].metadata.name})`.
+Kubernetes audit events will then be routed to the falco daemonset within the cluster, which you can observe via `kubectl logs -f $(kubectl get pods -l app=falco-example -o jsonpath={.items[0].metadata.name})`.
 
-## K8s 1.13 + Local Log File Instructions
+## Instructions for Kubernetes 1.13 with dynamic webhook and local log file
 
-If you want to use a mix of AuditSink for remote audit events as well as a local audit log file, you can run enable-k8s-audit.sh with the "dynamic+log" argument e.g. `bash ./enable-k8s-audit.sh <variant> dynamic+log`. This will enable dynamic audit logs as well as a static audit log to a local file. Its output looks like this:
+If you want to use a mix of `AuditSink` for remote audit events as well as a local audit log file, you can run `enable-k8s-audit.sh` with the `"dynamic+log"` argument e.g. `bash ./enable-k8s-audit.sh <variant> dynamic+log`. This will enable dynamic audit logs as well as a static audit log to a local file. Its output looks like this:
 
 ```
 ***Copying apiserver config patch script to apiserver...

--- a/examples/k8s_audit_config/README.md
+++ b/examples/k8s_audit_config/README.md
@@ -107,7 +107,7 @@ K8s audit events will then be routed to the falco daemonset within the cluster, 
 
 ## K8s 1.13 + Local Log File Instructions
 
-If you want to use a mix of AuditSink for remote audit events as well as a local audit log file, you can run enable-k8s-audit.sh with the "dynamic-log" argument e.g. `bash ./enable-k8s-audit.sh <variant> dynamic+log`. This will enable dynamic audit logs as well as a static audit log to a local file. Its output looks like this:
+If you want to use a mix of AuditSink for remote audit events as well as a local audit log file, you can run enable-k8s-audit.sh with the "dynamic+log" argument e.g. `bash ./enable-k8s-audit.sh <variant> dynamic+log`. This will enable dynamic audit logs as well as a static audit log to a local file. Its output looks like this:
 
 ```
 ***Copying apiserver config patch script to apiserver...

--- a/examples/k8s_audit_config/README.md
+++ b/examples/k8s_audit_config/README.md
@@ -3,6 +3,20 @@ Either using static audit backends in Kubernetes 1.11, or in Kubernetes 1.13 wit
 
 <!-- toc -->
 
+- [Instructions for Kubernetes 1.11](#instructions-for-kubernetes-111)
+  * [Deploy Falco to your Kubernetes cluster](#deploy-falco-to-your-kubernetes-cluster)
+  * [Define your audit policy and webhook configuration](#define-your-audit-policy-and-webhook-configuration)
+  * [Restart the API Server to enable Audit Logging](#restart-the-api-server-to-enable-audit-logging)
+  * [Observe Kubernetes audit events at falco](#observe-kubernetes-audit-events-at-falco)
+- [Instructions for Kubernetes 1.13](#instructions-for-kubernetes-113)
+  * [Deploy Falco to your Kubernetes cluster](#deploy-falco-to-your-kubernetes-cluster-1)
+  * [Restart the API Server to enable Audit Logging](#restart-the-api-server-to-enable-audit-logging-1)
+  * [Deploy AuditSink objects](#deploy-auditsink-objects)
+  * [Observe Kubernetes audit events at falco](#observe-kubernetes-audit-events-at-falco-1)
+- [Instructions for Kubernetes 1.13 with dynamic webhook and local log file](#instructions-for-kubernetes-113-with-dynamic-webhook-and-local-log-file)
+
+<!-- tocstop -->
+
 ## Instructions for Kubernetes 1.11
 
 The main steps are:

--- a/examples/k8s_audit_config/README.md
+++ b/examples/k8s_audit_config/README.md
@@ -104,3 +104,18 @@ FALCO_SERVICE_CLUSTERIP=$(kubectl get service falco-service -o=jsonpath={.spec.c
 ### Observe K8s audit events at falco
 
 K8s audit events will then be routed to the falco daemonset within the cluster, which you can observe via `kubectl logs -f $(kubectl get pods -l app=falco-example -o jsonpath={.items[0].metadata.name})`.
+
+## K8s 1.13 + Local Log File Instructions
+
+If you want to use a mix of AuditSink for remote audit events as well as a local audit log file, you can run enable-k8s-audit.sh with the "dynamic-log" argument e.g. `bash ./enable-k8s-audit.sh <variant> dynamic+log`. This will enable dynamic audit logs as well as a static audit log to a local file. Its output looks like this:
+
+```
+***Copying apiserver config patch script to apiserver...
+apiserver-config.patch.sh                                                                          100% 2211   662.9KB/s   00:00
+***Copying audit policy file to apiserver...
+audit-policy.yaml                                                                                  100% 2519   847.7KB/s   00:00
+***Modifying k8s apiserver config (will result in apiserver restarting)...
+***Done!
+```
+
+The audit log will be available on the apiserver host at `/var/lib/k8s_audit/audit.log`.

--- a/examples/k8s_audit_config/apiserver-config.patch.sh
+++ b/examples/k8s_audit_config/apiserver-config.patch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -8,13 +8,13 @@ FILENAME=${1:-/etc/kubernetes/manifests/kube-apiserver.yaml}
 VARIANT=${2:-minikube}
 AUDIT_TYPE=${3:-static}
 
-if [ $AUDIT_TYPE == "static" ]; then
-    if grep audit-webhook-config-file $FILENAME ; then
+if [ "$AUDIT_TYPE" == "static" ]; then
+    if grep audit-webhook-config-file "$FILENAME" ; then
 	echo audit-webhook patch already applied
 	exit 0
     fi
 else
-    if grep audit-dynamic-configuration $FILENAME ; then
+    if grep audit-dynamic-configuration "$FILENAME" ; then
 	echo audit-dynamic-configuration patch already applied
 	exit 0
     fi
@@ -26,12 +26,12 @@ rm -f "$TMPFILE"
 APISERVER_PREFIX="    -"
 APISERVER_LINE="- kube-apiserver"
 
-if [ $VARIANT == "kops" ]; then
+if [ "$VARIANT" == "kops" ]; then
     APISERVER_PREFIX="     "
     APISERVER_LINE="/usr/local/bin/kube-apiserver"
 fi
 
-while read LINE
+while read -r LINE
 do
     echo "$LINE" >> "$TMPFILE"
     case "$LINE" in

--- a/examples/k8s_audit_config/audit-sink.yaml.in
+++ b/examples/k8s_audit_config/audit-sink.yaml.in
@@ -1,0 +1,15 @@
+apiVersion: auditregistration.k8s.io/v1alpha1
+kind: AuditSink
+metadata:
+  name: falco-audit-sink
+spec:
+  policy:
+    level: RequestResponse
+    stages:
+      - ResponseComplete
+  webhook:
+    throttle:
+      qps: 10
+      burst: 15
+    clientConfig:
+      url: "http://$FALCO_SERVICE_CLUSTERIP:8765/k8s_audit"

--- a/examples/k8s_audit_config/audit-sink.yaml.in
+++ b/examples/k8s_audit_config/audit-sink.yaml.in
@@ -7,6 +7,7 @@ spec:
     level: RequestResponse
     stages:
       - ResponseComplete
+      - ResponseStarted
   webhook:
     throttle:
       qps: 10

--- a/examples/k8s_audit_config/enable-k8s-audit.sh
+++ b/examples/k8s_audit_config/enable-k8s-audit.sh
@@ -1,21 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
 VARIANT=${1:-minikube}
 AUDIT_TYPE=${2:-static}
 
-if [ $VARIANT == "minikube" ]; then
+if [ "$VARIANT" == "minikube" ]; then
     APISERVER_HOST=$(minikube ip)
     SSH_KEY=$(minikube ssh-key)
-    SSH_USER=docker
+    SSH_USER="docker"
     MANIFEST="/etc/kubernetes/manifests/kube-apiserver.yaml"
 fi
 
-if [ $VARIANT == "kops" ]; then
-#    APISERVER_HOST=api.your-kops-cluster-name.com
+if [ "$VARIANT" == "kops" ]; then
+    # APISERVER_HOST=api.your-kops-cluster-name.com
     SSH_KEY=~/.ssh/id_rsa
-    SSH_USER=admin
+    SSH_USER="admin"
     MANIFEST=/etc/kubernetes/manifests/kube-apiserver.manifest
 
     if [ -z "${APISERVER_HOST+xxx}" ]; then
@@ -25,22 +25,22 @@ if [ $VARIANT == "kops" ]; then
 fi
 
 echo "***Copying apiserver config patch script to apiserver..."
-ssh -i $SSH_KEY $SSH_USER@$APISERVER_HOST "sudo mkdir -p /var/lib/k8s_audit && sudo chown $SSH_USER /var/lib/k8s_audit"
-scp -i $SSH_KEY apiserver-config.patch.sh $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
+ssh -i $SSH_KEY "$SSH_USER@$APISERVER_HOST" "sudo mkdir -p /var/lib/k8s_audit && sudo chown $SSH_USER /var/lib/k8s_audit"
+scp -i $SSH_KEY apiserver-config.patch.sh "$SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit"
 
-if [ $AUDIT_TYPE == "static" ]; then
+if [ "$AUDIT_TYPE" == "static" ]; then
     echo "***Copying audit policy/webhook files to apiserver..."
-    scp -i $SSH_KEY audit-policy.yaml $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
-    scp -i $SSH_KEY webhook-config.yaml $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
+    scp -i $SSH_KEY audit-policy.yaml "$SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit"
+    scp -i $SSH_KEY webhook-config.yaml "$SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit"
 fi
 
-if [ $AUDIT_TYPE == "dynamic+log" ]; then
+if [ "$AUDIT_TYPE" == "dynamic+log" ]; then
     echo "***Copying audit policy file to apiserver..."
-    scp -i $SSH_KEY audit-policy.yaml $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
+    scp -i $SSH_KEY audit-policy.yaml "$SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit"
 fi
 
 echo "***Modifying k8s apiserver config (will result in apiserver restarting)..."
 
-ssh -i $SSH_KEY $SSH_USER@$APISERVER_HOST "sudo bash /var/lib/k8s_audit/apiserver-config.patch.sh $MANIFEST $VARIANT $AUDIT_TYPE"
+ssh -i $SSH_KEY "$SSH_USER@$APISERVER_HOST" "sudo bash /var/lib/k8s_audit/apiserver-config.patch.sh $MANIFEST $VARIANT $AUDIT_TYPE"
 
 echo "***Done!"

--- a/examples/k8s_audit_config/enable-k8s-audit.sh
+++ b/examples/k8s_audit_config/enable-k8s-audit.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 VARIANT=${1:-minikube}
+AUDIT_TYPE=${2:-static}
 
 if [ $VARIANT == "minikube" ]; then
     APISERVER_HOST=$(minikube ip)
@@ -23,14 +24,18 @@ if [ $VARIANT == "kops" ]; then
     fi
 fi
 
-echo "***Copying audit policy/webhook files to apiserver..."
+echo "***Copying apiserver config patch script to apiserver..."
 ssh -i $SSH_KEY $SSH_USER@$APISERVER_HOST "sudo mkdir -p /var/lib/k8s_audit && sudo chown $SSH_USER /var/lib/k8s_audit"
-scp -i $SSH_KEY audit-policy.yaml $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
-scp -i $SSH_KEY webhook-config.yaml $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
 scp -i $SSH_KEY apiserver-config.patch.sh $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
+
+if [ $AUDIT_TYPE == "static" ]; then
+    echo "***Copying audit policy/webhook files to apiserver..."
+    scp -i $SSH_KEY audit-policy.yaml $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
+    scp -i $SSH_KEY webhook-config.yaml $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
+fi
 
 echo "***Modifying k8s apiserver config (will result in apiserver restarting)..."
 
-ssh -i $SSH_KEY $SSH_USER@$APISERVER_HOST "sudo bash /var/lib/k8s_audit/apiserver-config.patch.sh $MANIFEST $VARIANT"
+ssh -i $SSH_KEY $SSH_USER@$APISERVER_HOST "sudo bash /var/lib/k8s_audit/apiserver-config.patch.sh $MANIFEST $VARIANT $AUDIT_TYPE"
 
 echo "***Done!"

--- a/examples/k8s_audit_config/enable-k8s-audit.sh
+++ b/examples/k8s_audit_config/enable-k8s-audit.sh
@@ -34,6 +34,11 @@ if [ $AUDIT_TYPE == "static" ]; then
     scp -i $SSH_KEY webhook-config.yaml $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
 fi
 
+if [ $AUDIT_TYPE == "dynamic+log" ]; then
+    echo "***Copying audit policy file to apiserver..."
+    scp -i $SSH_KEY audit-policy.yaml $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
+fi
+
 echo "***Modifying k8s apiserver config (will result in apiserver restarting)..."
 
 ssh -i $SSH_KEY $SSH_USER@$APISERVER_HOST "sudo bash /var/lib/k8s_audit/apiserver-config.patch.sh $MANIFEST $VARIANT $AUDIT_TYPE"


### PR DESCRIPTION
In K8s 1.13, there's a new mechanism for k8s audit logs using Audit
Sinks, which can be created and managed like other k8s objects.

Add instructions for enabling k8s audit logging for 1.13. The patching
script is still required, as dynamic audit is not a GA feature and needs
to be enabled. Also, the audit sink config is a template and needs to be
filled in with the cluster ip address, like the webhook config for 1.11.

fixes #611 