### PR TITLE
YAML linter configuration

### DIFF
--- a/.yamllint.conf
+++ b/.yamllint.conf
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  indentation: disable
+  document-start: disable
+  comments: disable
+  line-length: disable
+  new-line-at-end-of-file: disable


### PR DESCRIPTION

**What type of PR is this?**


/kind feature


**Any specific area of the project related to this PR?**

NONE

**What this PR does / why we need it**:

This PR simply adds a basic [yamllint](https://yamllint.readthedocs.io/en/stable/) configuration in order to also start the process of establish (and document) the coding style of the repo's YAML files (rules, falco config etc.).
The YAML lint config created extends the default one disabling some linting rules in order to minimize the mismatch from the current YAML style the repo contains.

Please notice this PR does NOT reformat any YAML file.

**Which issue(s) this PR fixes**:


Refs #619 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
