### PR TITLE
update(.github): PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,48 +7,66 @@
 -->
 
 **What type of PR is this?**
-> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
->
+
+> Uncomment one (or more) `/kind <>` lines:
+
 > /kind bug
+
 > /kind cleanup
+
 > /kind design
+
 > /kind documentation
+
 > /kind failing-test
+
 > /kind feature
+
 > /kind flaky-test
 
-> If contributing rules or changes to rules, please make sure to uncomment the appropriate kind
+> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:
 
 > /kind rule-update
+
 > /kind rule-create
 
 **Any specific area of the project related to this PR?**
 
+> Uncomment one (or more) `/area <>` lines:
+
 > /area engine
+
 > /area rules
+
 > /area deployment
+
 > /area integrations
+
 > /area examples
 
 **What this PR does / why we need it**:
 
 **Which issue(s) this PR fixes**:
+
 <!--
 Automatically closes linked issue when PR is merged.
 Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
 If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
 -->
+
 Fixes #
 
 **Special notes for your reviewer**:
 
 **Does this PR introduce a user-facing change?**:
+
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
-Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required:".
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
 For example, `action required: change the API interface of the rule engine`.
 -->
+
 ```release-note
 
 ```


### PR DESCRIPTION
Some refinements and improvements to the GitHub PR template.

Co-authored-by: Lorenzo Fontana <lo@linux.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
5. Please add a release note!
6. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug

/kind cleanup

> /kind design

/kind documentation

> /kind failing-test
> /kind feature
> /kind flaky-test

> If contributing rules or changes to rules, please make sure to uncomment the appropriate kind

> /kind rule-update
> /kind rule-create

**Any specific area of the project related to this PR?**

> /area engine
> /area rules
> /area deployment
> /area integrations
> /area examples

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->
```release-note
NONE
```
