### PR TITLE
fix(rules/Set Setuid or Setgid bit): use chmod syscalls instead of chmod command

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -72,6 +72,9 @@
 - macro: create_symlink
   condition: evt.type in (symlink, symlinkat) and evt.dir=<
 
+- macro: chmod
+  condition: evt.type in (chmod, fchmod, fchmodat)
+
 # File categories
 - macro: bin_dir
   condition: fd.directory in (/bin, /sbin, /usr/bin, /usr/sbin)
@@ -2416,10 +2419,10 @@
     When the setuid or setgid bits are set for an application,
     this means that the application will run with the privileges of the owning user or group respectively.
     Detect setuid or setgid bits set via chmod
-  condition: consider_all_chmods and spawned_process and proc.name = "chmod" and (proc.args contains "+s" or proc.args contains "4777")
+  condition: consider_all_chmods and chmod and (evt.arg.mode contains "S_ISUID" or evt.arg.mode contains "S_ISGID")
   output: >
-    Setuid or setgid bit is set via chmod (user=%user.name command=%proc.cmdline
-    container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
+    Setuid or setgid bit is set via chmod (fd=%evt.arg.fd filename=%evt.arg.filename mode=%evt.arg.mode user=%user.name
+    command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority:
     NOTICE
   tag: [process, mitre_persistence]

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -73,7 +73,7 @@
   condition: evt.type in (symlink, symlinkat) and evt.dir=<
 
 - macro: chmod
-  condition: evt.type in (chmod, fchmod, fchmodat)
+  condition: (evt.type in (chmod, fchmod, fchmodat) and evt.dir=<)
 
 # File categories
 - macro: bin_dir
@@ -2412,14 +2412,17 @@
   tag: [process, mitre_defense_evation]
 
 - macro: consider_all_chmods
-  condition: (never_true)
+  condition: (always_true)
+
+- list: user_known_chmod_applications
+  items: []
 
 - rule: Set Setuid or Setgid bit
   desc: >
     When the setuid or setgid bits are set for an application,
     this means that the application will run with the privileges of the owning user or group respectively.
     Detect setuid or setgid bits set via chmod
-  condition: consider_all_chmods and chmod and (evt.arg.mode contains "S_ISUID" or evt.arg.mode contains "S_ISGID")
+  condition: consider_all_chmods and chmod and (evt.arg.mode contains "S_ISUID" or evt.arg.mode contains "S_ISGID") and not proc.cmdline in (user_known_chmod_applications)
   output: >
     Setuid or setgid bit is set via chmod (fd=%evt.arg.fd filename=%evt.arg.filename mode=%evt.arg.mode user=%user.name
     command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>


**What type of PR is this?**

/kind bug

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules


**What this PR does / why we need it**:

The "Set Setuid or Setgid bit" rule is using a check on the invocation of the `chmod` command in order to check if a suid or sgid flag is applied to a file.
That method is ineffective because anyone using the raw syscall or glibc can bypass that.

For example:
```bash
#include <sys/stat.h>
#include <fcntl.h>

int main ()
{
  fchmodat(AT_FDCWD, "/tmp/yo", S_ISUID, 0);
}
```

This PR uses the newly added `fchmod, chmod, fchmodat` syscalls (to sysdig)
in order to avoid that.
**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Only works if sysdig PR https://github.com/draios/sysdig/pull/1472 is merged. It adds support to the chmod syscalls we are using here.
**Does this PR introduce a user-facing change?**:


```release-note
rule(Set Setuid or Setgid bit): syscalls are used to detect suid and sgid
```
