### PR TITLE
update: sysdig dir gate in subdirectories

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -18,6 +18,10 @@
 configure_file(debian/postinst.in debian/postinst)
 configure_file(debian/prerm.in debian/prerm)
 
+if(NOT SYSDIG_DIR)
+	set(SYSDIG_DIR "${PROJECT_SOURCE_DIR}/../sysdig")
+endif()
+
 file(COPY "${PROJECT_SOURCE_DIR}/scripts/debian/falco"
 	DESTINATION "${PROJECT_BINARY_DIR}/scripts/debian")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ if(FALCO_BUILD_TESTS)
            "${FAKEIT_INCLUDE}"
            "${PROJECT_SOURCE_DIR}/userspace/engine")
 
+  include(CMakeParseArguments)
   include(CTest)
   include(Catch)
   catch_discover_tests(falco_test)

--- a/userspace/engine/CMakeLists.txt
+++ b/userspace/engine/CMakeLists.txt
@@ -15,6 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(NOT SYSDIG_DIR)
+	set(SYSDIG_DIR "${PROJECT_SOURCE_DIR}/../sysdig")
+endif()
+
 set(FALCO_ENGINE_SOURCE_FILES
 	rules.cpp
 	falco_common.cpp

--- a/userspace/falco/CMakeLists.txt
+++ b/userspace/falco/CMakeLists.txt
@@ -15,8 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+if(NOT SYSDIG_DIR)
+	set(SYSDIG_DIR "${PROJECT_SOURCE_DIR}/../sysdig")
+endif()
 
-configure_file("${PROJECT_SOURCE_DIR}/../sysdig/userspace/sysdig/config_sysdig.h.in" config_sysdig.h)
+configure_file("${SYSDIG_DIR}/userspace/sysdig/config_sysdig.h.in" config_sysdig.h)
 
 add_executable(falco
 	configuration.cpp
@@ -25,7 +28,7 @@ add_executable(falco
 	event_drops.cpp
 	statsfilewriter.cpp
 	falco.cpp
-	"${PROJECT_SOURCE_DIR}/../sysdig/userspace/sysdig/fields_info.cpp"
+	"${SYSDIG_DIR}/userspace/sysdig/fields_info.cpp"
 	webserver.cpp)
 
 target_include_directories(falco PUBLIC
@@ -39,7 +42,7 @@ target_include_directories(falco PUBLIC
 
 target_link_libraries(falco falco_engine sinsp)
 target_link_libraries(falco
-        "${LIBYAML_LIB}"
+	"${LIBYAML_LIB}"
 	"${YAMLCPP_LIB}"
 	"${CIVETWEB_LIB}")
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**
NONE

> Uncomment one (or more) `/area <>` lines:

> /area engine

> /area rules

> /area deployment

> /area integrations

> /area examples

**What this PR does / why we need it**:

It fixes users of the falco engine, falco, and falco_tests as a library by adding a gate for SYSDIG_DIR.


**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

🐶 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
