### PR TITLE
new: SYSDIG_DIR can be passed as cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,8 @@ endif()
 
 set(CMD_MAKE make)
 
-set(SYSDIG_DIR "${PROJECT_SOURCE_DIR}/../sysdig")
+option(SYSDIG_DIR “Set the path to the Sysdig source” “${PROJECT_SOURCE_DIR}/../sysdig”)
+
 # make luaJIT work on OS X
 if(APPLE)
 	set(CMAKE_EXE_LINKER_FLAGS "-pagezero_size 10000 -image_base 100000000")


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

It allows to specify a path where to find the sysdig source when building Falco.
In this way the two projects don't have to stay in the same top level directory.

```
cmake -DSYSDIG_DIR=/my/path/to/sysdig ..
```

**Special notes for your reviewer**:

Be kind

**Does this PR introduce a user-facing change?**:

```release-note
build: ability to specify a custom path for the sysdig source code
```
