### PR TITLE
Exclude exe_running_docker_save in the "Write below etc" rule

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1266,7 +1266,9 @@
 
 - rule: Write below etc
   desc: an attempt to write to any file below /etc
-  condition: write_etc_common
+  condition: >
+    write_etc_common
+    and not exe_running_docker_save
   output: "File below /etc opened for writing (user=%user.name command=%proc.cmdline parent=%proc.pname pcmdline=%proc.pcmdline file=%fd.name program=%proc.name gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] container_id=%container.id image=%container.image.repository)"
   priority: ERROR
   tags: [filesystem, mitre_persistence]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind rule-update

**Any specific area of the project related to this PR?**
/area rules

**What this PR does / why we need it**:
The "Write below etc" rule is firing an event each time we spin a container. For example:
```JSON
{
    "priority": "Error",
    "output": "21:11:42.835233238: Error File below /etc opened for writing (user=<NA> command=exe /var/lib/docker/overlay2/b96d5259b14161da7fe7f3f0c036d723bbd937bc83cf6abdcac850210c397759/diff parent=<NA> pcmdline=<NA> file=/etc/group program=exe gparent=<NA> ggparent=<NA> gggparent=<NA> container_id=host image=<NA>) k8s.ns=<NA> k8s.pod=<NA> container=host k8s.ns=<NA> k8s.pod=<NA> container=host",
    "rule": "Write below etc",
    "output_fields": {
      "fd.name": "/etc/group",
      "proc.cmdline": "exe /var/lib/docker/overlay2/b96d5259b14161da7fe7f3f0c036d723bbd937bc83cf6abdcac850210c397759/diff",
      "container.id": "host",
      "evt.time": 1574889102835233300,
      "proc.name": "exe"
    }
  }
```
This event is surrounded by dozens like it.

Adding a simple `and not exe_running_docker_save` fixes the issue.

**Which issue(s) this PR fixes**:
I did not file an issue, here is the PR instead!

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a false positive in the "Write below etc" rule by excluding "exe_running_docker_save". 
```