### PR TITLE
Exclude exe_running_docker_save in the "Set Setuid or Setgid bit" rule

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2443,7 +2443,10 @@
     When the setuid or setgid bits are set for an application,
     this means that the application will run with the privileges of the owning user or group respectively.
     Detect setuid or setgid bits set via chmod
-  condition: consider_all_chmods and chmod and (evt.arg.mode contains "S_ISUID" or evt.arg.mode contains "S_ISGID") and not proc.name in (user_known_chmod_applications)
+  condition: >
+    consider_all_chmods and chmod and (evt.arg.mode contains "S_ISUID" or evt.arg.mode contains "S_ISGID")
+    and not proc.name in (user_known_chmod_applications)
+    and not exe_running_docker_save
   output: >
     Setuid or setgid bit is set via chmod (fd=%evt.arg.fd filename=%evt.arg.filename mode=%evt.arg.mode user=%user.name process=%proc.name
     command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
/kind rule-update

**Any specific area of the project related to this PR?**
/area rules

**What this PR does / why we need it**:
Since the upgrade to Falco 0.18.0, the "Set Setuid or Setgid bit" rule is enabled. That rule reports false positives each time we run a container. For example:
```JSON
{
    "rule": "Set Setuid or Setgid bit",
    "output": "2019-12-02T21:45:32.802828386+0000: Notice Setuid or setgid bit is set via chmod (fd=<NA> filename=/home/appuser mode=S_IXOTH|S_IROTH|S_IXGRP|S_IRGRP|S_IXUSR|S_IWUSR|S_IRUSR|S_ISGID user=root process=exe command=exe /var/lib/docker/overlay2/d06cc577802ae17ab015005a43d1370a3fdc039af0948cc05d0909e9a4404845/diff container_id=host container_name=host image=<NA>:<NA>) k8s.ns=<NA> k8s.pod=<NA> container=host k8s.ns=<NA> k8s.pod=<NA> container=host",
    "priority": "Notice",
    "output_fields": {
      "user.name": "root",
      "proc.name": "exe",
      "container.id": "host",
      "proc.cmdline": "exe /var/lib/docker/overlay2/d06cc577802ae17ab015005a43d1370a3fdc039af0948cc05d0909e9a4404845/diff",
      "evt.arg.mode": "S_IXOTH|S_IROTH|S_IXGRP|S_IRGRP|S_IXUSR|S_IWUSR|S_IRUSR|S_ISGID",
      "container.name": "host",
      "evt.arg.filename": "/home/appuser",
      "evt.time.iso8601": 1575323132802828300
    }
  }
```
This event is surrounded by dozens like it every time we start a container.

Adding a simple `and not exe_running_docker_save` fixes the issue.

**Which issue(s) this PR fixes**:
I did not file an issue, here is the PR instead!

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a false positive in the "Set Setuid or Setgid bit" rule by excluding "exe_running_docker_save". 
```