### PR TITLE
chore: clang format following the current style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,10 +1,16 @@
-# This coding convention's solely goal is to approximately match the current code style.
-# It MUST not be intended in any other way until a real and definitive coding convention is put in.
 ---
-BreakBeforeBraces: GNU
-ColumnLimit: 0
-IndentWidth: 4
 Language: Cpp
+BasedOnStyle: LLVM
+AccessModifierOffset: -8
+BreakBeforeBraces: Allman
+BreakConstructorInitializers: AfterColon
+ColumnLimit: 0
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+DerivePointerAlignment: true
+IndentWidth: 8
+SortIncludes: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeCtorInitializerColon: false
 SpaceBeforeParens: Never
-Standard: Auto
 UseTab: Always

--- a/tests/engine/test_token_bucket.cpp
+++ b/tests/engine/test_token_bucket.cpp
@@ -23,61 +23,61 @@ using namespace Catch::literals;
 
 TEST_CASE("token bucket default ctor", "[token_bucket]")
 {
-    auto tb = new token_bucket();
+	auto tb = new token_bucket();
 
-    REQUIRE(tb->get_tokens() == 1);
+	REQUIRE(tb->get_tokens() == 1);
 
-    SECTION("initialising with specific time, rate 2 tokens/sec")
-    {
-	auto max = 2.0;
-	uint64_t now = 1;
-	tb->init(1.0, max, now);
-	REQUIRE(tb->get_last_seen() == now);
-	REQUIRE(tb->get_tokens() == max);
-    }
+	SECTION("initialising with specific time, rate 2 tokens/sec")
+	{
+		auto max = 2.0;
+		uint64_t now = 1;
+		tb->init(1.0, max, now);
+		REQUIRE(tb->get_last_seen() == now);
+		REQUIRE(tb->get_tokens() == max);
+	}
 }
 
 TEST_CASE("token bucket ctor with custom timer", "[token_bucket]")
 {
-    auto t = []() -> uint64_t { return 22; };
-    auto tb = new token_bucket(t);
+	auto t = []() -> uint64_t { return 22; };
+	auto tb = new token_bucket(t);
 
-    REQUIRE(tb->get_tokens() == 1);
-    REQUIRE(tb->get_last_seen() == 22);
+	REQUIRE(tb->get_tokens() == 1);
+	REQUIRE(tb->get_last_seen() == 22);
 }
 
 TEST_CASE("token bucket with 2 tokens/sec rate, max 10 tokens", "[token_bucket]")
 {
-    auto tb = new token_bucket();
-    tb->init(2.0, 10, 1);
+	auto tb = new token_bucket();
+	tb->init(2.0, 10, 1);
 
-    SECTION("claiming 5 tokens")
-    {
-	bool claimed = tb->claim(5, 1000000001);
-	REQUIRE(tb->get_last_seen() == 1000000001);
-	REQUIRE(tb->get_tokens() == 5.0_a);
-	REQUIRE(claimed);
-
-	SECTION("claiming all the 7 remaining tokens")
+	SECTION("claiming 5 tokens")
 	{
-	    bool claimed = tb->claim(7, 2000000001);
-	    REQUIRE(tb->get_last_seen() == 2000000001);
-	    REQUIRE(tb->get_tokens() == 0.0_a);
-	    REQUIRE(claimed);
+		bool claimed = tb->claim(5, 1000000001);
+		REQUIRE(tb->get_last_seen() == 1000000001);
+		REQUIRE(tb->get_tokens() == 5.0_a);
+		REQUIRE(claimed);
 
-	    SECTION("claiming 1 token more than the 2 available fails")
-	    {
-		bool claimed = tb->claim(3, 3000000001);
-		REQUIRE(tb->get_last_seen() == 3000000001);
-		REQUIRE(tb->get_tokens() == 2.0_a);
-		REQUIRE_FALSE(claimed);
-	    }
+		SECTION("claiming all the 7 remaining tokens")
+		{
+			bool claimed = tb->claim(7, 2000000001);
+			REQUIRE(tb->get_last_seen() == 2000000001);
+			REQUIRE(tb->get_tokens() == 0.0_a);
+			REQUIRE(claimed);
+
+			SECTION("claiming 1 token more than the 2 available fails")
+			{
+				bool claimed = tb->claim(3, 3000000001);
+				REQUIRE(tb->get_last_seen() == 3000000001);
+				REQUIRE(tb->get_tokens() == 2.0_a);
+				REQUIRE_FALSE(claimed);
+			}
+		}
 	}
-    }
 }
 
 TEST_CASE("token bucket default initialization", "[token_bucket]")
 {
-    token_bucket tb;
-    REQUIRE(tb.get_tokens() == 1);
+	token_bucket tb;
+	REQUIRE(tb.get_tokens() == 1);
 }

--- a/userspace/engine/token_bucket.cpp
+++ b/userspace/engine/token_bucket.cpp
@@ -24,14 +24,15 @@ limitations under the License.
 #include "token_bucket.h"
 #include "utils.h"
 
