### PR TITLE
documenting the keepalive field of the gPRC outputs API

### DIFF
--- a/userspace/falco/output.proto
+++ b/userspace/falco/output.proto
@@ -16,6 +16,9 @@ service service {
 // The `request` message is the logical representation of the request model.
 // It is the input of the `subscribe` service.
 // It is used to configure the kind of subscription to the gRPC streaming server.
+//
+// By default the request asks to the server to only receive the accumulated events.
+// In case you want to wait indefinitely for new events to come set the keepalive option to true.
 message request {
   bool keepalive = 1;
   // string duration = 2; // TODO(leodido, fntlnz): not handled yet but keeping for reference.


### PR DESCRIPTION


**What type of PR is this?**

/kind failing-test


**Any specific area of the project related to this PR?**

NONE



**What this PR does / why we need it**:

Explains the `keepalive` option of the gRPC Outputs API's `request`s.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:



```release-note
NONE
```
