### PR TITLE
[Declined]rule(list network_tool_binaries): Add some network tools to detect suspicious network activity

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2281,7 +2281,7 @@
   tags: [network, k8s, container, mitre_port_knocking]
 
 - list: network_tool_binaries
-  items: [nc, ncat, nmap, dig, tcpdump, tshark, ngrep]
+  items: [nc, ncat, nmap, dig, tcpdump, tshark, ngrep, telnet, ssh, mitmproxy, socat]
 
 - macro: network_tool_procs
   condition: (proc.name in (network_tool_binaries))


### PR DESCRIPTION
Signed-off-by: Hiroki Suezawa <suezawa@gmail.com>

**What type of PR is this?**
/kind rule-update
<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**
/area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
### What this PR does
- Add network tool binaries to detect suspicious network process.

### Why we need it
- I added some common tools which attackers often use.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rule(list network_tool_binaries): Add some network tools to detect suspicious network activity.
```
