### PR TITLE
Allow Ansible to run using Python 3

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -522,7 +522,7 @@
 # compatiblity with some widely used rules files.
 # Begin Deprecated
 - macro: parent_ansible_running_python
-  condition: (proc.pname in (python, pypy) and proc.pcmdline contains ansible)
+  condition: (proc.pname in (python, pypy, python3) and proc.pcmdline contains ansible)
 
 - macro: parent_bro_running_python
   condition: (proc.pname=python and proc.cmdline contains /usr/share/broctl)
@@ -604,7 +604,7 @@
 ## End Deprecated
 
 - macro: ansible_running_python
-  condition: (proc.name in (python, pypy) and proc.cmdline contains ansible)
+  condition: (proc.name in (python, pypy, python3) and proc.cmdline contains ansible)
 
 - macro: python_running_chef
   condition: (proc.name=python and (proc.cmdline contains yum-dump.py or proc.cmdline="python /usr/bin/chef-monitor.py"))


### PR DESCRIPTION
Some newer distros default to Python 3 by default, not 2, which causes Ansible to trigger these rules.