### PR TITLE
Specify namespace compat w/ gcc 5

### DIFF
--- a/userspace/falco/grpc_server.cpp
+++ b/userspace/falco/grpc_server.cpp
@@ -36,8 +36,13 @@ limitations under the License.
 		ctx.start(this);                                                   \
 	}
 
+namespace falco
+{
+namespace grpc
+{
+
 template<>
-void falco::grpc::request_stream_context<falco::output::request, falco::output::response>::start(server* srv)
+void request_stream_context<falco::output::request, falco::output::response>::start(server* srv)
 {
 	m_state = request_context_base::REQUEST;
 	m_srv_ctx.reset(new ::grpc::ServerContext);
@@ -50,7 +55,7 @@ void falco::grpc::request_stream_context<falco::output::request, falco::output::
 }
 
 template<>
-void falco::grpc::request_stream_context<falco::output::request, falco::output::response>::process(server* srv)
+void request_stream_context<falco::output::request, falco::output::response>::process(server* srv)
 {
 	// When it is the 1st process call
 	if(m_state == request_context_base::REQUEST)
@@ -79,7 +84,7 @@ void falco::grpc::request_stream_context<falco::output::request, falco::output::
 }
 
 template<>
-void falco::grpc::request_stream_context<falco::output::request, falco::output::response>::end(server* srv, bool errored)
+void request_stream_context<falco::output::request, falco::output::response>::end(server* srv, bool errored)
 {
 	if(m_stream_ctx)
 	{
@@ -92,6 +97,8 @@ void falco::grpc::request_stream_context<falco::output::request, falco::output::
 
 	start(srv);
 }
+} // namespace grpc
+} // namespace falco
 
 void falco::grpc::server::thread_process(int thread_index)
 {


### PR DESCRIPTION
I wasn't able to compile the dev branch with gcc 5.4 (e.g. not using the
builder), getting this error:

```
.../falco/userspace/falco/grpc_server.cpp:40:109: error: specialization of ‘template<class Request, class Response> void falco::grpc::request_stream_context<Request, Response>::start(falco::grpc::server*)’ in different namespace [-fpermissive]
 void falco::grpc::request_stream_context<falco::output::request, falco::output::response>::start(server* srv)
                                                                                                             ^
In file included from .../falco/userspace/falco/grpc_server.cpp:26:0:
.../falco/userspace/falco/grpc_server.h:102:7: error:   from definition of ‘template<class Request, class Response> void falco::grpc::request_stream_context<Request, Response>::start(falco::grpc::server*)’ [-fpermissive]
  void start(server* srv);
```

It looks like gcc 5.4 doesn't handle a declaration with namespace blocks
but a definition with namespaces in the
function. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480 has more
detail.

A workaround is to add `namespace falco {` and `namespace grpc {` around
the declarations.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

 /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area examples

> /area rules

> /area integrations

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fix compilation on gcc 5.4 (and as early as 4.8, most likely)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #862 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Fix compilation on gcc 5.4 by working around gcc bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
```
