### PR TITLE
fix egrep rule and ncat rule

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2114,7 +2114,8 @@
   condition: >
     spawned_process and container and
     ((proc.name = "nc" and (proc.args contains "-e" or proc.args contains "-c")) or
-     (proc.name = "ncat" and (proc.args contains "--sh-exec" or proc.args contains "--exec" or proc.args contains "-e" or proc.args contains "-c"))
+     (proc.name = "ncat" and (proc.args contains "--sh-exec" or proc.args contains "--exec" or proc.args contains "-e " 
+                              or proc.args contains "-c " or proc.args contains "--lua-exec"))
     )
   output: >
     Netcat runs inside container that allows remote code execution (user=%user.name

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2114,7 +2114,7 @@
   condition: >
     spawned_process and container and
     ((proc.name = "nc" and (proc.args contains "-e" or proc.args contains "-c")) or
-     (proc.name = "ncat" and (proc.args contains "--sh-exec" or proc.args contains "--exec"))
+     (proc.name = "ncat" and (proc.args contains "--sh-exec" or proc.args contains "--exec" or proc.args contains "-e" or proc.args contains "-c"))
     )
   output: >
     Netcat runs inside container that allows remote code execution (user=%user.name
@@ -2151,7 +2151,7 @@
   tags: [network, process, mitre_discovery, mitre_exfiltration]
 
 - list: grep_binaries
-  items: [grep, egre, fgrep]
+  items: [grep, egrep, fgrep]
 
 - macro: grep_commands
   condition: (proc.name in (grep_binaries))


### PR DESCRIPTION
fixed the grep binaries list that had `egre` instead of `egrep`
added the ncat command line arguments `-c` and `-e` that can be used to spawn remote shells

Launching this : ` ncat -l localhost 4443 -e "/bin/ls"`

would not match anything when running: `sudo sysdig "proc.name = \"ncat\" and (proc.args contains \"--sh-exec\" or proc.args contains \"--exec\")"`

using `sudo sysdig "proc.name = \"ncat\" and (proc.args contains \"--sh-exec\" or proc.args contains \"--exec\" or proc.args contains \"-e\")"` fixes this