### PR TITLE
rule update: Add rules to detect access to GCE Instance Metadata

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2210,26 +2210,25 @@
   priority: NOTICE
   tags: [network, aws, container, mitre_discovery]
 
-# In a local/user rules file, you could override this macro to
-# explicitly enumerate the container images that you want to allow
-# access to GCE metadata. In this main falco rules file, there isn't
-# any way to know all the containers that should have access, so any
-# container is alllowed, by repeating the "container" macro. In the
-# overridden macro, the condition would look something like
-# (container.image.repository = vendor/container-1 or
-# container.image.repository = vendor/container-2 or ...)
+
+# This rule is not enabled by default, since this rule is for GCP only.
+# If you want to enable this rule, overwrite the first macro,
+# And you can filter the container that you want to allow access to metadata by overwriting the second macro.
+- macro: consider_gce_metadata_access
+  condition: (never_true)
+
 - macro: gce_metadata_containers
-  condition: container
+  condition: (k8s.ns.name = "kube-system")
 
 # On GCE instances, 169.254.169.254 is a special IP used to fetch
-# metadata about the instance. It may be desirable to prevent access
-# to this IP from containers.
+# metadata about the instance. The metadata could be used to get credentials by attackers.
 - rule: Contact GCE Instance Metadata Service From Container
   desc: Detect attempts to contact the GCE Instance Metadata Service from a container
-  condition: outbound and fd.sip="169.254.169.254" and container and not gce_metadata_containers
+  condition: outbound and fd.sip="169.254.169.254" and container and consider_gce_metadata_access and not gce_metadata_containers
   output: Outbound connection to GCE instance metadata service (command=%proc.cmdline connection=%fd.name %container.info image=%container.image.repository:%container.image.tag)
   priority: NOTICE
   tags: [network, gcp, container, mitre_discovery]
+
 
 # In a local/user rules file, you should override this macro with the
 # IP address of your k8s api server. The IP 1.2.3.4 is a placeholder

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2222,7 +2222,7 @@
 
 # On GCP, AWS and Azure, 169.254.169.254 is a special IP used to fetch
 # metadata about the instance. The metadata could be used to get credentials by attackers.
-- rule: Contact Cloud Instance Metadata Service From Container
+- rule: Contact cloud metadata service from container
   desc: Detect attempts to contact the Cloud Instance Metadata Service from a container
   condition: outbound and fd.sip="169.254.169.254" and container and consider_metadata_access and not user_known_metadata_access
   output: Outbound connection to cloud instance metadata service (command=%proc.cmdline connection=%fd.name %container.info image=%container.image.repository:%container.image.tag)

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2211,23 +2211,23 @@
   tags: [network, aws, container, mitre_discovery]
 
 
-# This rule is not enabled by default, since this rule is for GCP only.
+# This rule is not enabled by default, since this rule is for cloud environment(GCP, AWS and Azure) only.
 # If you want to enable this rule, overwrite the first macro,
 # And you can filter the container that you want to allow access to metadata by overwriting the second macro.
-- macro: consider_gce_metadata_access
+- macro: consider_metadata_access
   condition: (never_true)
 
-- macro: gce_metadata_containers
+- macro: user_known_metadata_access
   condition: (k8s.ns.name = "kube-system")
 
-# On GCE instances, 169.254.169.254 is a special IP used to fetch
+# On GCP, AWS and Azure, 169.254.169.254 is a special IP used to fetch
 # metadata about the instance. The metadata could be used to get credentials by attackers.
-- rule: Contact GCE Instance Metadata Service From Container
-  desc: Detect attempts to contact the GCE Instance Metadata Service from a container
-  condition: outbound and fd.sip="169.254.169.254" and container and consider_gce_metadata_access and not gce_metadata_containers
-  output: Outbound connection to GCE instance metadata service (command=%proc.cmdline connection=%fd.name %container.info image=%container.image.repository:%container.image.tag)
+- rule: Contact Cloud Instance Metadata Service From Container
+  desc: Detect attempts to contact the Cloud Instance Metadata Service from a container
+  condition: outbound and fd.sip="169.254.169.254" and container and consider_metadata_access and not user_known_metadata_access
+  output: Outbound connection to cloud instance metadata service (command=%proc.cmdline connection=%fd.name %container.info image=%container.image.repository:%container.image.tag)
   priority: NOTICE
-  tags: [network, gcp, container, mitre_discovery]
+  tags: [network, container, mitre_discovery]
 
 
 # In a local/user rules file, you should override this macro with the

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2210,6 +2210,27 @@
   priority: NOTICE
   tags: [network, aws, container, mitre_discovery]
 
+# In a local/user rules file, you could override this macro to
+# explicitly enumerate the container images that you want to allow
+# access to GCE metadata. In this main falco rules file, there isn't
+# any way to know all the containers that should have access, so any
+# container is alllowed, by repeating the "container" macro. In the
+# overridden macro, the condition would look something like
+# (container.image.repository = vendor/container-1 or
+# container.image.repository = vendor/container-2 or ...)
+- macro: gce_metadata_containers
+  condition: container
+
+# On GCE instances, 169.254.169.254 is a special IP used to fetch
+# metadata about the instance. It may be desirable to prevent access
+# to this IP from containers.
+- rule: Contact GCE Instance Metadata Service From Container
+  desc: Detect attempts to contact the GCE Instance Metadata Service from a container
+  condition: outbound and fd.sip="169.254.169.254" and container and not gce_metadata_containers
+  output: Outbound connection to GCE instance metadata service (command=%proc.cmdline connection=%fd.name %container.info image=%container.image.repository:%container.image.tag)
+  priority: NOTICE
+  tags: [network, gcp, container, mitre_discovery]
+
 # In a local/user rules file, you should override this macro with the
 # IP address of your k8s api server. The IP 1.2.3.4 is a placeholder
 # IP that is not likely to be seen in practice.


### PR DESCRIPTION
Signed-off-by: Hiroki Suezawa <suezawa@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature
/kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
- The motivation of this new rule is to detect access to GCE Instance Metadata.
  - SSRF is still a threat to GKE, so I think it's good to have the rule.
    - (Ref: https://hackerone.com/reports/341876)
- This rule doesn't turn on by default. To use this rule, a user has to overwrite gce_metadata_containers on local/user rules file.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
- "169.254.169.254" is a metadata server on GKE(GCE).
  - (Ref: https://cloud.google.com/compute/docs/storing-retrieving-metadata, https://github.com/googleapis/google-cloud-go/blob/master/compute/metadata/metadata.go)
  - The IP is the same as metadata on EC2(AWS). So we can use the same rule as EC2 ("Contact EC2 Instance Metadata Service From Container"), but for backward compatibility, I think it's not good to change the rule name and macro name("ec2_metadata_containers"). So I would like to add this rule.

**Does this PR introduce a user-facing change?**:
NONE

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rules: add rules to detect access to GCE Instance Metadata
```