-token_bucket::token_bucket() : token_bucket(sinsp_utils::get_current_time_ns)
+token_bucket::token_bucket():
+	token_bucket(sinsp_utils::get_current_time_ns)
 {
 }
 
 token_bucket::token_bucket(std::function<uint64_t()> timer)
 {
-    m_timer = timer;
-    init(1, 1);
+	m_timer = timer;
+	init(1, 1);
 }
 
 token_bucket::~token_bucket()
@@ -40,51 +41,51 @@ token_bucket::~token_bucket()
 
 void token_bucket::init(double rate, double max_tokens, uint64_t now)
 {
-    m_rate = rate;
-    m_max_tokens = max_tokens;
-    m_tokens = max_tokens;
-    m_last_seen = now == 0 ? m_timer() : now;
+	m_rate = rate;
+	m_max_tokens = max_tokens;
+	m_tokens = max_tokens;
+	m_last_seen = now == 0 ? m_timer() : now;
 }
 
 bool token_bucket::claim()
 {
-    return claim(1, m_timer());
+	return claim(1, m_timer());
 }
 
 bool token_bucket::claim(double tokens, uint64_t now)
 {
-    double tokens_gained = m_rate * ((now - m_last_seen) / (1000000000.0));
-    m_last_seen = now;
+	double tokens_gained = m_rate * ((now - m_last_seen) / (1000000000.0));
+	m_last_seen = now;
 
-    m_tokens += tokens_gained;
+	m_tokens += tokens_gained;
 
-    //
-    // Cap at max_tokens
-    //
-    if(m_tokens > m_max_tokens)
+	//
+	// Cap at max_tokens
+	//
+	if(m_tokens > m_max_tokens)
 	{
-	    m_tokens = m_max_tokens;
+		m_tokens = m_max_tokens;
 	}
 
-    //
-    // If m_tokens is < tokens, can't claim.
-    //
-    if(m_tokens < tokens)
+	//
+	// If m_tokens is < tokens, can't claim.
+	//
+	if(m_tokens < tokens)
 	{
-	    return false;
+		return false;
 	}
 
-    m_tokens -= tokens;
+	m_tokens -= tokens;
 
-    return true;
+	return true;
 }
 
 double token_bucket::get_tokens()
 {
-    return m_tokens;
+	return m_tokens;
 }
 
 uint64_t token_bucket::get_last_seen()
 {
-    return m_last_seen;
+	return m_last_seen;
 }

--- a/userspace/engine/token_bucket.h
+++ b/userspace/engine/token_bucket.h
@@ -26,55 +26,55 @@ limitations under the License.
 // for limited bursting in the form of "banked" tokens.
 class token_bucket
 {
-  public:
-    token_bucket();
-    token_bucket(std::function<uint64_t()> timer);
-    virtual ~token_bucket();
+public:
+	token_bucket();
+	token_bucket(std::function<uint64_t()> timer);
+	virtual ~token_bucket();
 
-    //
-    // Initialize the token bucket and start accumulating tokens
-    //
-    void init(double rate, double max_tokens, uint64_t now = 0);
+	//
+	// Initialize the token bucket and start accumulating tokens
+	//
+	void init(double rate, double max_tokens, uint64_t now = 0);
 
-    //
-    // Try to claim tokens tokens from the token bucket, using a
-    // timestamp of now. Returns true if the tokens could be
-    // claimed. Also updates internal metrics.
-    //
-    bool claim(double tokens, uint64_t now);
+	//
+	// Try to claim tokens tokens from the token bucket, using a
+	// timestamp of now. Returns true if the tokens could be
+	// claimed. Also updates internal metrics.
+	//
+	bool claim(double tokens, uint64_t now);
 
-    // Simpler version of claim that claims a single token and
-    // uses the current time for now
-    bool claim();
+	// Simpler version of claim that claims a single token and
+	// uses the current time for now
+	bool claim();
 
-    // Return the current number of tokens available
-    double get_tokens();
+	// Return the current number of tokens available
+	double get_tokens();
 
-    // Return the last time someone tried to claim a token.
-    uint64_t get_last_seen();
+	// Return the last time someone tried to claim a token.
+	uint64_t get_last_seen();
 
-  private:
-    std::function<uint64_t()> m_timer;
+private:
+	std::function<uint64_t()> m_timer;
 
-    //
-    // The number of tokens generated per second.
-    //
-    double m_rate;
+	//
+	// The number of tokens generated per second.
+	//
+	double m_rate;
 
-    //
-    // The maximum number of tokens that can be banked for future
-    // claim()s.
-    //
-    double m_max_tokens;
+	//
+	// The maximum number of tokens that can be banked for future
+	// claim()s.
+	//
+	double m_max_tokens;
 
-    //
-    // The current number of tokens
-    //
-    double m_tokens;
+	//
+	// The current number of tokens
+	//
+	double m_tokens;
 
-    //
-    // The last time claim() was called (or the object was created).
-    // Nanoseconds since the epoch.
-    //
-    uint64_t m_last_seen;
+	//
+	// The last time claim() was called (or the object was created).
+	// Nanoseconds since the epoch.
+	//
+	uint64_t m_last_seen;
 };


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:


/kind cleanup

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

@mstemm pointed out that our new clang format wasn't really following the current code style.

We added a clang format created by @gianlucaborello that is better to match the current style and reformatted the files from #692 

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
