### PR TITLE
rule(Change thread namespace): Modify condition to detect suspicious container activity

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1544,9 +1544,9 @@
     an attempt to change a program/thread\'s namespace (commonly done
     as a part of creating a container) by calling setns.
   condition: >
-    evt.type = setns
-    and not proc.name in (docker_binaries, k8s_binaries, lxd_binaries, sysdigcloud_binaries,
-                          sysdig, nsenter, calico, oci-umount, cilium-cni, network_plugin_binaries)
+    evt.type=setns and evt.dir=<
+    and not (container.id=host and proc.name in (docker_binaries, k8s_binaries, lxd_binaries, nsenter))
+    and not proc.name in (sysdigcloud_binaries, sysdig, calico, oci-umount, cilium-cni, network_plugin_binaries)
     and not proc.name in (user_known_change_thread_namespace_binaries)
     and not proc.name startswith "runc"
     and not proc.cmdline startswith "containerd"
@@ -1561,9 +1561,9 @@
     and not user_known_change_thread_namespace_activities
   output: >
     Namespace change (setns) by unexpected program (user=%user.name command=%proc.cmdline
-    parent=%proc.pname %container.info container_id=%container.id image=%container.image.repository)
+    parent=%proc.pname %container.info container_id=%container.id image=%container.image.repository:%container.image.tag)
   priority: NOTICE
-  tags: [process]
+  tags: [process, mitre_privilege_escalation, mitre_lateral_movement]
 
 # The binaries in this list and their descendents are *not* allowed
 # spawn shells. This includes the binaries spawning shells directly as

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1550,7 +1550,7 @@
     and not proc.name in (user_known_change_thread_namespace_binaries)
     and not proc.name startswith "runc"
     and not proc.cmdline startswith "containerd"
-    and not proc.pname in (sysdigcloud_binaries)
+    and not proc.pname in (sysdigcloud_binaries, hyperkube, kubelet)
     and not python_running_sdchecks
     and not java_running_sdjagent
     and not kubelet_running_loopback

--- a/test/falco_tests.yaml
+++ b/test/falco_tests.yaml
@@ -689,7 +689,7 @@ trace_files: !mux
       - "Non sudo setuid": 1
       - "Create files below dev": 1
       - "Modify binary dirs": 2
-      - "Change thread namespace": 2
+      - "Change thread namespace": 1
 
   disabled_tags_a:
     detect: True

--- a/test/falco_traces.yaml.in
+++ b/test/falco_traces.yaml.in
@@ -26,7 +26,7 @@ traces: !mux
     detect: True
     detect_level: NOTICE
     detect_counts:
-      - "Change thread namespace": 2
+      - "Change thread namespace": 1
 
   container-privileged:
     trace_file: traces-positive/container-privileged.scap
@@ -73,7 +73,7 @@ traces: !mux
       - "Non sudo setuid": 1
       - "Create files below dev": 1
       - "Modify binary dirs": 2
-      - "Change thread namespace": 2
+      - "Change thread namespace": 1
 
   mkdir-binary-dirs:
     trace_file: traces-positive/mkdir-binary-dirs.scap


### PR DESCRIPTION
Signed-off-by: Hiroki Suezawa <suezawa@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind rule-update

**Any specific area of the project related to this PR?**
/area rules

**What this PR does / why we need it**:
- What this PR does
  - Modify condition to detect some process names within a container.
  - Add evt.dir to avoid detection of same syscall
  
- Why we need it
  - The current rule exclude some process names used on host
    - i.e. `k8s_binaries`, `nsenter`
  - But `nsenter` could be used to do privilege escalation
    - https://twitter.com/mauilion/status/1129468485480751104
    - (nsenter is included in many container images like `alpine` by default)
  - So I would like to change condition to detect suspicious container activity.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rule(Change thread namespace): Modify condition to detect suspicious container activity
```
