### PR TITLE
Handle sinsp::next errors in the inspect loop

### DIFF
--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -257,8 +257,15 @@ uint64_t do_inspect(falco_engine *engine,
 	//
 	while(1)
 	{
-
-		rc = inspector->next(&ev);
+    try {
+      rc = inspector->next(&ev);
+    } catch(sinsp_exception& e) {
+      string err = "Error handling inspector event: ";
+      err.append(e.what());
+      err.append("\n");
+      falco_logger::log(LOG_ERR, err);
+      continue;
+    }
 
 		writer.handle();
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The problem was that when entering the event processing loop for sinsp events
sinsp calls the `sinsp_parser` that when doing the `process_event` call throws an exception like the one observed by OP in #683 .
While an error while parsing an event from sinsp is certainly representing a problem for the event itself it should not stop falco from operating its service.

This PR adds an error detection mechanism to allow falco to log when errors in handling the current event happen while calling `sinsp::next`, in that way the user
is informed with a log of type error.

This kind of behavior should be more common when dealing with non syscall events like container information coming from a webserver or a socket (like the CRI implementation) because
the service might not be able to respond correctly to a request or the parser can't parse the response.

**Which issue(s) this PR fixes**:

This is related to #683 - it doesn't actually fix the underlaying problem of not being able to parse huge json files but at least solves the problem of having falco crashing when that happens.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Instead of crashing, now Falco will report the error when an internal error occurs while handling an event to be inspected. The log line will be of type error and will contain the string `Error handling inspector event`
```
