### PR TITLE
Pass the build dir along when running tests

### DIFF
--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -34,13 +34,11 @@ class FalcoTest(Test):
         """
         Load the sysdig kernel module if not already loaded.
         """
-        build_type = "release"
-        if 'BUILD_TYPE' in os.environ:
-            build_type = os.environ['BUILD_TYPE'].lower()
-            build_type = "debug" if build_type == "debug" else "release"
+        build_dir = "/build"
+        if 'BUILD_DIR' in os.environ:
+            build_dir = os.environ['BUILD_DIR']
 
-        build_dir = os.path.join('/build', build_type)
-        self.falcodir = self.params.get('falcodir', '/', default=os.path.join(self.basedir, build_dir))
+        self.falcodir = self.params.get('falcodir', '/', default=build_dir)
 
         self.stdout_is = self.params.get('stdout_is', '*', default='')
         self.stderr_is = self.params.get('stderr_is', '*', default='')

--- a/test/run_regression_tests.sh
+++ b/test/run_regression_tests.sh
@@ -92,7 +92,7 @@ function run_tests() {
     for mult in $SCRIPTDIR/falco_traces.yaml $SCRIPTDIR/falco_tests.yaml $SCRIPTDIR/falco_tests_package.yaml $SCRIPTDIR/falco_k8s_audit_tests.yaml; do
 	CMD="avocado run --mux-yaml $mult --job-results-dir $SCRIPTDIR/job-results -- $SCRIPTDIR/falco_test.py"
 	echo "Running: $CMD"
-	$CMD
+	BUILD_DIR=${BUILD_DIR} $CMD
 	RC=$?
 	TEST_RC=$((TEST_RC+$RC))
 	if [ $RC -ne 0 ]; then


### PR DESCRIPTION
As of 0e1c436d14fb468dd1530115ed19e43faa0a8331, the build directory is
an argument to run_regression_tests.sh. However, the build directory in
falco_tests.yaml is currently hard-coded to /build, with the build
variant influencing the subdirectory.

Clean this up so the entire build directory passed to
run_regression_tests.sh is passed to avocado and used for the build
directory.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
5. Please add a release note!
6. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

> /area rules

> /area deployment

> /area integrations

> /area examples

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Make it easier to run regression tests without necessarily using the falco-tester docker image.
```
