### PR TITLE
Better tracking of rule counts per ruleset

### DIFF
--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -251,6 +251,14 @@ uint16_t falco_engine::find_ruleset_id(const std::string &ruleset)
 	return it->second;
 }
 
+uint64_t falco_engine::num_rules_for_ruleset(const std::string &ruleset)
+{
+	uint16_t ruleset_id = find_ruleset_id(ruleset);
+
+	return m_sinsp_rules->num_rules_for_ruleset(ruleset_id) +
+		m_k8s_audit_rules->num_rules_for_ruleset(ruleset_id);
+}
+
 void falco_engine::evttypes_for_ruleset(std::vector<bool> &evttypes, const std::string &ruleset)
 {
 	uint16_t ruleset_id = find_ruleset_id(ruleset);

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -107,6 +107,11 @@ public:
 	uint16_t find_ruleset_id(const std::string &ruleset);
 
 	//
+	// Return the number of falco rules enabled for the provided ruleset
+	//
+	uint64_t num_rules_for_ruleset(const std::string &ruleset);
+
+	//
 	// Print details on the given rule. If rule is NULL, print
 	// details on all rules.
 	//

--- a/userspace/engine/ruleset.cpp
+++ b/userspace/engine/ruleset.cpp
@@ -41,6 +41,7 @@ falco_ruleset::~falco_ruleset()
 }
 
 falco_ruleset::ruleset_filters::ruleset_filters()
+	: m_num_filters(0)
 {
 }
 
@@ -58,10 +59,14 @@ falco_ruleset::ruleset_filters::~ruleset_filters()
 
 void falco_ruleset::ruleset_filters::add_filter(filter_wrapper *wrap)
 {
+
+	bool added = false;
+
 	for(uint32_t etag = 0; etag < wrap->event_tags.size(); etag++)
 	{
 		if(wrap->event_tags[etag])
 		{
+			added = true;
 			if(m_filter_by_event_tag.size() <= etag)
 			{
 				m_filter_by_event_tag.resize(etag+1);
@@ -75,10 +80,17 @@ void falco_ruleset::ruleset_filters::add_filter(filter_wrapper *wrap)
 			m_filter_by_event_tag[etag]->push_back(wrap);
 		}
 	}
+
+	if(added)
+	{
+		m_num_filters++;
+	}
 }
 
 void falco_ruleset::ruleset_filters::remove_filter(filter_wrapper *wrap)
 {
+	bool removed = false;
+
 	for(uint32_t etag = 0; etag < wrap->event_tags.size(); etag++)
 	{
 		if(wrap->event_tags[etag])
@@ -88,22 +100,38 @@ void falco_ruleset::ruleset_filters::remove_filter(filter_wrapper *wrap)
 				list<filter_wrapper *> *l = m_filter_by_event_tag[etag];
 				if(l)
 				{
-					l->erase(remove(l->begin(),
-							l->end(),
-							wrap),
-						 l->end());
+					auto it = remove(l->begin(),
+							 l->end(),
+							 wrap);
 
-					if(l->size() == 0)
+					if(it != l->end())
 					{
-						delete l;
-						m_filter_by_event_tag[etag] = NULL;
+						removed = true;
+
+						l->erase(it,
+							l->end());
+
+						if(l->size() == 0)
+						{
+							delete l;
+							m_filter_by_event_tag[etag] = NULL;
+						}
 					}
 				}
 			}
 		}
 	}
+
+	if(removed)
+	{
+		m_num_filters--;
+	}
 }
 
+uint64_t falco_ruleset::ruleset_filters::num_filters()
+{
+	return m_num_filters;
+}
 
 bool falco_ruleset::ruleset_filters::run(gen_event *evt, uint32_t etag)
 {
@@ -238,6 +266,16 @@ void falco_ruleset::enable_tags(const set<string> &tags, bool enabled, uint16_t 
 			}
 		}
 	}
+}
+
+uint64_t falco_ruleset::num_rules_for_ruleset(uint16_t ruleset)
+{
+	while (m_rulesets.size() < (size_t) ruleset + 1)
+	{
+		m_rulesets.push_back(new ruleset_filters());
+	}
+
+	return m_rulesets[ruleset]->num_filters();
 }
 
 bool falco_ruleset::run(gen_event *evt, uint32_t etag, uint16_t ruleset)

--- a/userspace/engine/ruleset.h
+++ b/userspace/engine/ruleset.h
@@ -61,6 +61,10 @@ public:
 	// enable_tags.
 	void enable_tags(const std::set<std::string> &tags, bool enabled, uint16_t ruleset = 0);
 
+
+	// Return the number of falco rules enabled for the provided ruleset
+	uint64_t num_rules_for_ruleset(uint16_t ruleset = 0);
+
 	// Match all filters against the provided event.
 	bool run(gen_event *evt, uint32_t etag, uint16_t ruleset = 0);
 
@@ -89,11 +93,15 @@ private:
 		void add_filter(filter_wrapper *wrap);
 		void remove_filter(filter_wrapper *wrap);
 
+		uint64_t num_filters();
+
 		bool run(gen_event *evt, uint32_t etag);
 
 		void event_tags_for_ruleset(std::vector<bool> &event_tags);
 
 	private:
+		uint64_t m_num_filters;
+
 		// Maps from event tag to a list of filters. There can
 		// be multiple filters for a given event tag.
 		std::vector<std::list<filter_wrapper *> *> m_filter_by_event_tag;


### PR DESCRIPTION
Add more accurate tracking of the number of falco rules loaded per
ruleset, which are made available via the engine method
::num_rules_for_ruleset().

In the ruleset objects, keep track if a filter wrapper is actually
added/removed and if so increment/decrement the count.