### PR TITLE
Always catch json type errors when extracting

### DIFF
--- a/userspace/engine/json_evt.cpp
+++ b/userspace/engine/json_evt.cpp
@@ -324,6 +324,10 @@ bool json_event_filter_check::def_extract(const nlohmann::json &root,
 	{
 		return false;
 	}
+	catch(json::type_error &e)
+	{
+		return false;
+	}
 
 	return true;
 }
@@ -704,6 +708,10 @@ bool json_event_filter_check::extract_values(json_event *jevt)
 	{
 		return false;
 	}
+	catch(json::type_error &e)
+	{
+		return false;
+	}
 
 	return true;
 }
@@ -817,6 +825,10 @@ bool jevt_filter_check::extract_values(json_event *jevt)
 		{
 			return false;
 		}
+		catch(json::type_error &e)
+		{
+			return false;
+		}
 	}
 	else
 	{
@@ -881,6 +893,10 @@ bool k8s_audit_filter_check::extract_images(const json &j,
 	{
 		return false;
 	}
+	catch(json::type_error &e)
+	{
+		return false;
+	}
 
 	return true;
 }
@@ -897,6 +913,10 @@ bool k8s_audit_filter_check::extract_query_param(const nlohmann::json &j,
 		uri = j.at(request_uri_ptr);
 	}
 	catch(json::out_of_range &e)
+	{
+		return false;
+	}
+	catch(json::type_error &e)
 	{
 		return false;
 	}
@@ -953,6 +973,10 @@ bool k8s_audit_filter_check::extract_rule_attrs(const json &j,
 	{
 		return false;
 	}
+	catch(json::type_error &e)
+	{
+		return false;
+	}
 
 	return true;
 }
@@ -996,6 +1020,10 @@ bool k8s_audit_filter_check::check_volumes_hostpath(const json &j,
 	{
 		return false;
 	}
+	catch(json::type_error &e)
+	{
+		return false;
+	}
 
 	jchk.add_extracted_value(string("false"));
 
@@ -1023,6 +1051,10 @@ bool k8s_audit_filter_check::extract_volume_types(const json &j,
 		}
 	}
 	catch(json::out_of_range &e)
+	{
+		return false;
+	}
+	catch(json::type_error &e)
 	{
 		return false;
 	}
@@ -1062,6 +1094,10 @@ bool k8s_audit_filter_check::extract_host_port(const json &j,
 		}
 	}
 	catch(json::out_of_range &e)
+	{
+		return false;
+	}
+	catch(json::type_error &e)
 	{
 		return false;
 	}
@@ -1113,6 +1149,10 @@ bool k8s_audit_filter_check::extract_effective_run_as(const json &j,
 	{
 		return false;
 	}
+	catch(json::type_error &e)
+	{
+		return false;
+	}
 
 	return true;
 }
@@ -1146,6 +1186,10 @@ bool k8s_audit_filter_check::extract_any_privileged(const json &j,
 			{
 				// No-op
 			}
+			catch(json::type_error &e)
+			{
+				return false;
+			}
 
 			if(privileged)
 			{
@@ -1155,6 +1199,10 @@ bool k8s_audit_filter_check::extract_any_privileged(const json &j,
 		}
 	}
 	catch(json::out_of_range &e)
+	{
+		return false;
+	}
+	catch(json::type_error &e)
 	{
 		return false;
 	}


### PR DESCRIPTION
In all extraction functions, always catch json type errors alongside
json out of range errors. Both cases result in not extracting any value
from the event.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind flaky-test

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area examples

> /area rules

> /area integrations

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Prevent throwing json type error c++ exceptions outside of the falco engine when procesing k8s audit events.
```
