### PR TITLE
fix: use base name in docker-entrypoint.sh

### DIFF
--- a/docker/dev/docker-entrypoint.sh
+++ b/docker/dev/docker-entrypoint.sh
@@ -25,7 +25,8 @@ if [[ -z "${SKIP_MODULE_LOAD}" ]]; then
 
     for i in "$HOST_ROOT/usr/src"/*
     do
-        ln -s "$i" "/usr/src/$i"
+        base=$(basename "$i")
+        ln -s "$i" "/usr/src/$base"
     done
 
     /usr/bin/falco-probe-loader

--- a/docker/local/docker-entrypoint.sh
+++ b/docker/local/docker-entrypoint.sh
@@ -25,7 +25,7 @@ if [[ -z "${SKIP_MODULE_LOAD}" ]]; then
 
     for i in "$HOST_ROOT/usr/src"/*
     do
-	base=$(basename $i)
+        base=$(basename $i)
         ln -s "$i" "/usr/src/$base"
     done
 

--- a/docker/local/docker-entrypoint.sh
+++ b/docker/local/docker-entrypoint.sh
@@ -25,7 +25,8 @@ if [[ -z "${SKIP_MODULE_LOAD}" ]]; then
 
     for i in "$HOST_ROOT/usr/src"/*
     do
-        ln -s "$i" "/usr/src/$i"
+	base=$(basename $i)
+        ln -s "$i" "/usr/src/$base"
     done
 
     /usr/bin/falco-probe-loader

--- a/docker/local/docker-entrypoint.sh
+++ b/docker/local/docker-entrypoint.sh
@@ -25,7 +25,7 @@ if [[ -z "${SKIP_MODULE_LOAD}" ]]; then
 
     for i in "$HOST_ROOT/usr/src"/*
     do
-        base=$(basename $i)
+        base=$(basename "$i")
         ln -s "$i" "/usr/src/$base"
     done
 

--- a/docker/rhel/docker-entrypoint.sh
+++ b/docker/rhel/docker-entrypoint.sh
@@ -25,7 +25,8 @@ if [[ -z "${SKIP_MODULE_LOAD}" ]]; then
 
     for i in "$HOST_ROOT/usr/src"/*
     do
-        ln -s "$i" "/usr/src/$i"
+        base=$(basename "$i")
+        ln -s "$i" "/usr/src/$base"
     done
 
     /usr/bin/falco-probe-loader

--- a/docker/stable/docker-entrypoint.sh
+++ b/docker/stable/docker-entrypoint.sh
@@ -25,7 +25,8 @@ if [[ -z "${SKIP_MODULE_LOAD}" ]]; then
 
     for i in "$HOST_ROOT/usr/src"/*
     do
-        ln -s "$i" "/usr/src/$i"
+        base=$(basename "$i")
+        ln -s "$i" "/usr/src/$base"
     done
 
     /usr/bin/falco-probe-loader


### PR DESCRIPTION

**What type of PR is this?**


/kind bug



**Any specific area of the project related to this PR?**



/area build



**What this PR does / why we need it**:

It uses the base path in the docker-entrypoint.sh. This is needed because when you build Falco from source along with the driver, it tries to create a link with destination /usr/src//host/usr/src/XXX which is wrong and should be /usr/src/XXX 

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
fix(docker): use base name in docker-entrypoint.sh
```
