### PR TITLE
bump falco engine version

### DIFF
--- a/userspace/engine/falco_engine_version.h
+++ b/userspace/engine/falco_engine_version.h
@@ -19,7 +19,7 @@ limitations under the License.
 
 // The version of rules/filter fields/etc supported by this falco
 // engine.
-#define FALCO_ENGINE_VERSION (3)
+#define FALCO_ENGINE_VERSION (4)
 
 // This is the result of running "falco --list -N | sha256sum" and
 // represents the fields supported by this version of falco. It's used


### PR DESCRIPTION


**What type of PR is this?**



/kind documentation
/kind feature



**Any specific area of the project related to this PR?**


/area engine
/area rules


**What this PR does / why we need it**:

We need to bump the engine version in order to signal that `ka.useragent` alias (https://github.com/falcosecurity/falco/pull/709) is available starting from engine version 4.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:



```release-note
bump falco engine to version 4
```
