### PR TITLE
add lib to falco engine to work with latest sysdig

### DIFF
--- a/userspace/engine/CMakeLists.txt
+++ b/userspace/engine/CMakeLists.txt
@@ -38,6 +38,7 @@ target_include_directories(falco_engine PUBLIC
 	"${SYSDIG_DIR}/userspace/libsinsp/third-party/jsoncpp"
 	"${SYSDIG_DIR}/userspace/libscap"
 	"${SYSDIG_DIR}/userspace/libsinsp"
+	"${SYSDIG_DIR}/userspace/userspace-common/src"
 	"${PROJECT_BINARY_DIR}/userspace/engine"
 	)
 


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

Any specific area of the project related to this PR?

/area build

What this PR does / why we need it:

In draios/sysdig#1554, a new lib will be added to the sysdig repo below libsinsp. The appropriate includes need to be added to falco engine so that it continues to build.  

Which issue(s) this PR fixes:

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

```release-note
NONE
```