### PR TITLE
Set dropping mode after open so it is effective

### DIFF
--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -856,7 +856,6 @@ int falco_init(int argc, char **argv)
 		if(!all_events)
 		{
 			inspector->set_drop_event_flags(EF_DROP_FALCO);
-			inspector->start_dropping_mode(1);
 		}
 
 		if (describe_all_rules)
@@ -962,6 +961,12 @@ int falco_init(int argc, char **argv)
 				}
 				inspector->open();
 			}
+		}
+
+		// This must be done after the open
+		if(!all_events)
+		{
+			inspector->start_dropping_mode(1);
 		}
 
 		// If daemonizing, do it here so any init errors will


### PR DESCRIPTION
For a while, falco has set the inspector drop mode to 1, which should
discard several classes of events that weren't necessary to use most
falco rules.

However, it was mistakenly being called before the inspector was opened,
which meant it wasn't actually doing anything.

Fix this by setting the dropping mode after the inspector open.

On some spot testing on a moderately loaded environment, this results in
a 30-40% drop in the number of system calls processed per second, and
should result in a nice boost in performance.