### PR TITLE
Exclude exe_running_docker_save in the "Modify Shell Configuration File" rule

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -447,7 +447,7 @@
     and not proc.name in (shell_binaries)
     and not exe_running_docker_save
   output: >
-    a shell configuration file has been modified (user=%user.name command=%proc.cmdline parent=%proc.pname pcmdline=%proc.pcmdline file=%fd.name container_id=%container.id image=%container.image.repository)
+    a shell configuration file has been modified (user=%user.name command=%proc.cmdline pcmdline=%proc.pcmdline file=%fd.name container_id=%container.id image=%container.image.repository)
   priority:
     WARNING
   tag: [file, mitre_persistence]

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -443,10 +443,11 @@
     open_write and
     (fd.filename in (shell_config_filenames) or
      fd.name in (shell_config_files) or
-     fd.directory in (shell_config_directories)) and
-    not proc.name in (shell_binaries)
+     fd.directory in (shell_config_directories))
+    and not proc.name in (shell_binaries)
+    and not exe_running_docker_save
   output: >
-    a shell configuration file has been modified (user=%user.name command=%proc.cmdline file=%fd.name container_id=%container.id image=%container.image.repository)
+    a shell configuration file has been modified (user=%user.name command=%proc.cmdline parent=%proc.pname pcmdline=%proc.pcmdline file=%fd.name container_id=%container.id image=%container.image.repository)
   priority:
     WARNING
   tag: [file, mitre_persistence]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind rule-update

**Any specific area of the project related to this PR?**
/area rules

**What this PR does / why we need it**:
The "Modify Shell Configuration File" gets fired each time we launch a container.
```JSON
{
    "output_fields": {
      "container.id": "host",
      "proc.cmdline": "exe /var/lib/docker/aufs/diff/2af477a6cb2dc69462ddd8aa43a147dab7cd86f7580d1766b2043143eb267d07",
      "evt.time": 1575046614282228200,
      "fd.name": "/etc/profile",
      "user.name": "root"
    },
    "output": "16:56:54.282228311: Warning a shell configuration file has been modified (user=root command=exe /var/lib/docker/aufs/diff/2af477a6cb2dc69462ddd8aa43a147dab7cd86f7580d1766b2043143eb267d07 file=/etc/profile container_id=host image=<NA>)",
    "rule": "Modify Shell Configuration File",
    "priority": "Warning"
  }
```
This event is surrounded by dozens like it.

Adding a simple `and not exe_running_docker_save` fixes the issue.

**Which issue(s) this PR fixes**:
I did not file an issue, here is the PR instead!

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
rules: fixed a false positive in the "Modify Shell Configuration File" rule by excluding "exe_running_docker_save".
```