### PR TITLE
wip: Clean up privileged/sens mount container rules

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1671,7 +1671,7 @@
 # NOTE: This list is only provided for backwards compatibility with
 # older local falco rules files that may have been appending to
 # trusted_images. To make customizations, it's better to add images to
-# either privileged_images or sensitive_mount_images.
+# either privileged_images or falco_sensitive_mount_images.
 - list: trusted_images
   items: []
 
@@ -1696,7 +1696,7 @@
           registry.access.redhat.com/sematext/logagent]
 
 # These container images are allowed to run with --privileged
-- list: privileged_images
+- list: falco_privileged_images
   items: [
     sysdig/agent, sysdig/falco, sysdig/sysdig,
     gcr.io/google_containers/kube-proxy, calico/node,
@@ -1704,11 +1704,11 @@
     docker/ucp-agent, sematext_images
     ]
 
-- macro: privileged_containers
+- macro: falco_privileged_containers
   condition: (openshift_image or
               user_trusted_containers or
               container.image.repository in (trusted_images) or
-              container.image.repository in (privileged_images) or
+              container.image.repository in (falco_privileged_images) or
               container.image.repository startswith istio/proxy_ or
               container.image.repository startswith quay.io/sysdig)
 
@@ -1716,7 +1716,7 @@
 # overwriting this macro) to specify additional containers that are
 # allowed to run privileged
 #
-# In this file, it just takes one of the images in privileged_images
+# In this file, it just takes one of the images in falco_privileged_images
 # and repeats it.
 - macro: user_privileged_containers
   condition: (container.image.repository=sysdig/agent)
@@ -1730,7 +1730,7 @@
 
 # These container images are allowed to mount sensitive paths from the
 # host filesystem.
-- list: sensitive_mount_images
+- list: falco_sensitive_mount_images
   items: [
     sysdig/agent, sysdig/falco, sysdig/sysdig,
     gcr.io/google_containers/hyperkube,
@@ -1739,21 +1739,21 @@
     datadog/docker-dd-agent, datadog/agent, docker/ucp-agent, gliderlabs/logspout
     ]
 
-- macro: sensitive_mount_containers
+- macro: falco_sensitive_mount_containers
   condition: (user_trusted_containers or
               container.image.repository in (trusted_images) or
-              container.image.repository in (sensitive_mount_images) or
+              container.image.repository in (falco_sensitive_mount_images) or
               container.image.repository startswith quay.io/sysdig)
 
 # These container images are allowed to run with hostnetwork=true
-- list: hostnetwork_images
+- list: falco_hostnetwork_images
   items: []
 
 # Add conditions to this macro (probably in a separate file,
 # overwriting this macro) to specify additional containers that are
 # allowed to perform sensitive mounts.
 #
-# In this file, it just takes one of the images in sensitive_mount_images
+# In this file, it just takes one of the images in falco_sensitive_mount_images
 # and repeats it.
 - macro: user_sensitive_mount_containers
   condition: (container.image.repository=sysdig/agent)
@@ -1763,7 +1763,7 @@
   condition: >
     container_started and container
     and container.privileged=true
-    and not privileged_containers
+    and not falco_privileged_containers
     and not user_privileged_containers
   output: Privileged container started (user=%user.name command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)
   priority: INFO
@@ -1803,7 +1803,7 @@
   condition: >
     container_started and container
     and sensitive_mount
-    and not sensitive_mount_containers
+    and not falco_sensitive_mount_containers
     and not user_sensitive_mount_containers
   output: Container with sensitive mount started (user=%user.name command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag mounts=%container.mounts)
   priority: INFO

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1665,19 +1665,62 @@
        container.image.repository contains ose-docker-registry or
        container.image.repository contains image-inspector))
 
+# These images are allowed both to run with --privileged and to mount
+# sensitive paths from the host filesystem.
+#
+# NOTE: This list is only provided for backwards compatibility with
+# older local falco rules files that may have been appending to
+# trusted_images. To make customizations, it's better to add images to
+# either privileged_images or sensitive_mount_images.
 - list: trusted_images
