### PR TITLE
Automatic area/* labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
 2. Please label this pull request according to what type of issue you are addressing.
-5. Please add a release note!
-6. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
+3. . Please add a release note!
+4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
 -->
 
 **What type of PR is this?**
@@ -30,19 +30,29 @@
 
 > /kind rule-create
 
+<!--
+Please remove the leading whitespace before the `/kind <>` you uncommented.
+-->
+
 **Any specific area of the project related to this PR?**
 
 > Uncomment one (or more) `/area <>` lines:
 
+> /area build
+
 > /area engine
+
+> /area examples
 
 > /area rules
 
-> /area deployment
-
 > /area integrations
 
-> /area examples
+> /area tests
+
+<!--
+Please remove the leading whitespace before the `/area <>` you uncommented.
+-->
 
 **What this PR does / why we need it**:
 
@@ -63,7 +73,8 @@ Fixes #
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:
-Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
+Enter your extended release note in the block below.
+If the PR requires additional action from users switching to the new release, prepend the string "action required:".
 For example, `action required: change the API interface of the rule engine`.
 -->
 

--- a/docker/OWNERS
+++ b/docker/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/integration

--- a/examples/OWNERS
+++ b/examples/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/examples

--- a/integrations/OWNERS
+++ b/integrations/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/integration

--- a/rules/OWNERS
+++ b/rules/OWNERS
@@ -7,4 +7,6 @@ reviewers:
   - mfdii
   - kaizhe
   - mstemm
+labels:
+  - area/rules
 

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/tests

--- a/tests/OWNERS
+++ b/tests/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/tests

--- a/userspace/engine/OWNERS
+++ b/userspace/engine/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/engine


### PR DESCRIPTION


**What type of PR is this?**



/kind documentation



**Any specific area of the project related to this PR?**

NONE

**What this PR does / why we need it**:

Specifies an OWNER file for every (almost) every sub-section we have.
The OWNERs file only contain the `labels` field (in most cases): this should make Prow automatically assign the labels specified when the files in the directory of the OWNER file have been modified by a PR.

Furthermore this PR improves the PR template accordingly.

**Which issue(s) this PR fixes**:



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
