### PR TITLE
update: cleanup the gRPC dependency and use the url from the main project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ services:
     - docker
 before_install:
     - sudo apt-get update
-    - sudo apt install wget -y
 install:
     - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
     - sudo apt-get install rpm linux-headers-$(uname -r) libelf-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ services:
     - docker
 before_install:
     - sudo apt-get update
+    - sudo apt install wget -y
 install:
     - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
     - sudo apt-get install rpm linux-headers-$(uname -r) libelf-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ else()
                 CONFIGURE_COMMAND ./configure --disable-maintainer-mode --enable-all-static --disable-dependency-tracking
                 BUILD_COMMAND ${CMD_MAKE} LDFLAGS=-all-static
                 BUILD_IN_SOURCE 1
-		PATCH_COMMAND curl -L https://github.com/stedolan/jq/commit/8eb1367ca44e772963e704a700ef72ae2e12babd.patch | patch
+                PATCH_COMMAND curl -L https://github.com/stedolan/jq/commit/8eb1367ca44e772963e704a700ef72ae2e12babd.patch | patch
                 INSTALL_COMMAND "")
 endif()
 
@@ -626,7 +626,7 @@ endif()
 		BUILD_BYPRODUCTS ${GRPC_LIB} ${GRPCPP_LIB}
 		# TODO s390x support
 		# TODO what if using system zlib
-		PATCH_COMMAND rm -rf third_party/zlib && ln -s ${ZLIB_SRC} third_party/zlib && wget https://download.sysdig.com/dependencies/grpc-1.8.1-Makefile.patch && patch < grpc-1.8.1-Makefile.patch
+		PATCH_COMMAND rm -rf third_party/zlib && ln -s ${ZLIB_SRC} third_party/zlib && curl -L https://download.sysdig.com/dependencies/grpc-1.8.1-Makefile.patch | patch
 		INSTALL_COMMAND "")
 	endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,45 +579,56 @@ else()
 		INSTALL_COMMAND make install)
 endif()
 
-option(USE_BUNDLED_GRPC "Enable building of the bundled grpc" ${USE_BUNDLED_DEPS})
-if(NOT USE_BUNDLED_GRPC)
-	find_path(GRPC_INCLUDE grpc++/impl/codegen/rpc_method.h)
-	find_library(GRPC_LIB NAMES libgrpc_unsecure.a)
-	find_library(GRPCPP_LIB NAMES libgrpc++_unsecure.a)
-	if(GRPC_INCLUDE AND GRPC_LIB AND GRPCPP_LIB)
-		message(STATUS "Found grpc: include: ${GRPC_INCLUDE}, C lib: ${GRPC_LIB}, C++ lib: ${GRPC_PP_LIB}")
+	option(USE_BUNDLED_GRPC "Enable building of the bundled grpc" ${USE_BUNDLED_DEPS})
+	if(NOT USE_BUNDLED_GRPC)
+		find_path(GRPCXX_INCLUDE NAMES grpc++/grpc++.h)
+		if(GRPCXX_INCLUDE)
+			set(GRPC_INCLUDE ${GRPCXX_INCLUDE})
+		else()
+			find_path(GRPCPP_INCLUDE NAMES grpcpp/grpcpp.h)
+			set(GRPC_INCLUDE ${GRPCPP_INCLUDE})
+			add_definitions(-DGRPC_INCLUDE_IS_GRPCPP=1)
+		endif()
+		find_library(GRPC_LIB NAMES grpc_unsecure)
+		find_library(GRPCPP_LIB NAMES grpc++_unsecure)
+		if(GRPC_INCLUDE AND GRPC_LIB AND GRPCPP_LIB)
+			message(STATUS "Found grpc: include: ${GRPC_INCLUDE}, C lib: ${GRPC_LIB}, C++ lib: ${GRPCPP_LIB}")
+		else()
+			message(FATAL_ERROR "Couldn't find system grpc")
+		endif()
+		find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin)
+		if(NOT GRPC_CPP_PLUGIN)
+			message(FATAL_ERROR "System grpc_cpp_plugin not found")
+		endif()
 	else()