+  items: []
+
+# Add conditions to this macro (probably in a separate file,
+# overwriting this macro) to specify additional containers that are
+# trusted and therefore allowed to run privileged *and* with sensitive
+# mounts.
+#
+# Like trusted_images, this is deprecated in favor of
+# user_privileged_containers and user_sensitive_mount_containers and
+# is only provided for backwards compatibility.
+#
+# In this file, it just takes one of the images in trusted_containers
+# and repeats it.
+- macro: user_trusted_containers
+  condition: (container.image.repository=sysdig/agent)
+
+- list: sematext_images
+  items: [sematext/sematext-agent-docker, sematext/agent, sematext/logagent,
+          registry.access.redhat.com/sematext/sematext-agent-docker,
+          registry.access.redhat.com/sematext/agent,
+          registry.access.redhat.com/sematext/logagent]
+
+# These container images are allowed to run with --privileged
+- list: privileged_images
   items: [
-    sysdig/agent, sysdig/falco, sysdig/sysdig, gcr.io/google_containers/hyperkube,
-    quay.io/coreos/flannel, gcr.io/google_containers/kube-proxy, calico/node,
-    rook/toolbox, cloudnativelabs/kube-router, consul, mesosphere/mesos-slave,
-    datadog/docker-dd-agent, datadog/agent, docker/ucp-agent, gliderlabs/logspout
+    sysdig/agent, sysdig/falco, sysdig/sysdig,
+    gcr.io/google_containers/kube-proxy, calico/node,
+    rook/toolbox, cloudnativelabs/kube-router, mesosphere/mesos-slave,
+    docker/ucp-agent, sematext_images
     ]
 
-- macro: trusted_containers
+- macro: privileged_containers
   condition: (openshift_image or
+              user_trusted_containers or
               container.image.repository in (trusted_images) or
+              container.image.repository in (privileged_images) or
               container.image.repository startswith istio/proxy_ or
               container.image.repository startswith quay.io/sysdig)
+
+# Add conditions to this macro (probably in a separate file,
+# overwriting this macro) to specify additional containers that are
+# allowed to run privileged
+#
+# In this file, it just takes one of the images in privileged_images
+# and repeats it.
+- macro: user_privileged_containers
+  condition: (container.image.repository=sysdig/agent)
+
 
 - list: rancher_images
   items: [
@@ -1685,20 +1728,32 @@
     rancher/lb-service-haproxy, rancher/metadata, rancher/healthcheck
   ]
 
-# Add conditions to this macro (probably in a separate file,
-# overwriting this macro) to specify additional containers that are
-# trusted and therefore allowed to run privileged.
-#
-# In this file, it just takes one of the images in trusted_containers
-# and repeats it.
-- macro: user_trusted_containers
-  condition: (container.image.repository=sysdig/agent)
+# These container images are allowed to mount sensitive paths from the
+# host filesystem.
+- list: sensitive_mount_images
+  items: [
+    sysdig/agent, sysdig/falco, sysdig/sysdig,
+    gcr.io/google_containers/hyperkube,
+    gcr.io/google_containers/kube-proxy, calico/node,
+    rook/toolbox, cloudnativelabs/kube-router, consul,
+    datadog/docker-dd-agent, datadog/agent, docker/ucp-agent, gliderlabs/logspout
+    ]
+
+- macro: sensitive_mount_containers
+  condition: (user_trusted_containers or
+              container.image.repository in (trusted_images) or
+              container.image.repository in (sensitive_mount_images) or
+              container.image.repository startswith quay.io/sysdig)
+
+# These container images are allowed to run with hostnetwork=true
+- list: hostnetwork_images
+  items: []
 
 # Add conditions to this macro (probably in a separate file,
 # overwriting this macro) to specify additional containers that are
 # allowed to perform sensitive mounts.
 #
-# In this file, it just takes one of the images in trusted_containers
+# In this file, it just takes one of the images in sensitive_mount_images
 # and repeats it.
 - macro: user_sensitive_mount_containers
   condition: (container.image.repository=sysdig/agent)
