### PR TITLE
Exclude exe_running_docker_save in the "Update Package Repository" rule

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -916,9 +916,11 @@
 - rule: Update Package Repository
   desc: Detect package repositories get updated
   condition: >
-    ((open_write and access_repositories) or (modify and modify_repositories)) and not package_mgmt_procs
+    ((open_write and access_repositories) or (modify and modify_repositories))
+    and not package_mgmt_procs
+    and not exe_running_docker_save
   output: >
-    Repository files get updated (user=%user.name command=%proc.cmdline file=%fd.name newpath=%evt.arg.newpath container_id=%container.id image=%container.image.repository)
+    Repository files get updated (user=%user.name command=%proc.cmdline parent=%proc.pname pcmdline=%proc.pcmdline file=%fd.name newpath=%evt.arg.newpath container_id=%container.id image=%container.image.repository)
   priority:
     NOTICE
   tags: [filesystem, mitre_persistence]

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -920,7 +920,7 @@
     and not package_mgmt_procs
     and not exe_running_docker_save
   output: >
-    Repository files get updated (user=%user.name command=%proc.cmdline parent=%proc.pname pcmdline=%proc.pcmdline file=%fd.name newpath=%evt.arg.newpath container_id=%container.id image=%container.image.repository)
+    Repository files get updated (user=%user.name command=%proc.cmdline pcmdline=%proc.pcmdline file=%fd.name newpath=%evt.arg.newpath container_id=%container.id image=%container.image.repository)
   priority:
     NOTICE
   tags: [filesystem, mitre_persistence]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind rule-update

**Any specific area of the project related to this PR?**
/area rules

**What this PR does / why we need it**:
The "Update Package Repository" gets fired each time we launch a container.
```JSON
{
    "output": "13:50:21.811741662: Notice Repository files get updated (user=root command=exe /var/lib/docker/overlay2/c8a17dac80b37bf1911335032d83ab0be5805fad1ddc02cfa6d591fd96de4927/diff file=/etc/yum.repos.d/CentOS-fasttrack.repo container_id=host image=<NA>) k8s.ns=<NA> k8s.pod=<NA> container=host k8s.ns=<NA> k8s.pod=<NA> container=host",
    "priority": "Notice",
    "output_fields": {
      "container.id": "host",
      "fd.name": "/etc/yum.repos.d/CentOS-fasttrack.repo",
      "proc.cmdline": "exe /var/lib/docker/overlay2/c8a17dac80b37bf1911335032d83ab0be5805fad1ddc02cfa6d591fd96de4927/diff",
      "user.name": "root",
      "evt.time": 1574949021811741700
    },
    "rule": "Update Package Repository"
  }
```
This event is surrounded by dozens like it.

Adding a simple `and not exe_running_docker_save` fixes the issue.

**Which issue(s) this PR fixes**:
I did not file an issue, here is the PR instead!

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
rules: fixed a false positive in the "Update Package Repository" rule by excluding "exe_running_docker_save". 
```