### PR TITLE
Add a simple user_known_package_manager_in_container_conditions macro

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2255,7 +2255,13 @@
 - macro: network_tool_procs
   condition: (proc.name in (network_tool_binaries))
 
-- macro: user_known_package_manager_in_container_conditions
+# In a local/user rules file, create a condition that matches legitimate uses
+# of a package management process inside a container.
+#
+# For example:
+# - macro: user_known_package_manager_in_container
+#   condition: proc.cmdline="dpkg -l"
+- macro: user_known_package_manager_in_container
   condition: (never_true)
 
 # Container is supposed to be immutable. Package management should be done in building the image.
@@ -2267,7 +2273,7 @@
     and user.name != "_apt"
     and package_mgmt_procs
     and not package_mgmt_ancestor_procs
-    and not user_known_package_manager_in_container_conditions
+    and not user_known_package_manager_in_container
   output: >
     Package management process launched in container (user=%user.name
     command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2255,11 +2255,19 @@
 - macro: network_tool_procs
   condition: (proc.name in (network_tool_binaries))
 
+- macro: user_known_package_manager_in_container_conditions
+  condition: (never_true)
+
 # Container is supposed to be immutable. Package management should be done in building the image.
 - rule: Launch Package Management Process in Container
   desc: Package management process ran inside container
   condition: >
-    spawned_process and container and user.name != "_apt" and package_mgmt_procs and not package_mgmt_ancestor_procs
+    spawned_process
+    and container
+    and user.name != "_apt"
+    and package_mgmt_procs
+    and not package_mgmt_ancestor_procs
+    and not user_known_package_manager_in_container_conditions
   output: >
     Package management process launched in container (user=%user.name
     command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:
Changes I made:
\+ Add a simple user_known_package_manager_in_container_conditions macro
\* Use the user_known_package_manager_in_container_conditions macro in the "Launch Package Management Process in Container" rule

This is particularly useful when we need to ignore a Jenkins pod running jobs in a Kubernetes cluster.

**Which issue(s) this PR fixes**:
I did not file an issue.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
rules: Added a user_known_package_manager_in_container macro to allow users to specify conditions that match a legitimate use case for using a package management process in a container.
```