@@ -1708,8 +1763,8 @@
   condition: >
     container_started and container
     and container.privileged=true
-    and not trusted_containers
-    and not user_trusted_containers
+    and not privileged_containers
+    and not user_privileged_containers
   output: Privileged container started (user=%user.name command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)
   priority: INFO
   tags: [container, cis, mitre_privilege_escalation, mitre_lateral_movement]
@@ -1748,7 +1803,7 @@
   condition: >
     container_started and container
     and sensitive_mount
-    and not trusted_containers
+    and not sensitive_mount_containers
     and not user_sensitive_mount_containers
   output: Container with sensitive mount started (user=%user.name command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag mounts=%container.mounts)
   priority: INFO

--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -117,7 +117,7 @@
 - rule: Create Privileged Pod
   desc: >
     Detect an attempt to start a pod with a privileged container
-  condition: kevt and pod and kcreate and ka.req.container.privileged=true and not ka.req.container.image.repository in (privileged_images)
+  condition: kevt and pod and kcreate and ka.req.container.privileged=true and not ka.req.container.image.repository in (falco_privileged_images)
   output: Pod started with privileged container (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace image=%ka.req.container.image)
   priority: WARNING
   source: k8s_audit
@@ -135,7 +135,7 @@
   desc: >
     Detect an attempt to start a pod with a volume from a sensitive host directory (i.e. /proc).
     Exceptions are made for known trusted images.
-  condition: kevt and pod and kcreate and sensitive_vol_mount and not ka.req.container.image.repository in (sensitive_mount_images)
+  condition: kevt and pod and kcreate and sensitive_vol_mount and not ka.req.container.image.repository in (falco_sensitive_mount_images)
   output: Pod started with sensitive mount (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace image=%ka.req.container.image mounts=%jevt.value[/requestObject/spec/volumes])
   priority: WARNING
   source: k8s_audit
@@ -144,7 +144,7 @@
 # Corresponds to K8s CIS Benchmark 1.7.4
 - rule: Create HostNetwork Pod
   desc: Detect an attempt to start a pod using the host network.
-  condition: kevt and pod and kcreate and ka.req.container.host_network=true and not ka.req.container.image.repository in (hostnetwork_images)
+  condition: kevt and pod and kcreate and ka.req.container.host_network=true and not ka.req.container.image.repository in (falco_hostnetwork_images)
   output: Pod started using host network (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace image=%ka.req.container.image)
   priority: WARNING
   source: k8s_audit

--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -48,8 +48,7 @@
 # explicitly enumerate the container images that you want to run in
 # your environment. In this main falco rules file, there isn't any way
 # to know all the containers that can run, so any container is
-# alllowed, by using a filter that is guaranteed to evaluate to true
-# (the event time existing). In the overridden macro, the condition
+# allowed, by using the always_true macro. In the overridden macro, the condition
 # would look something like (ka.req.container.image.repository=my-repo/my-image)
 - macro: allowed_k8s_containers
   condition: (jevt.rawtime exists)
@@ -108,31 +107,10 @@
   source: k8s_audit
   tags: [k8s]
 
-- list: trusted_k8s_containers
-  items: [sysdig/agent, sysdig/falco, quay.io/coreos/flannel, calico/node, rook/toolbox,
-    gcr.io/google_containers/hyperkube, gcr.io/google_containers/kube-proxy,
-    openshift3/ose-sti-builder,
-    registry.access.redhat.com/openshift3/logging-fluentd,
-    registry.access.redhat.com/openshift3/logging-elasticsearch,
-    registry.access.redhat.com/openshift3/metrics-cassandra,
-    registry.access.redhat.com/openshift3/ose-sti-builder,
-    registry.access.redhat.com/openshift3/ose-docker-builder,
-    registry.access.redhat.com/openshift3/image-inspector,
-    registry.access.redhat.com/sematext/sematext-agent-docker,
-    registry.access.redhat.com/sematext/agent,
-    registry.access.redhat.com/sematext/logagent,
-    cloudnativelabs/kube-router, istio/proxy,
-    datadog/docker-dd-agent, datadog/agent,
-    docker/ucp-agent,
-    gliderlabs/logspout
-    sematext/agent
-    sematext/logagent
-    sematext/sematext-agent-docker]
-
 - rule: Create Privileged Pod
   desc: >
     Detect an attempt to start a pod with a privileged container
