### PR TITLE
rule(The docker client is executed in a container): modify condition to reduce false positive

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2644,10 +2644,13 @@
 
 - list: k8s_client_binaries
   items: [docker, kubectl, crictl]
+
+- macro: user_known_k8s_client_container
+  condition: (k8s.ns.name = "kube-system")
   
 - rule: The docker client is executed in a container
   desc: Detect a k8s client tool executed inside a container
-  condition: spawned_process and container and proc.name in (k8s_client_binaries)
+  condition: spawned_process and container and not user_known_k8s_client_container and proc.name in (k8s_client_binaries)
   output: "Docker or kubernetes client executed in container (user=%user.name %container.info parent=%proc.pname cmdline=%proc.cmdline)"
   priority: WARNING
   tags: [container, mitre_execution]


### PR DESCRIPTION
Signed-off-by: Hiroki Suezawa <suezawa@gmail.com>

**What type of PR is this?**
/kind rule-update


**Any specific area of the project related to this PR?**
/area rules

**What this PR does / why we need it**:
- What this PR does
  - Modify condition of `The docker client is executed in a container` rule.
- Why we need it
  - On GKE, The rule has many false positives because default running container uses kubectl.
  - To reduce false positives, and to be able to set additional condition, I would like to add `user_known_k8s_client_container` macro to this rule.


**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:
- This Deployment is the cause of false positive on GKE.
  - https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/fluentd-gcp-scaler
  - `kubectl` is used on `scaler.sh`

**Does this PR introduce a user-facing change?**:

```release-note
rule(The docker client is executed in a container): when executing the docker client, exclude containers running in the `kube-system` namespace to avoid false positives
```