-		message(FATAL_ERROR "Couldn't find system grpc")
-	endif()
-	find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin)
-	if(NOT GRPC_CPP_PLUGIN)
-		message(FATAL_ERROR "System grpc_cpp_plugin not found")
-	endif()
-else()
-	set(GRPC_SRC "${PROJECT_BINARY_DIR}/grpc-prefix/src/grpc")
-	message(STATUS "Using bundled grpc in '${GRPC_SRC}'")
-	set(GRPC_INCLUDE "${GRPC_SRC}/include")
-	set(GRPC_LIB "${GRPC_SRC}/libs/opt/libgrpc.a")
-	set(GRPCPP_LIB "${GRPC_SRC}/libs/opt/libgrpc++.a")
-	set(GRPC_CPP_PLUGIN "${GRPC_SRC}/bins/opt/grpc_cpp_plugin")
+		find_package(PkgConfig)
+		if(NOT PKG_CONFIG_FOUND)
+			message(FATAL_ERROR "pkg-config binary not found")
+		endif()
+		message(STATUS "Found pkg-config executable: ${PKG_CONFIG_EXECUTABLE}")
+		set(GRPC_SRC "${PROJECT_BINARY_DIR}/grpc-prefix/src/grpc")
+		message(STATUS "Using bundled grpc in '${GRPC_SRC}'")
+		set(GRPC_INCLUDE "${GRPC_SRC}/include")
+		set(GRPC_LIB "${GRPC_SRC}/libs/opt/libgrpc.a")
+		set(GRPCPP_LIB "${GRPC_SRC}/libs/opt/libgrpc++.a")
+		set(GRPC_CPP_PLUGIN "${GRPC_SRC}/bins/opt/grpc_cpp_plugin")
 
-	get_filename_component(PROTOC_DIR ${PROTOC} DIRECTORY)
+		get_filename_component(PROTOC_DIR ${PROTOC} PATH)
 
-	ExternalProject_Add(grpc
-		DEPENDS protobuf zlib c-ares
-		URL "https://s3.amazonaws.com/download.draios.com/dependencies/grpc-1.8.1.tar.gz"
+		ExternalProject_Add(grpc
+		DEPENDS protobuf zlib c-ares openssl
+		URL "https://github.com/grpc/grpc/archive/v1.8.1.tar.gz"
 		URL_MD5 "2fc42c182a0ed1b48ad77397f76bb3bc"
 		CONFIGURE_COMMAND ""
 		# TODO what if using system openssl, protobuf or cares?
-		BUILD_COMMAND sh -c "CFLAGS=-Wno-implicit-fallthrough CXXFLAGS=\"-Wno-ignored-qualifiers -Wno-stringop-truncation\" HAS_SYSTEM_ZLIB=false LDFLAGS=-static PATH=${PROTOC_DIR}:$ENV{PATH} PKG_CONFIG_PATH=${OPENSSL_BUNDLE_DIR}:${PROTOBUF_SRC}:${CARES_SRC} make grpc_cpp_plugin static_cxx static_c"
+		BUILD_COMMAND CFLAGS=-Wno-implicit-fallthrough HAS_SYSTEM_ZLIB=false LDFLAGS=-static PATH=${PROTOC_DIR}:$ENV{PATH} PKG_CONFIG_PATH=${OPENSSL_BUNDLE_DIR}:${PROTOBUF_SRC}:${CARES_SRC} PKG_CONFIG=${PKG_CONFIG_EXECUTABLE} make grpc_cpp_plugin static_cxx static_c
 		BUILD_IN_SOURCE 1
 		BUILD_BYPRODUCTS ${GRPC_LIB} ${GRPCPP_LIB}
 		# TODO s390x support
 		# TODO what if using system zlib
-		PATCH_COMMAND rm -rf third_party/zlib && ln -s ${ZLIB_SRC} third_party/zlib && curl -L https://download.sysdig.com/dependencies/grpc-1.1.4-Makefile.patch | patch
+		PATCH_COMMAND rm -rf third_party/zlib && ln -s ${ZLIB_SRC} third_party/zlib && wget https://download.sysdig.com/dependencies/grpc-1.8.1-Makefile.patch && patch < grpc-1.8.1-Makefile.patch
 		INSTALL_COMMAND "")
-endif()
-
+	endif()
 
 install(FILES falco.yaml
 	DESTINATION "${FALCO_ETC_DIR}")


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>


**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:
/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**


/area build

**What this PR does / why we need it**:

I noticed that Falco wasn't compiling on some machines because gRPC was not being handled righty by CMake so I'm sending this with the needed changes.

Also I did some cleanup and changed the download url to be the one of the main project, checksums are matching.

This is also preparation work for https://github.com/falcosecurity/falco/issues/921 since we will need to update gRPC and this was needed to be prepared for that.



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
