### PR TITLE
Update BPF_PROBE variable to SYSDIG_BPF_PROBE

### DIFF
--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap-slim.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap-slim.yaml
@@ -39,7 +39,7 @@ spec:
 # Leave blank for the default probe location, or set to the path
 # of a precompiled probe.
 #          env:
-#          - name: BPF_PROBE
+#          - name: SYSDIG_BPF_PROBE
 #            value: ""
           args: [ "/usr/bin/falco", "--cri", "/host/run/containerd/containerd.sock", "-K", "/var/run/secrets/kubernetes.io/serviceaccount/token", "-k", "https://$(KUBERNETES_SERVICE_HOST)", "-pk"]
           volumeMounts:

--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
@@ -23,7 +23,7 @@ spec:
 # Leave blank for the default probe location, or set to the path
 # of a precompiled probe.
 #          env:
-#          - name: BPF_PROBE
+#          - name: SYSDIG_BPF_PROBE
 #            value: ""
           args: [ "/usr/bin/falco", "--cri", "/host/run/containerd/containerd.sock", "-K", "/var/run/secrets/kubernetes.io/serviceaccount/token", "-k", "https://$(KUBERNETES_SERVICE_HOST)", "-pk"]
           volumeMounts:


### PR DESCRIPTION
Signed-off-by: Jessica Schalz <jscha@remitly.com>

**What type of PR is this?**

/kind bug
/kind documentation

**Any specific area of the project related to this PR?**

/area integrations

**What this PR does / why we need it**:

Correcting the eBPF's variable in the daemonset configmap to the SYSDIG_BPF_PROBE. Without the "SYSDIG_" prefix, it will default to falco-probe.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
