### PR TITLE
rule(macro user_known_k8s_client_container): have more strict condition to avoid false positives

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2646,8 +2646,8 @@
 - list: k8s_client_binaries
   items: [docker, kubectl, crictl]
 
-# You can overwrite this macro to avoid false positives.
-# (The default value is a condition for Kubernetes Cluster on GCP) 
+# Whitelist for known docker client binaries run inside container
+# - k8s.gcr.io/fluentd-gcp-scaler in GCP/GKE 
 - macro: user_known_k8s_client_container
   condition: (k8s.ns.name="kube-system" and container.image.repository=k8s.gcr.io/fluentd-gcp-scaler)
   

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2646,13 +2646,15 @@
 - list: k8s_client_binaries
   items: [docker, kubectl, crictl]
 
+# You can overwrite this macro to avoid false positives.
+# (The default value is a condition for Kubernetes Cluster on GCP) 
 - macro: user_known_k8s_client_container
-  condition: (k8s.ns.name = "kube-system")
+  condition: (k8s.ns.name="kube-system" and container.image.repository=k8s.gcr.io/fluentd-gcp-scaler)
   
 - rule: The docker client is executed in a container
   desc: Detect a k8s client tool executed inside a container
   condition: spawned_process and container and not user_known_k8s_client_container and proc.name in (k8s_client_binaries)
-  output: "Docker or kubernetes client executed in container (user=%user.name %container.info parent=%proc.pname cmdline=%proc.cmdline)"
+  output: "Docker or kubernetes client executed in container (user=%user.name %container.info parent=%proc.pname cmdline=%proc.cmdline image=%container.image.repository:%container.image.tag)"
   priority: WARNING
   tags: [container, mitre_execution]
 


### PR DESCRIPTION
Signed-off-by: Hiroki Suezawa <suezawa@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind rule-update

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**
/area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
- What this PR does
  - Modify `user_known_k8s_client_container` macro to have more strict condition.
  - Add image info to output of `The docker client is executed in a container`

- Why We need it
  - As I discussed on https://github.com/falcosecurity/falco/pull/955#issuecomment-562341172, I would like to have more strict condition for GCP(GKE).
  - To know image info when getting false positives, I would like to add image info to output.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
- Output Sample
```
{"output":"18:14:42.779407953: Warning Docker or kubernetes client executed in container (user=root k8s.ns=kube-system k8s.pod=fluentd-gcp-scaler-54ccb89d5-nqb7c container=42bcc1ab542b parent=scaler.sh cmdline=kubectl get ds -n kube-system fluentd-gcp-v3.1.1 -o jsonpath={.spec.template.spec.containers[?(@.name=='fluentd-gcp')].resources.requests.cpu} image=k8s.gcr.io/fluentd-gcp-scaler:0.5.2) k8s.ns=kube-system k8s.pod=fluentd-gcp-scaler-54ccb89d5-nqb7c container=42bcc1ab542b k8s.ns=kube-system k8s.pod=fluentd-gcp-scaler-54ccb89d5-nqb7c container=42bcc1ab542b","priority":"Warning","rule":"The docker client is executed in a container","time":"2019-12-06T18:14:42.779407953Z", "output_fields": {"container.id":"42bcc1ab542b","container.image.repository":"k8s.gcr.io/fluentd-gcp-scaler","container.image.tag":"0.5.2","evt.time":1575656082779407953,"k8s.ns.name":"kube-system","k8s.pod.name":"fluentd-gcp-scaler-54ccb89d5-nqb7c","proc.cmdline":"kubectl get ds -n kube-system fluentd-gcp-v3.1.1 -o jsonpath={.spec.template.spec.containers[?(@.name=='fluentd-gcp')].resources.requests.cpu}","proc.pname":"scaler.sh","user.name":"root"}}
```

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rule(macro user_known_k8s_client_container): when executing the docker client, exclude fluentd-gcp-scaler container running in the `kube-system` namespace to avoid false positives
```
