### PR TITLE
fix(permissions): Restrict to RO access to /dev on underlying host

### DIFF
--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
@@ -33,6 +33,7 @@ spec:
               name: containerd-socket
             - mountPath: /host/dev
               name: dev-fs
+              readOnly: true
             - mountPath: /host/proc
               name: proc-fs
               readOnly: true

--- a/integrations/k8s-using-daemonset/k8s-without-rbac/falco-daemonset.yaml
+++ b/integrations/k8s-using-daemonset/k8s-without-rbac/falco-daemonset.yaml
@@ -26,6 +26,7 @@ spec:
               name: containerd-socket
             - mountPath: /host/dev
               name: dev-fs
+              readOnly: true
             - mountPath: /host/proc
               name: proc-fs
               readOnly: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
5. Please add a release note!
6. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind bug
/kind design

**Any specific area of the project related to this PR?**
/area deployment
/area integrations

**What this PR does / why we need it**:
This PR improves the security posture of falco container deployment by only allowing readOnly access to `/dev` on underlying host. Following the [least-privilage access principle](https://en.wikipedia.org/wiki/Principle_of_least_privilege) is a nice to have, especially for a security tool itself.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
I tested this change locally on minikube. Falco container was able to correctly load kernel modules and start cleanly. I also tested the detection by falco when a privileged container is spawned.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