-  condition: kevt and pod and kcreate and ka.req.container.privileged=true and not ka.req.container.image.repository in (trusted_k8s_containers)
+  condition: kevt and pod and kcreate and ka.req.container.privileged=true and not ka.req.container.image.repository in (privileged_images)
   output: Pod started with privileged container (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace image=%ka.req.container.image)
   priority: WARNING
   source: k8s_audit
@@ -150,7 +128,7 @@
   desc: >
     Detect an attempt to start a pod with a volume from a sensitive host directory (i.e. /proc).
     Exceptions are made for known trusted images.
-  condition: kevt and pod and kcreate and sensitive_vol_mount and not ka.req.container.image.repository in (trusted_k8s_containers)
+  condition: kevt and pod and kcreate and sensitive_vol_mount and not ka.req.container.image.repository in (sensitive_mount_images)
   output: Pod started with sensitive mount (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace image=%ka.req.container.image mounts=%jevt.value[/requestObject/spec/volumes])
   priority: WARNING
   source: k8s_audit
@@ -159,7 +137,7 @@
 # Corresponds to K8s CIS Benchmark 1.7.4
 - rule: Create HostNetwork Pod
   desc: Detect an attempt to start a pod using the host network.
-  condition: kevt and pod and kcreate and ka.req.container.host_network=true and not ka.req.container.image.repository in (trusted_k8s_containers)
+  condition: kevt and pod and kcreate and ka.req.container.host_network=true and not ka.req.container.image.repository in (hostnetwork_images)
   output: Pod started using host network (user=%ka.user.name pod=%ka.resp.name ns=%ka.target.namespace image=%ka.req.container.image)
   priority: WARNING
   source: k8s_audit

--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -17,6 +17,13 @@
 #
 - required_engine_version: 2
 
+# Like always_true/always_false, but works with k8s audit events
+- macro: k8s_audit_always_true
+  condition: (jevt.rawtime exists)
+
+- macro: k8s_audit_never_true
+  condition: (jevt.rawtime=0)
+
 # Generally only consider audit events once the response has completed
 - list: k8s_audit_stages
   items: ["ResponseComplete"]
@@ -51,7 +58,7 @@
 # allowed, by using the always_true macro. In the overridden macro, the condition
 # would look something like (ka.req.container.image.repository=my-repo/my-image)
 - macro: allowed_k8s_containers
-  condition: (jevt.rawtime exists)
+  condition: (k8s_audit_always_true)
 
 - macro: response_successful
   condition: (ka.response.code startswith 2)
@@ -285,7 +292,7 @@
 # represent a stream of activity for a cluster. If you wish to disable
 # these events, modify the following macro.
 - macro: consider_activity_events
-  condition: (jevt.rawtime exists)
+  condition: (k8s_audit_always_true)
 
 - macro: kactivity
   condition: (kevt and consider_activity_events)
@@ -407,7 +414,7 @@
 # following macro.
 #  condition: (jevt.rawtime exists)
 - macro: consider_all_events
-  condition: (not jevt.rawtime exists)
+  condition: (k8s_audit_never_true)
 
 - macro: kall
   condition: (kevt and consider_all_events)

--- a/test/falco_k8s_audit_tests.yaml
+++ b/test/falco_k8s_audit_tests.yaml
@@ -21,6 +21,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/allow_namespace_foo.yaml
     detect_counts:
@@ -30,6 +31,7 @@ trace_files: !mux
   user_in_allowed_set:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/allow_namespace_foo.yaml
       - ./rules/k8s_audit/allow_user_some-user.yaml
