### PR TITLE
hotfix: SYSDIG_DIR not as an option but as a set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,10 @@ endif()
 
 set(CMD_MAKE make)
 
-option(SYSDIG_DIR “Set the path to the Sysdig source” “${PROJECT_SOURCE_DIR}/../sysdig”)
+if(NOT SYSDIG_DIR)
+	set(SYSDIG_DIR "${PROJECT_SOURCE_DIR}/../sysdig")
+endif()
+
 
 # make luaJIT work on OS X
 if(APPLE)


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>


**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**
NONE

**What this PR does / why we need it**:

There was a mistake in how the SYSDIG_DIR option had been made.
We were kind of sure that it was just fine but discovered that it's not like that.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
