### PR TITLE
Update the exe_running_docker_save macro to support docker in docker

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -845,7 +845,10 @@
   condition: (proc.name=start-ipsec.sh and fd.directory=/etc/ipsec)
 
 - macro: exe_running_docker_save
-  condition: (proc.cmdline startswith "exe /var/lib/docker" and proc.pname in (dockerd, docker))
+  condition: >
+    proc.name = "exe"
+    and proc.cmdline contains "/var/lib/docker"
+    and proc.pname in (dockerd, docker)
 
 # Ideally we'd have a length check here as well but sysdig
 # filterchecks don't have operators like len()


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind rule-update

**Any specific area of the project related to this PR?**
/area rules

**What this PR does / why we need it**:
In an environment where Docker in Docker is overly used, we see multiple events where `proc.cmdline` contains `exe / /var/lib/docker` (notice the `/` between `exe` and `/var/lib/docker`).

A common use-case for Docker in Docker in a Kubernetes cluster is a Jenkins agent running as a Kubernetes pod using the docker.io/library/docker:stable-dind Docker image. Such agent is used in a Jenkins job to build container images.

We already have the `exe_running_docker_save` macro:
```YAML
- macro: exe_running_docker_save
  condition: (proc.cmdline startswith "exe /var/lib/docker" and proc.pname in (dockerd, docker))
```
but we did not had any macro for `exe / /var/lib/docker`.

After discussing with multiple Falco maintainers in Slack, we think the best option is to modify the exe_running_docker_save macro to support Docker in Docker. 

**Which issue(s) this PR fixes**:
I did not file an issue, here is a PR instead!

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
We fixed false positives in multiple rules that were caused by the use of Docker in Docker by updating the exe_running_docker_save macro.
```
