### PR TITLE
Allow regex chars rule names

### DIFF
--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -268,7 +268,7 @@ class FalcoTest(Test):
         triggered_rules = match.group(1)
 
         for rule, count in self.detect_counts.iteritems():
-            expected = '\s{}: (\d+)'.format(rule)
+            expected = '\s{}: (\d+)'.format(re.sub(r'([$\.*+?()[\]{}|^])', r'\\\1', rule))
             match = re.search(expected, triggered_rules)
 
             if match is None:

--- a/test/falco_tests.yaml
+++ b/test/falco_tests.yaml
@@ -456,13 +456,13 @@ trace_files: !mux
       - open_from_cat
     trace_file: trace_files/cat_write.scap
 
-  disabled_rules_using_regex:
+  disabled_rules_using_substring:
     detect: False
     rules_file:
       - rules/empty_rules.yaml
       - rules/single_rule.yaml
     disabled_rules:
-      - "open.*"
+      - "open_from"
     trace_file: trace_files/cat_write.scap
 
   disabled_rules_using_enabled_flag:

--- a/test/falco_tests.yaml
+++ b/test/falco_tests.yaml
@@ -86,6 +86,15 @@ trace_files: !mux
       - rules/rule_names_with_spaces.yaml
     trace_file: trace_files/cat_write.scap
 
+  rule_names_with_regex_chars:
+    detect: True
+    detect_level: WARNING
+    rules_file:
+      - rules/rule_names_with_regex_chars.yaml
+    detect_counts:
+      - 'Open From Cat ($\.*+?()[]{}|^)': 8
+    trace_file: trace_files/cat_write.scap
+
   multiple_rules_first_empty:
     detect: True
     detect_level: WARNING

--- a/test/rules/rule_names_with_regex_chars.yaml
+++ b/test/rules/rule_names_with_regex_chars.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2016-2018 Draios Inc dba Sysdig.
+#
+# This file is part of falco.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+- macro: is_cat
+  condition: proc.name=cat
+
+- rule: Open From Cat ($\.*+?()[]{}|^)
+  desc: A process named cat does an open
+  condition: evt.type=open and is_cat
+  output: "An open was seen (command=%proc.cmdline)"
+  priority: WARNING

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -206,17 +206,17 @@ void falco_engine::load_rules_file(const string &rules_filename, bool verbose, b
 	load_rules(rules_content, verbose, all_events, required_engine_version);
 }
 
-void falco_engine::enable_rule(const string &pattern, bool enabled, const string &ruleset)
+void falco_engine::enable_rule(const string &substring, bool enabled, const string &ruleset)
 {
 	uint16_t ruleset_id = find_ruleset_id(ruleset);
 
-	m_sinsp_rules->enable(pattern, enabled, ruleset_id);
-	m_k8s_audit_rules->enable(pattern, enabled, ruleset_id);
+	m_sinsp_rules->enable(substring, enabled, ruleset_id);
+	m_k8s_audit_rules->enable(substring, enabled, ruleset_id);
 }
 
-void falco_engine::enable_rule(const string &pattern, bool enabled)
+void falco_engine::enable_rule(const string &substring, bool enabled)
 {
-	enable_rule(pattern, enabled, m_default_ruleset);
+	enable_rule(substring, enabled, m_default_ruleset);
 }
 
 void falco_engine::enable_rule_by_tag(const set<string> &tags, bool enabled, const string &ruleset)

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -76,16 +76,16 @@ public:
 	void load_rules(const std::string &rules_content, bool verbose, bool all_events, uint64_t &required_engine_version);
 
 	//
-	// Enable/Disable any rules matching the provided pattern
-	// (regex). When provided, enable/disable these rules in the
+	// Enable/Disable any rules matching the provided substring.
+	// When provided, enable/disable these rules in the
 	// context of the provided ruleset. The ruleset (id) can later
 	// be passed as an argument to process_event(). This allows
 	// for different sets of rules being active at once.
 	//
-	void enable_rule(const std::string &pattern, bool enabled, const std::string &ruleset);
+	void enable_rule(const std::string &substring, bool enabled, const std::string &ruleset);
 
 	// Wrapper that assumes the default ruleset
-	void enable_rule(const std::string &pattern, bool enabled);
+	void enable_rule(const std::string &substring, bool enabled);
 
 	//
 	// Enable/Disable any rules with any of the provided tags (set, exact matches only)

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -77,6 +77,7 @@ public:
 
 	//
 	// Enable/Disable any rules matching the provided substring.
+	// If the substring is "", all rules are enabled/disabled.
 	// When provided, enable/disable these rules in the
 	// context of the provided ruleset. The ruleset (id) can later
 	// be passed as an argument to process_event(). This allows

