### PR TITLE
Make lua state access thread-safe

### DIFF
--- a/userspace/engine/falco_common.h
+++ b/userspace/engine/falco_common.h
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include <string>
 #include <exception>
+#include <mutex>
 
 extern "C" {
 #include "lua.h"
@@ -94,11 +95,10 @@ public:
 protected:
 	lua_State *m_ls;
 
+	std::mutex m_ls_semaphore;
+
 	sinsp *m_inspector;
 
 private:
 	void add_lua_path(std::string &path);
 };
-
-
-

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -287,8 +287,8 @@ unique_ptr<falco_engine::rule_result> falco_engine::process_sinsp_event(sinsp_ev
 
 	unique_ptr<struct rule_result> res(new rule_result());
 
+	std::lock_guard<std::mutex> guard(m_ls_semaphore);
 	lua_getglobal(m_ls, lua_on_event.c_str());
-
 	if(lua_isfunction(m_ls, -1))
 	{
 		lua_pushnumber(m_ls, ev->get_check_id());
@@ -335,8 +335,8 @@ unique_ptr<falco_engine::rule_result> falco_engine::process_k8s_audit_event(json
 
 	unique_ptr<struct rule_result> res(new rule_result());
 
+	std::lock_guard<std::mutex> guard(m_ls_semaphore);
 	lua_getglobal(m_ls, lua_on_event.c_str());
-
 	if(lua_isfunction(m_ls, -1))
 	{
 		lua_pushnumber(m_ls, ev->get_check_id());


### PR DESCRIPTION

**What type of PR is this?**

/kind bug


**Any specific area of the project related to this PR?**

/area engine



**What this PR does / why we need it**:

We need that the concurrent access to Lua state is thread-safe.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix: make lua state access thread-safe
```
