### PR TITLE
Modifying apiVersion for daemonset and adding selectors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
   # This build is static, dependencies are bundled in the falco binary
   "build/centos8":
     docker:
-      - image: falcosecurity/falco-builder:dynamic-builds # todo(fntlnz): replace this with the actual image once PR #968 is merged
+      - image: falcosecurity/falco-builder:latest
         environment:
           BUILD_TYPE: "release"
     steps:
@@ -72,7 +72,7 @@ jobs:
   # Execute integration tests based on the build results coming from the "build/centos8" job
   "tests/integration":
     docker:
-      - image: falcosecurity/falco-tester:dynamic-builds # todo(fntlnz): replace this with the actual image once PR #968 is merged
+      - image: falcosecurity/falco-tester:latest
         environment:
           SOURCE_DIR: "/source"
           BUILD_DIR: "/build"

--- a/cmake/modules/sysdig.cmake
+++ b/cmake/modules/sysdig.cmake
@@ -46,6 +46,9 @@ add_dependencies(sinsp tbb b64 luajit)
 # explicitly force this dependency to use the system OpenSSL
 set(USE_BUNDLED_OPENSSL OFF)
 
+# explicitly disable the tests of this dependency
+set(CREATE_TEST_TARGETS OFF)
+
 if(USE_BUNDLED_DEPS)
   add_dependencies(scap grpc curl jq)
 endif()

--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
@@ -1,3 +1,4 @@
+#Daemonset for Falco on k8s
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: falco-daemonset
@@ -6,6 +6,9 @@ metadata:
     app: falco-example
     role: security
 spec:
+  selector:
+    matchLabels:
+      app: falco-example
   template:
     metadata:
       labels:

--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
@@ -1,4 +1,4 @@
-#Daemonset for Falco on k8s
+# Daemonset for Falco on k8s
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area integrations

**What this PR does / why we need it**:

This PR fixes the case where Falco daemonset cannot be deployed in Kubernetes 1.17+ due to incorrect apiVersion and missing selector for pods

**Which issue(s) this PR fixes**:

#993

Automatically closes linked issue when PR is merged.
Usage: `Fixes #993`.

Fixes #993 

**Special notes for your reviewer**:

This should fix the following errors:

```
root@int:~/falco/integrations/k8s-using-daemonset# kubectl apply -f k8s-with-rbac/falco-config/falco-daemonset-configmap.yaml
error: unable to recognize "k8s-with-rbac/falco-config/falco-daemonset-configmap.yaml": no matches for kind "DaemonSet" in version "extensions/v1beta1"

root@int:~/falco/integrations/k8s-using-daemonset# kubectl apply -f k8s-with-rbac/falco-config/falco-daemonset-configmap.yaml
error: error validating "k8s-with-rbac/falco-config/falco-daemonset-configmap.yaml": error validating data: ValidationError(DaemonSet.spec): missing required field "selector" in io.k8s.api.apps.v1.DaemonSetSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
