### PR TITLE
Added rule to detect docker client in container

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2599,3 +2599,9 @@
 # there if you want to enable them by adding to
 # falco_rules.local.yaml.
 
+- rule: The docker client is executed in a container
+  desc: Detect a k8s client tool executed inside a container
+  condition: spawned_process and container and proc.name in (k8s_client_binaries)
+  output: "Docker or kubernetes client executed in container (user=%user.name %container.info parent=%proc.pname cmdline=%proc.cmdline)"
+  priority: WARNING
+  tags: [container, mitre_execution]

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2595,13 +2595,16 @@
   priority: CRITICAL
   tags: [process, mitre_execution]
 
-# Application rules have moved to application_rules.yaml. Please look
-# there if you want to enable them by adding to
-# falco_rules.local.yaml.
-
+- list: k8s_client_binaries
+  items: [docker, kubectl, crictl]
+  
 - rule: The docker client is executed in a container
   desc: Detect a k8s client tool executed inside a container
   condition: spawned_process and container and proc.name in (k8s_client_binaries)
   output: "Docker or kubernetes client executed in container (user=%user.name %container.info parent=%proc.pname cmdline=%proc.cmdline)"
   priority: WARNING
   tags: [container, mitre_execution]
+  
+# Application rules have moved to application_rules.yaml. Please look
+# there if you want to enable them by adding to
+# falco_rules.local.yaml.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind rule-create

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

The motivation of this new rule is to detect suspicious activity like seen in the Graboid threat (more details here: https://unit42.paloaltonetworks.com/graboid-first-ever-cryptojacking-worm-found-in-images-on-docker-hub/). 

There are rules for detection of miners, but not the scenario where the container is used to attack other vulnerable hosts via a docker client. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
The priority is set to WARNING, but I have doubts if it should be other. I don't have the experience enough to decide this part of the rule.

**Does this PR introduce a user-facing change?**:
NONE

```release-note
A new rule is added to detect the execution of the docker client in a container and logs it with WARNING priority. 
```