@@ -40,6 +42,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/allow_only_apache_container.yaml
     detect_counts:
@@ -49,6 +52,7 @@ trace_files: !mux
   create_allowed_pod:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/allow_nginx_container.yaml
     trace_file: trace_files/k8s_audit/create_nginx_pod_unprivileged.json
@@ -57,6 +61,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - Create Privileged Pod: 1
@@ -66,6 +71,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - Create Privileged Pod: 1
@@ -74,6 +80,7 @@ trace_files: !mux
   create_privileged_trusted_pod:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/trust_nginx_container.yaml
     trace_file: trace_files/k8s_audit/create_nginx_pod_privileged.json
@@ -81,12 +88,14 @@ trace_files: !mux
   create_unprivileged_pod:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     trace_file: trace_files/k8s_audit/create_nginx_pod_unprivileged.json
 
   create_unprivileged_trusted_pod:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/trust_nginx_container.yaml
     trace_file: trace_files/k8s_audit/create_nginx_pod_unprivileged.json
@@ -95,6 +104,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - Create Sensitive Mount Pod: 1
@@ -104,6 +114,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - Create Sensitive Mount Pod: 1
@@ -112,6 +123,7 @@ trace_files: !mux
   create_sensitive_mount_trusted_pod:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/trust_nginx_container.yaml
     trace_file: trace_files/k8s_audit/create_nginx_pod_sensitive_mount.json
@@ -119,12 +131,14 @@ trace_files: !mux
   create_unsensitive_mount_pod:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     trace_file: trace_files/k8s_audit/create_nginx_pod_unsensitive_mount.json
 
   create_unsensitive_mount_trusted_pod:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/trust_nginx_container.yaml
     trace_file: trace_files/k8s_audit/create_nginx_pod_unsensitive_mount.json
@@ -133,6 +147,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - Create HostNetwork Pod: 1
@@ -141,6 +156,7 @@ trace_files: !mux
   create_hostnetwork_trusted_pod:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/trust_nginx_container.yaml
     trace_file: trace_files/k8s_audit/create_nginx_pod_hostnetwork.json
@@ -148,12 +164,14 @@ trace_files: !mux
   create_nohostnetwork_pod:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     trace_file: trace_files/k8s_audit/create_nginx_pod_nohostnetwork.json
 
   create_nohostnetwork_trusted_pod:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/trust_nginx_container.yaml
     trace_file: trace_files/k8s_audit/create_nginx_pod_nohostnetwork.json
@@ -162,6 +180,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/disallow_kactivity.yaml
     detect_counts:
@@ -171,6 +190,7 @@ trace_files: !mux
   create_nonodeport_service:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/disallow_kactivity.yaml
     trace_file: trace_files/k8s_audit/create_nginx_service_nonodeport.json
@@ -179,6 +199,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/disallow_kactivity.yaml
     detect_counts:
@@ -188,6 +209,7 @@ trace_files: !mux
   create_configmap_no_private_creds:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/disallow_kactivity.yaml
     trace_file: trace_files/k8s_audit/create_configmap_no_sensitive_values.json
@@ -196,6 +218,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - Anonymous Request Allowed: 1
@@ -205,6 +228,7 @@ trace_files: !mux
     detect: True
     detect_level: NOTICE
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - Attach/Exec Pod: 1
@@ -214,6 +238,7 @@ trace_files: !mux
     detect: True
     detect_level: NOTICE
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - Attach/Exec Pod: 1
@@ -223,6 +248,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/allow_user_some-user.yaml
     detect_counts:
@@ -232,6 +258,7 @@ trace_files: !mux
   namespace_in_allowed_set:
     detect: False
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/allow_namespace_foo.yaml
       - ./rules/k8s_audit/disallow_kactivity.yaml
