### PR TITLE
Fix shell_procs macro

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -111,7 +111,7 @@
   items: [add-shell, remove-shell]
 
 - macro: shell_procs
-  condition: (proc.name in (shell_binaries))
+  condition: proc.name in (shell_binaries)
 
 - list: coreutils_binaries
   items: [


### PR DESCRIPTION
Extra parentheses broke the Terminal check

Co-Authored-By: Michael Ducy <michael@ducy.org>
Signed-off-by: Spencer Krum <skrum@us.ibm.com>

**What type of PR is this?**

/kind bug
/kind rule-update


**Any specific area of the project related to this PR?**


/area rules


**What this PR does / why we need it**:

The rule was broken, this fixes it.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
The Terminal shell in container rule works again.
```
