### PR TITLE
rule(Write below etc): whitelist automount writing under /etc/mtab

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1153,6 +1153,9 @@
 - macro: etcd_manager_updating_dns
   condition: (container and proc.name=etcd-manager and fd.name=/etc/hosts)
 
+- macro: automount_using_mtab
+  condition: (proc.pname = automount and fd.name startswith /etc/mtab)
+
 # Add conditions to this macro (probably in a separate file,
 # overwriting this macro) to allow for specific combinations of
 # programs writing below specific directories below
@@ -1269,6 +1272,7 @@
     and not jboss_in_container_writing_passwd
     and not etcd_manager_updating_dns
     and not user_known_write_below_etc_activities
+    and not automount_using_mtab
 
 - rule: Write below etc
   desc: an attempt to write to any file below /etc


### PR DESCRIPTION
**Type of PR**
/kind rule-update
/area rules

**What this PR does / why we need it**:
This will reduce false-positives related to `automount` writing to `/etc/mtab`. For the sake of completeness (and to help anyone that might not be aware), "mtab lists currently mounted file systems and is used by the mount and unmount commands when you want to list your mounts or unmount all. It's not used by the kernel, which maintains its own list." (https://serverfault.com/questions/267609/how-to-understand-etc-mtab). `automount` is expected to write under `/etc/mtab`, but there was no macro to whitelist it.

**Which issue(s) this PR fixes**: I didn't open an issue for this.

**Does this PR introduce a user-facing change?**:

```release-note
rule(Write below etc): allow automount to write to /etc/mtab
```
