### PR TITLE
ignore container probes

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -24,7 +24,7 @@
 # change to this rules file, we'll uncomment this line and set it to
 # the falco engine version in use at the time.
 #
-#- required_engine_version: 2
+- required_engine_version: 4
 
 # Currently disabled as read/write are ignored syscalls. The nearly
 # similar open_write/open_read check for files being opened for
@@ -2118,6 +2118,15 @@
 - macro: user_known_non_sudo_setuid_conditions
   condition: user.name=root
 
+# Various probes may be necessary to manage and orchestrate containers and
+# these probes should be excepted out of certain rules.
+# See https://github.com/falcosecurity/falco/issues/310
+- macro: is_container_probe
+  condition: >
+    (proc.is_container_healthcheck=true or
+    proc.is_container_liveness_probe=true or
+    proc.is_container_readiness_probe=true)
+
 # sshd, mail programs attempt to setuid to root even when running as non-root. Excluding here to avoid meaningless FPs
 - rule: Non sudo setuid
   desc: >
@@ -2134,6 +2143,7 @@
     and not java_running_sdjagent
     and not nrpe_becoming_nagios
     and not user_known_non_sudo_setuid_conditions
+    and not is_container_probe
   output: >
     Unexpected setuid call by non-sudo, non-root program (user=%user.name cur_uid=%user.uid parent=%proc.pname
     command=%proc.cmdline uid=%evt.arg.uid container_id=%container.id image=%container.image.repository)


### PR DESCRIPTION
- support for this check was added in sysdig and engine v3
- k8s and other container healthchecks, liveness, and readiness probes
  should be ignored by certain rules like "Non sudo setuid"

Signed-off-by: Anton Gilgur <agilgur5@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
5. Please add a release note!
6. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug
/kind rule-update

**Any specific area of the project related to this PR?**

/area rules
/area integrations

**What this PR does / why we need it**:

Container probes currently fire off alerts, and since they are frequent, fire off lots of noisy false positive alerts. The support introduced in sysdig to detect these alerts means they can now be ignored in the default rules.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #310 

**Special notes for your reviewer**:

/assign @mstemm 

`required_engine_version` has never been changed before, so I'm not sure what that process entails or how that should work (or if 3 is correct -- that's the one you said, so I just went with that).
You also mentioned in #310 that `Terminal shell in container` might also need an exception, but I've not gotten a false positive on that one before. I wrote the container probe check as a macro so it could easily be added anywhere though (might want to move the macro up higher or something then from where it currently is).

Not sure if my comment on the macro should include some other details or what

**Does this PR introduce a user-facing change?**:

Yes? I think so, since engine version update and rules update.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
- `required_engine_version` was updated
- A new `is_container_probe` macro was added
- The "Non sudo setuid" rule was updated to ignore container probes (via above macro)
```
