### PR TITLE
rules: strict checks on hidden files and repository files that are modified

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -908,12 +908,15 @@
 - macro: access_repositories
   condition: (fd.filename in (repository_files) or fd.directory in (repository_directories))
 
+- macro: modify_repositories
+  condition: (evt.arg.newpath pmatch (repository_directories))
+
 - rule: Update Package Repository
   desc: Detect package repositories get updated
   condition: >
-    open_write and access_repositories and not package_mgmt_procs
+    ((open_write and access_repositories) or (modify and modify_repositories)) and not package_mgmt_procs
   output: >
-    Repository files get updated (user=%user.name command=%proc.cmdline file=%fd.name container_id=%container.id image=%container.image.repository)
+    Repository files get updated (user=%user.name command=%proc.cmdline file=%fd.name newpath=%evt.arg.newpath container_id=%container.id image=%container.image.repository)
   priority:
     NOTICE
   tags: [filesystem, mitre_persistence]
@@ -2440,12 +2443,14 @@
 - rule: Create Hidden Files or Directories
   desc: Detect hidden files or directories created
   condition: >
-    ((mkdir and consider_hidden_file_creation and evt.arg.path contains "/.") or
-     (open_write and consider_hidden_file_creation and evt.arg.flags contains "O_CREAT" and
-      fd.name contains "/." and not fd.name pmatch (exclude_hidden_directories)))
+    (consider_hidden_file_creation and (
+      (modify and evt.arg.newpath contains "/.") or
+      (mkdir and evt.arg.path contains "/.") or
+      (open_write and evt.arg.flags contains "O_CREAT" and fd.name contains "/." and not fd.name pmatch (exclude_hidden_directories)))
+    )
   output: >
     Hidden file or directory created (user=%user.name command=%proc.cmdline
-    file=%fd.name container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
+    file=%fd.name newpath=%evt.arg.newpath container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority:
     NOTICE
   tag: [file, mitre_persistence]


### PR DESCRIPTION

Signed-off-by: Lorenzo Fontana <lo@linux.com>


**What type of PR is this?**

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

In "Create Hidden Files or Directories", when a directory or a file is created the rule is triggered but it should also trigger when a file or directory is moved to become and hidden one, this PR uses the `modify` macro to do that additional check.

In "Update Package Repository" when a directory or a file is updated in the sensitive packages folder the rule is triggered, however it was not triggered when a file is moved into those directories. This PR fixes that using the `modify` macro.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rules: "Create Hidden Files or Directories" and "Update Package Repository" now trigger also if the files are moved and not just if modified or created.
```