@@ -241,6 +268,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - Pod Created in Kube Namespace: 1
@@ -250,6 +278,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - Pod Created in Kube Namespace: 1
@@ -259,6 +288,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - Service Account Created in Kube Namespace: 1
@@ -268,6 +298,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - Service Account Created in Kube Namespace: 1
@@ -277,6 +308,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - System ClusterRole Modified/Deleted: 1
@@ -286,6 +318,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - System ClusterRole Modified/Deleted: 1
@@ -295,6 +328,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - Attach to cluster-admin Role: 1
@@ -304,6 +338,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - ClusterRole With Wildcard Created: 1
@@ -313,6 +348,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - ClusterRole With Wildcard Created: 1
@@ -322,6 +358,7 @@ trace_files: !mux
     detect: True
     detect_level: NOTICE
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - ClusterRole With Write Privileges Created: 1
@@ -331,6 +368,7 @@ trace_files: !mux
     detect: True
     detect_level: WARNING
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - ClusterRole With Pod Exec Created: 1
@@ -340,6 +378,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - K8s Deployment Created: 1
@@ -349,6 +388,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - K8s Deployment Deleted: 1
@@ -358,6 +398,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - K8s Service Created: 1
@@ -367,6 +408,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - K8s Service Deleted: 1
@@ -376,6 +418,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - K8s ConfigMap Created: 1
@@ -385,6 +428,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - K8s ConfigMap Deleted: 1
@@ -394,6 +438,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/allow_namespace_foo.yaml
       - ./rules/k8s_audit/allow_user_some-user.yaml
@@ -405,6 +450,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - K8s Namespace Deleted: 1
@@ -414,6 +460,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - K8s Serviceaccount Created: 1
@@ -423,6 +470,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - K8s Serviceaccount Deleted: 1
@@ -432,6 +480,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - K8s Role/Clusterrole Created: 1
@@ -441,6 +490,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - K8s Role/Clusterrole Deleted: 1
@@ -450,6 +500,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - K8s Role/Clusterrolebinding Created: 1
@@ -459,6 +510,7 @@ trace_files: !mux
     detect: True
     detect_level: INFO
     rules_file:
+      - ../rules/falco_rules.yaml
       - ../rules/k8s_audit_rules.yaml
     detect_counts:
       - K8s Role/Clusterrolebinding Deleted: 1

--- a/test/rules/k8s_audit/trust_nginx_container.yaml
+++ b/test/rules/k8s_audit/trust_nginx_container.yaml
@@ -1,3 +1,11 @@
-- list: trusted_k8s_containers
+- list: falco_sensitive_mount_images
+  items: [nginx]
+  append: true
+
+- list: falco_privileged_images
+  items: [nginx]
+  append: true
+
+- list: falco_hostnetwork_images
   items: [nginx]
   append: true


### PR DESCRIPTION
Previously, the exceptions for Launch Privileged Container/Launch
Sensitive Mount Container came from a list of "trusted" images and/or a
macro that defined "trusted" containers. We want more fine-grained
control over the exceptions for these rules, so split them into
exception lists/macros that are specific to each rule. This defines:

 - privileged_images: only those images that are known to require
   privileged=true
 - privileged_containers: uses privileged_images and (for now) still
   allows all openshift images
 - user_privileged_containers: allows user exceptions
 - sensitive_mount_images: only those images that are known to perform
   sensitive mounts
 - sensitive_mount_containers: uses sensitive_mount_images
 - user_sensitive_mount_containers: allows user exceptions

For backwards compatibility purposes only, we keep the trusted_images
list and user_trusted_containers macro and they are still used as
exceptions for both rules. Comments recommend using the more
fine-grained alternatives, though.

While defining these lists, also do another survey to see if they still
require these permissions and remove them if they didn't.

Removed:
 - quay.io/coreos/flannel
 - consul

Moved to sensitive mount only:
 - gcr.io/google_containers/hyperkube
 - datadog
 - gliderlabs/logspout

Finally, get rid of the k8s audit-specific lists of privileged/sensitive
mount images, relying on the ones in falco_rules.yaml.

```release-note
Refactor rules/exception lists for sensitive mount, privileged, hostnetwork images to have separate lists for each instead of a combined "trusted" list that was used for all three.
```