### PR TITLE
fix: make sure that when deleting shell history the system call is taken into account

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2381,13 +2381,29 @@
     WARNING
   tags: [process, mitre_persistence]
 
-- rule: Delete Bash History
-  desc: Detect bash history deletion
+- rule: Delete or rename shell history
+  desc: Detect shell history deletion
   condition: >
-    ((spawned_process and proc.name in (shred, rm, mv) and proc.args contains "bash_history") or
-     (open_write and fd.name contains "bash_history" and evt.arg.flags contains "O_TRUNC"))
+    (modify and (
+      evt.arg.name contains "bash_history" or
+      evt.arg.name contains "zsh_history" or
+      evt.arg.name contains "fish_read_history" or
+      evt.arg.name endswith "fish_history" or
+      evt.arg.oldpath contains "bash_history" or
+      evt.arg.oldpath contains "zsh_history" or
+      evt.arg.oldpath contains "fish_read_history" or
+      evt.arg.oldpath endswith "fish_history" or
+      evt.arg.path contains "bash_history" or
+      evt.arg.path contains "zsh_history" or
+      evt.arg.path contains "fish_read_history" or
+      evt.arg.path endswith "fish_history")) or
+    (open_write and (
+      fd.name contains "bash_history" or
+      fd.name contains "zsh_history" or
+      fd.name contains "fish_read_history" or
+      fd.name endswith "fish_history") and evt.arg.flags contains "O_TRUNC")
   output: >
-    Bash history has been deleted (user=%user.name command=%proc.cmdline file=%fd.name %container.info)
+    Shell history had been deleted or renamed (user=%user.name type=%evt.type command=%proc.cmdline fd.name=%fd.name name=%evt.arg.name path=%evt.arg.path oldpath=%evt.arg.oldpath %container.info)
   priority:
     WARNING
   tag: [process, mitre_defense_evation]


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>

**What type of PR is this?**

/kind bug
/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

When deleting a shell history file we can't rely on the name of the command deleting it.
This PR uses the rmdir, unlink and unlinkat syscalls instead to reliably detect if an history file had been deleted.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
rules: Delete Bash History is renamed to Delete or rename shell history
rules, Delete or rename shell history: When deleting a shell history file now the syscalls are taken into account rather than just the commands deleting the files
rules, Delete or rename shell history: history deletion now supports fish and zsh in addition to bash
```
