### PR TITLE
rule update: modify rule to detect connection to K8S API Server from a container

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2240,13 +2240,7 @@
   tags: [network, container, mitre_discovery]
 
 
-# In a local/user rules file, you should override this macro with the
-# IP address of your k8s api server. The IP 1.2.3.4 is a placeholder
-# IP that is not likely to be seen in practice.
-- macro: k8s_api_server
-  condition: (fd.sip="1.2.3.4" and fd.sport=8080)
-
-# In a local/user rules file, list the container images that are
+# In a local/user rules file, list the namespace or container images that are
 # allowed to contact the K8s API Server from within a container. This
 # might cover cases where the K8s infrastructure itself is running
 # within a container.
@@ -2254,11 +2248,14 @@
   condition: >
     (container.image.repository in (gcr.io/google_containers/hyperkube-amd64,
      gcr.io/google_containers/kube2sky, sysdig/agent, sysdig/falco,
-     sysdig/sysdig))
+     sysdig/sysdig, falcosecurity/falco) or (k8s.ns.name = "kube-system"))
+
+- macro: k8s_api_server
+  condition: (fd.sip.name="kubernetes.default.svc.cluster.local")
 
 - rule: Contact K8S API Server From Container
   desc: Detect attempts to contact the K8S API Server from a container
-  condition: outbound and k8s_api_server and container and not k8s_containers
+  condition: evt.type=connect and evt.dir=< and (fd.typechar=4 or fd.typechar=6) and container and not k8s_containers and k8s_api_server
   output: Unexpected connection to K8s API Server from container (command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag connection=%fd.name)
   priority: NOTICE
   tags: [network, k8s, container, mitre_discovery]


### PR DESCRIPTION
Signed-off-by: Hiroki Suezawa <suezawa@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind rule-update

**Any specific area of the project related to this PR?**
/area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
- What this PR does
  - Change default condition of "Contact K8S API Server From Container" rule
- Why we need it
  - To use this rule, Users have to set K8S API's IP address for every cluster now.
    - I want to use dynamic DNS resolution instead of manual IP address setting. By using updated rule, users can use this rule by default.
    - Ref: https://github.com/draios/sysdig/wiki/Domain-Name-Resolution-for-Connections

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
- Pod can access to K8S API using private ip address, so I stopped using "outbound" macro.
- K8S API might have global IP address too. but this rule detects connection to "kubernetes.default.svc.cluster.local" only.
  - "kubernetes.default.svc.cluster.local" is a name to Kubernetes API
  ```
  Pods can use the kubernetes.default.svc hostname to query the API server
  ```
    - Ref: https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/

### Procedure and Trigger
1. Start a container
1. Connect K8S API (Trigger)
```
curl -k https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/
```

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rules: update "Contact K8S API Server From Container"
```
