### PR TITLE
Fix bugs when verifying macro/rule objects.

### DIFF
--- a/userspace/engine/lua/rule_loader.lua
+++ b/userspace/engine/lua/rule_loader.lua
@@ -196,7 +196,9 @@ function split_lines(rules_content)
       line = string.sub(rules_content, last_pos, pos-1)
       if line ~= "" then
 	 lines[#lines+1] = line
-	 if string.sub(line, 1, 1) == '-' then
+	 if string.len(line) >= 3 and string.sub(line, 1, 3) == "---" then
+	    -- Document marker, skip
+         elseif string.sub(line, 1, 1) == '-' then
 	    indices[#indices+1] = idx
 	 end
 
@@ -328,7 +330,7 @@ function load_rules(sinsp_lua_parser,
 	 end
 
 	 if state.macros_by_name[v['macro']] == nil then
-	    state.ordered_macro_names[#state.ordered_macro_names+1] = v['macro']
+	    state.ordered_macro_names[#state.ordered_macro_names+1] = {["idx"]=i, ["name"]=v['macro']}
 	 end
 
 	 for j, field in ipairs({'condition'}) do
@@ -450,7 +452,7 @@ function load_rules(sinsp_lua_parser,
 	       -- loaded in the order in which they first appeared,
 	       -- potentially across multiple files.
 	       if state.rules_by_name[v['rule']] == nil then
-		  state.ordered_rule_names[#state.ordered_rule_names+1] = v['rule']
+		  state.ordered_rule_names[#state.ordered_rule_names+1] = {["idx"]=i, ["name"]=v['rule']}
 	       end
 
 	       -- The output field might be a folded-style, which adds a
@@ -496,7 +498,10 @@ function load_rules(sinsp_lua_parser,
       state.lists[v['list']] = {["items"] = items, ["used"] = false}
    end
 
-   for i, name in ipairs(state.ordered_macro_names) do
+   for _, obj in ipairs(state.ordered_macro_names) do
+
+      local i = obj["idx"]
+      local name = obj["name"]
 
       local v = state.macros_by_name[name]
 
@@ -515,7 +520,10 @@ function load_rules(sinsp_lua_parser,
       state.macros[v['macro']] = {["ast"] = ast.filter.value, ["used"] = false}
    end
 
-   for i, name in ipairs(state.ordered_rule_names) do
+   for _, obj in ipairs(state.ordered_rule_names) do
+
+      local i = obj["idx"]
+      local name = obj["name"]
 
       local v = state.rules_by_name[name]
 


### PR DESCRIPTION




**What type of PR is this?**



/kind bug



**Any specific area of the project related to this PR?**



/area engine



**What this PR does / why we need it**:

Fix a couple of small bugs when verifying macro/rule objects:

1) Yaml can have document separators "---", and those were mistakenly
being considered array items.

2) When reading macros and rules and using array position to find the
right document offset, the overall object order should be
used (e.g. this is the 5th object from the file) and not the array
position (e.g. this is the 3rd rule from the file).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Fix small bugs when displaying context from rule validation/loading errors.
```
