### PR TITLE
wip: build: update gRPC to 1.25.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -568,8 +568,8 @@ else()
 	set(PROTOBUF_LIB "${PROTOBUF_SRC}/target/lib/libprotobuf.a")
 	ExternalProject_Add(protobuf
 		DEPENDS openssl zlib
-		URL "https://github.com/google/protobuf/releases/download/v3.5.0/protobuf-cpp-3.5.0.tar.gz"
-		URL_MD5 "e4ba8284a407712168593e79e6555eb2"
+		URL "https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/protobuf-cpp-3.8.0.tar.gz"
+		URL_MD5 "9054bb5571905a28b3ae787d1d6cf8de"
 		# TODO what if using system zlib?
 		CONFIGURE_COMMAND /usr/bin/env CPPFLAGS=-I${ZLIB_INCLUDE} LDFLAGS=-L${ZLIB_SRC} ./configure --with-zlib --prefix=${PROTOBUF_SRC}/target
 		BUILD_COMMAND ${CMD_MAKE}
@@ -617,8 +617,8 @@ endif()
 
 		ExternalProject_Add(grpc
 		DEPENDS protobuf zlib c-ares openssl
-		URL "https://github.com/grpc/grpc/archive/v1.8.1.tar.gz"
-		URL_MD5 "2fc42c182a0ed1b48ad77397f76bb3bc"
+		URL "https://github.com/grpc/grpc/archive/v1.25.0.tar.gz"
+		URL_MD5 "3a875f7b3f0e3bdd3a603500bcef3d41"
 		CONFIGURE_COMMAND ""
 		# TODO what if using system openssl, protobuf or cares?
 		BUILD_COMMAND CFLAGS=-Wno-implicit-fallthrough HAS_SYSTEM_ZLIB=false LDFLAGS=-static PATH=${PROTOC_DIR}:$ENV{PATH} PKG_CONFIG_PATH=${OPENSSL_BUNDLE_DIR}:${PROTOBUF_SRC}:${CARES_SRC} PKG_CONFIG=${PKG_CONFIG_EXECUTABLE} make grpc_cpp_plugin static_cxx static_c
@@ -626,7 +626,7 @@ endif()
 		BUILD_BYPRODUCTS ${GRPC_LIB} ${GRPCPP_LIB}
 		# TODO s390x support
 		# TODO what if using system zlib
-		PATCH_COMMAND rm -rf third_party/zlib && ln -s ${ZLIB_SRC} third_party/zlib && curl -L https://download.sysdig.com/dependencies/grpc-1.8.1-Makefile.patch | patch
+		PATCH_COMMAND rm -rf third_party/zlib && ln -s ${ZLIB_SRC} third_party/zlib && patch -p1 < ${PROJECT_SOURCE_DIR}/cmake/patch/grpc-1.25.0-Makefile.patch
 		INSTALL_COMMAND "")
 	endif()
 

--- a/cmake/patch/grpc-1.25.0-Makefile.patch
+++ b/cmake/patch/grpc-1.25.0-Makefile.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index dd4ced8112..d6abccda82 100644
+--- a/Makefile
++++ b/Makefile
+@@ -839,6 +839,7 @@ ifneq ($(LDFLAGS_PROTOBUF_PKG_CONFIG),)
+ LDFLAGS_PROTOBUF_PKG_CONFIG += $(shell $(PKG_CONFIG) --libs-only-L protobuf | sed s/L/Wl,-rpath,/)
+ endif
+ endif
++LDFLAGS := $(LDFLAGS_PROTOBUF_PKG_CONFIG) $(LDFLAGS)
+ else
+ PC_LIBS_GRPCXX = -lprotobuf
+ endif

--- a/cmake/patch/grpc-1.25.0-Makefile.patch
+++ b/cmake/patch/grpc-1.25.0-Makefile.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile b/Makefile
-index dd4ced8112..d6abccda82 100644
+index 8fd7044dd9..428da4c6c5 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -839,6 +839,7 @@ ifneq ($(LDFLAGS_PROTOBUF_PKG_CONFIG),)
+@@ -852,6 +852,7 @@ ifneq ($(LDFLAGS_PROTOBUF_PKG_CONFIG),)
  LDFLAGS_PROTOBUF_PKG_CONFIG += $(shell $(PKG_CONFIG) --libs-only-L protobuf | sed s/L/Wl,-rpath,/)
  endif
  endif
@@ -10,3 +10,15 @@ index dd4ced8112..d6abccda82 100644
  else
  PC_LIBS_GRPCXX = -lprotobuf
  endif
+diff --git a/templates/Makefile.template b/templates/Makefile.template
+index 8063bd4771..eac629d1c7 100644
+--- a/templates/Makefile.template
++++ b/templates/Makefile.template
+@@ -749,6 +749,7 @@
+   LDFLAGS_PROTOBUF_PKG_CONFIG += $(shell $(PKG_CONFIG) --libs-only-L protobuf | sed s/L/Wl,-rpath,/)
+   endif
+   endif
++  LDFLAGS := $(LDFLAGS_PROTOBUF_PKG_CONFIG) $(LDFLAGS)
+   else
+   PC_LIBS_GRPCXX = -lprotobuf
+   endif


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>


**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:

At the moment, Falco does not compile when glibc is > 2.3.0 .
This is because of some incompatibilities between gRPC and glibc, not caused by falco itself. See the PR on gRPC https://github.com/grpc/grpc/pull/18950
My proposed solution is to upgrade gRPC and protobuf to fix this.

**Which issue(s) this PR fixes**:

Fixes #921

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
