### PR TITLE
fix the image name and tag for the linuxkit Dockerfile

### DIFF
--- a/docker/kernel/linuxkit/Dockerfile
+++ b/docker/kernel/linuxkit/Dockerfile
@@ -3,7 +3,7 @@ ARG KERNEL_VERSION=4.9.184
 ARG FALCO_VERSION=0.18.0
 
 FROM linuxkit/kernel:${KERNEL_VERSION} AS ksrc
-FROM falcosecurity/falco-minimal:${FALCO_VERSION} as falco
+FROM falcosecurity/falco:${FALCO_VERSION}-minimal as falco
 FROM alpine:${ALPINE_VERSION} AS probe-build
 LABEL maintainer="opensource@sysdig.com"
 ARG KERNEL_VERSION=4.9.184


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:
fixes the image name and tag for the linuxkit Dockerfile

```release-note
fix(docker/kernel/linuxkit): correct FROM for falco minimal image
```
