### PR TITLE
Add a user_known_package_manager_in_container_conditions macro

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2255,11 +2255,19 @@
 - macro: network_tool_procs
   condition: (proc.name in (network_tool_binaries))
 
+- macro: user_known_package_manager_in_container_conditions
+  condition: (never_true)
+
 # Container is supposed to be immutable. Package management should be done in building the image.
 - rule: Launch Package Management Process in Container
   desc: Package management process ran inside container
   condition: >
-    spawned_process and container and user.name != "_apt" and package_mgmt_procs and not package_mgmt_ancestor_procs
+    spawned_process
+    and container
+    and user.name != "_apt"
+    and package_mgmt_procs
+    and not package_mgmt_ancestor_procs
+    and not user_known_package_manager_in_container_conditions
   output: >
     Package management process launched in container (user=%user.name
     command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:
This PR adds a simple macro allowing Falco users to allow package manager process in containers in some conditions.

One use-case is a Jenkins instance running a Jenkins job. It currently generate a ton of noise, this macro allows us to whitelist the Jenkins Pod in the build environment.

**Which issue(s) this PR fixes**:
I did not open an issue.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```


Signed-off-by: Jean-Philippe Lachance <jplachance@coveo.com>