--- a/userspace/engine/rules.cpp
+++ b/userspace/engine/rules.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 */
 
+
 #include "rules.h"
 #include "logger.h"
 
@@ -195,7 +196,20 @@ int falco_rules::enable_rule(lua_State *ls)
 	std::string rule = rulec;
 	bool enabled = (lua_tonumber(ls, -1) ? true : false);
 
-	rules->enable_rule(rule, enabled);
+	// Escape any regex special characters in the rule name
+	std::string sanitized = rule;
+
+	std::string escape_chars = R"($\.*+?()[]{}|^)";
+
+	size_t pos = sanitized.find_first_of(escape_chars);
+
+	while (pos != std::string::npos)
+	{
+		sanitized.insert(pos, "\\");
+		pos = sanitized.find_first_of(escape_chars, pos+2);
+	}
+
+	rules->enable_rule(sanitized, enabled);
 
 	return 0;
 }

--- a/userspace/engine/rules.cpp
+++ b/userspace/engine/rules.cpp
@@ -196,20 +196,7 @@ int falco_rules::enable_rule(lua_State *ls)
 	std::string rule = rulec;
 	bool enabled = (lua_tonumber(ls, -1) ? true : false);
 
-	// Escape any regex special characters in the rule name
-	std::string sanitized = rule;
-
-	std::string escape_chars = R"($\.*+?()[]{}|^)";
-
-	size_t pos = sanitized.find_first_of(escape_chars);
-
-	while (pos != std::string::npos)
-	{
-		sanitized.insert(pos, "\\");
-		pos = sanitized.find_first_of(escape_chars, pos+2);
-	}
-
-	rules->enable_rule(sanitized, enabled);
+	rules->enable_rule(rule, enabled);
 
 	return 0;
 }

--- a/userspace/engine/ruleset.cpp
+++ b/userspace/engine/ruleset.cpp
@@ -213,7 +213,7 @@ void falco_ruleset::enable(const string &substring, bool enabled, uint16_t rules
 	{
 		bool matches;
 
-		matches = (val.first.find(substring) != string::npos);
+		matches = (substring == "" || (val.first.find(substring) != string::npos));
 
 		if (matches)
 		{

--- a/userspace/engine/ruleset.cpp
+++ b/userspace/engine/ruleset.cpp
@@ -202,19 +202,8 @@ void falco_ruleset::add(string &name,
 	}
 }
 
-void falco_ruleset::enable(const string &pattern, bool enabled, uint16_t ruleset)
+void falco_ruleset::enable(const string &substring, bool enabled, uint16_t ruleset)
 {
-	regex re;
-	bool match_using_regex = true;
-
-	try {
-		re.assign(pattern);
-	}
-	catch (std::regex_error e)
-	{
-		match_using_regex = false;
-	}
-
 	while (m_rulesets.size() < (size_t) ruleset + 1)
 	{
 		m_rulesets.push_back(new ruleset_filters());
@@ -223,14 +212,9 @@ void falco_ruleset::enable(const string &pattern, bool enabled, uint16_t ruleset
 	for(const auto &val : m_filters)
 	{
 		bool matches;
-		if(match_using_regex)
-		{
-			matches = regex_match(val.first, re);
-		}
-		else
-		{
-			matches = (val.first.find(pattern) != string::npos);
-		}
+
+		matches = (val.first.find(substring) != string::npos);
+
 		if (matches)
 		{
 			if(enabled)

--- a/userspace/engine/ruleset.h
+++ b/userspace/engine/ruleset.h
@@ -24,7 +24,6 @@ limitations under the License.
 #include <vector>
 #include <list>
 #include <map>
-#include <regex>
 
 #include "sinsp.h"
 #include "filter.h"
@@ -48,9 +47,9 @@ public:
         // specifying unnecessarily large rulesets will result in
         // unnecessarily large vectors.
 
-	// Find those rules matching the provided pattern and set
+	// Find those rules matching the provided substring and set
 	// their enabled status to enabled.
-	void enable(const std::string &pattern, bool enabled, uint16_t ruleset = 0);
+	void enable(const std::string &substring, bool enabled, uint16_t ruleset = 0);
 
 	// Find those rules that have a tag in the set of tags and set
 	// their enabled status to enabled. Note that the enabled


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
5. Please add a release note!
6. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

> /area rules

> /area deployment

> /area integrations

> /area examples

**What this PR does / why we need it**:

Escape regex characters in rule names before passing them to the falco engine.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Escape regex characters in rule names before passing them to the falco engine.
```
