### PR TITLE
Use falcoctl 0.0.4+ tests for space/dash psp names

### DIFF
--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -43,7 +43,7 @@ class FalcoTest(Test):
         self.falcodir = self.params.get('falcodir', '/', default=build_dir)
 
         self.psp_conv_path = os.path.join(build_dir, "falcoctl")
-        self.psp_conv_url = "https://github.com/falcosecurity/falcoctl/releases/download/v0.0.3/falcoctl-0.0.3-linux-amd64"
+        self.psp_conv_url = "https://github.com/falcosecurity/falcoctl/releases/download/v0.0.4/falcoctl-0.0.4-linux-amd64"
 
         self.stdout_is = self.params.get('stdout_is', '*', default='')
         self.stderr_is = self.params.get('stderr_is', '*', default='')

--- a/test/falco_tests_psp.yaml
+++ b/test/falco_tests_psp.yaml
@@ -644,3 +644,23 @@ trace_files: !mux
     conf_file: confs/psp.yaml
     psp_file: psps/allowed_proc_mount_types.yaml
     trace_file: trace_files/psp/proc_mount_type_default.json
+
+  psp_name_with_dashes:
+    detect: True
+    detect_level: WARNING
+    detect_counts:
+      - "PSP no_privileged Violation (privileged) System Activity": 1
+    rules_file: []
+    conf_file: confs/psp.yaml
+    psp_file: psps/privileged_name_with_dashes.yaml
+    trace_file: trace_files/psp/privileged.scap
+
+  psp_name_with_spaces:
+    detect: True
+    detect_level: WARNING
+    detect_counts:
+      - "PSP no_privileged Violation (privileged) System Activity": 1
+    rules_file: []
+    conf_file: confs/psp.yaml
+    psp_file: psps/privileged_name_with_spaces.yaml
+    trace_file: trace_files/psp/privileged.scap

--- a/test/psps/privileged_name_with_dashes.yaml
+++ b/test/psps/privileged_name_with_dashes.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    falco-rules-psp-images: "[nginx]"
+  name: no-privileged
+spec:
+  privileged: false

--- a/test/psps/privileged_name_with_spaces.yaml
+++ b/test/psps/privileged_name_with_spaces.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    falco-rules-psp-images: "[nginx]"
+  name: no privileged
+spec:
+  privileged: false


### PR DESCRIPTION
Use falcoctl, which properly handles psp names containing
spaces/dashes. Also add tests that verify that the resulting rules are
valid.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area examples

> /area rules

> /area integrations

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Add tests for psp conversions with names containing spaces/dashes.
```
