### PR TITLE
wip: Ignore errors arising from docker extracting images

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -445,7 +445,8 @@
     (fd.filename in (shell_config_filenames) or
      fd.name in (shell_config_files) or
      fd.directory in (shell_config_directories)) and
-    not proc.name in (shell_binaries)
+    not proc.name in (shell_binaries) and
+    not exe_running_docker_untar
   output: >
     a shell configuration file has been modified (user=%user.name command=%proc.cmdline file=%fd.name container_id=%container.id image=%container.image.repository)
   priority:
@@ -848,6 +849,9 @@
 - macro: exe_running_docker_save
   condition: (proc.cmdline startswith "exe /var/lib/docker" and proc.pname in (dockerd, docker))
 
+- macro: exe_running_docker_untar
+  condition: (proc.exeline startswith "docker-untar /var/lib/docker" and proc.pname in (dockerd, docker))
+
 # Ideally we'd have a length check here as well but sysdig
 # filterchecks don't have operators like len()
 - macro: sed_temporary_file
@@ -914,7 +918,7 @@
 - rule: Update Package Repository
   desc: Detect package repositories get updated
   condition: >
-    ((open_write and access_repositories) or (modify and modify_repositories)) and not package_mgmt_procs
+    ((open_write and access_repositories) or (modify and modify_repositories)) and not package_mgmt_procs and not exe_running_docker_untar
   output: >
     Repository files get updated (user=%user.name command=%proc.cmdline file=%fd.name newpath=%evt.arg.newpath container_id=%container.id image=%container.image.repository)
   priority:
@@ -2439,7 +2443,7 @@
     When the setuid or setgid bits are set for an application,
     this means that the application will run with the privileges of the owning user or group respectively.
     Detect setuid or setgid bits set via chmod
-  condition: consider_all_chmods and chmod and (evt.arg.mode contains "S_ISUID" or evt.arg.mode contains "S_ISGID") and not proc.cmdline in (user_known_chmod_applications)
+  condition: consider_all_chmods and chmod and (evt.arg.mode contains "S_ISUID" or evt.arg.mode contains "S_ISGID") and not proc.cmdline in (user_known_chmod_applications) and not exe_running_docker_untar
   output: >
     Setuid or setgid bit is set via chmod (fd=%evt.arg.fd filename=%evt.arg.filename mode=%evt.arg.mode user=%user.name
     command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)


### PR DESCRIPTION
I'm marking this as wip because I'm not 100% happy with the changes, although they seem to resolve the linked issue. Any comments are appreciated

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind rule-update

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

 This commit adds an extra condition that checks if the process being
 executed is docker-untar, which is used when Docker is extracting new
 images.

**Which issue(s) this PR fixes**:

Fixes #882 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

Tested in AWS against the ECS-optimized AMI `ami-0da6ab8acebc7f9db` in `sa-east-1`

Falco installed using

```
rpm --import https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public
curl -s -o /etc/yum.repos.d/draios.repo https://s3.amazonaws.com/download.draios.com/stable/rpm/draios.repo
yum -y install kernel-devel-$(uname -r)
yum -y install falco
```

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
ignore errors from `docker pull` in Amazon Linux 2
```