### PR TITLE
build: add FALCO_COVERAGE CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ cmake_minimum_required(VERSION 3.3.2)
 
 project(falco)
 
+option(FALCO_Coverage "Build test suite with coverage information" OFF)
+
 if(NOT SYSDIG_DIR)
   get_filename_component(SYSDIG_DIR "${PROJECT_SOURCE_DIR}/../sysdig" REALPATH)
 endif()
@@ -632,6 +634,18 @@ endif()
 
 install(FILES falco.yaml
 	DESTINATION "${FALCO_ETC_DIR}")
+
+if(FALCO_Coverage)
+    if (NOT (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
+        message(FATAL_ERROR "FALCO_Coverage requires GCC or Clang.")
+    endif()
+
+    message(STATUS "Building with coverage information")
+    add_compile_options(-g --coverage)
+    set(CMAKE_SHARED_LINKER_FLAGS "--coverage ${CMAKE_SHARED_LINKER_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "--coverage ${CMAKE_EXE_LINKER_FLAGS}")
+endif()
+
 
 add_subdirectory(test)
 add_subdirectory(rules)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -637,7 +637,7 @@ install(FILES falco.yaml
 
 if(FALCO_COVERAGE)
     if (NOT (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
-        message(FATAL_ERROR "FALCO_Coverage requires GCC or Clang.")
+        message(FATAL_ERROR "FALCO_COVERAGE requires GCC or Clang.")
     endif()
 
     message(STATUS "Building with coverage information")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 3.3.2)
 
 project(falco)
 
-option(FALCO_Coverage "Build test suite with coverage information" OFF)
+option(FALCO_COVERAGE "Build test suite with coverage information" OFF)
 
 if(NOT SYSDIG_DIR)
   get_filename_component(SYSDIG_DIR "${PROJECT_SOURCE_DIR}/../sysdig" REALPATH)
@@ -635,7 +635,7 @@ endif()
 install(FILES falco.yaml
 	DESTINATION "${FALCO_ETC_DIR}")
 
-if(FALCO_Coverage)
+if(FALCO_COVERAGE)
     if (NOT (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
         message(FATAL_ERROR "FALCO_Coverage requires GCC or Clang.")
     endif()


### PR DESCRIPTION




**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build
/area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This adds a new CMake option `Falco_Coverage` that can be used to generate
code coverage analysis.  I used this while building up my test cases for PR #965 

With `cmake FALCO_COVERAGE=on` the `--coverage` option
is passed to both clang and gcc to help analyze untested
portions of the code base.  It produces gcov files.

These files can be analyzed by many tools such as lcov,
gcovr, etc.

Here is an example of one such tool, lcov:

```sh
 lcov --directory . --capture --output-file coverage.info
 lcov --extract coverage.info '/source/*' --output-file coverage.info
 genhtml coverage.info
```

**Special notes for your reviewer**:

Note: I put the `option` at the top of the CMakeLists file just because my style is to put
all options at the top of the for ease of use. What do you think?

I certainly could move that line near the conditional like all other options.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
