### PR TITLE
Refactor integration images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,13 +21,13 @@ jobs:
             cmake ..
             popd
       - run:
-          name: build
+          name: Build
           command: |
             pushd build
             make -j4 all
             popd
       - run:
-          name: run unit tests
+          name: Run unit tests
           command: |
             pushd build
             make tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
   # Execute integration tests based on the build results coming from the "build/centos7" job
   "tests/integration":
     docker:
-      - image: falcosecurity/falco-tester:refactor-images # todo: restore this to latest after pushing it once this pr is merged
+      - image: falcosecurity/falco-tester:latest
         environment:
           SOURCE_DIR: "/source"
           BUILD_DIR: "/build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
   # Execute integration tests based on the build results coming from the "build/centos7" job
   "tests/integration":
     docker:
-      - image: falcosecurity/falco-tester:latest
+      - image: falcosecurity/falco-tester:refactor-images # todo: restore this to latest after pushing it once this pr is merged
         environment:
           SOURCE_DIR: "/source"
           BUILD_DIR: "/build"

--- a/docker/tester/root/runners/deb.Dockerfile
+++ b/docker/tester/root/runners/deb.Dockerfile
@@ -6,7 +6,7 @@ RUN test -n FALCO_VERSION
 ENV FALCO_VERSION ${FALCO_VERSION}
 
 RUN apt update -y
-RUN apt install dkms -y
+RUN apt install dkms libyaml-0-2 -y
 
 ADD falco-${FALCO_VERSION}-x86_64.deb /
 RUN dpkg -i /falco-${FALCO_VERSION}-x86_64.deb

--- a/docker/tester/root/runners/deb.Dockerfile
+++ b/docker/tester/root/runners/deb.Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:18.04
+LABEL maintainer="opensource@sysdig.com"
+
+ARG FALCO_VERSION=
+RUN test -n FALCO_VERSION
+ENV FALCO_VERSION ${FALCO_VERSION}
+
+ADD falco-${FALCO_VERSION}-x86_64.deb /
+RUN dpkg -i /falco-${FALCO_VERSION}-x86_64.deb
+
+# Change the falco config within the container to enable ISO 8601 output.
+RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/falco/falco.yaml > /etc/falco/falco.yaml.new \
+    && mv /etc/falco/falco.yaml.new /etc/falco/falco.yaml
+
+# # The local container also copies some test trace files and
+# # corresponding rules that are used when running regression tests.
+# COPY source/testrules/*.yaml /rules/
+# COPY traces/*.scap /traces/
+
+VOLUME ["/rules"]
+VOLUME ["/traces"]
+
+CMD ["/usr/bin/falco"]

--- a/docker/tester/root/runners/deb.Dockerfile
+++ b/docker/tester/root/runners/deb.Dockerfile
@@ -5,6 +5,9 @@ ARG FALCO_VERSION=
 RUN test -n FALCO_VERSION
 ENV FALCO_VERSION ${FALCO_VERSION}
 
+RUN apt update -y
+RUN apt install dkms -y
+
 ADD falco-${FALCO_VERSION}-x86_64.deb /
 RUN dpkg -i /falco-${FALCO_VERSION}-x86_64.deb
 

--- a/docker/tester/root/runners/deb.Dockerfile
+++ b/docker/tester/root/runners/deb.Dockerfile
@@ -15,11 +15,6 @@ RUN dpkg -i /falco-${FALCO_VERSION}-x86_64.deb
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/falco/falco.yaml > /etc/falco/falco.yaml.new \
     && mv /etc/falco/falco.yaml.new /etc/falco/falco.yaml
 
-# # The local container also copies some test trace files and
-# # corresponding rules that are used when running regression tests.
-# COPY source/testrules/*.yaml /rules/
-# COPY traces/*.scap /traces/
-
 VOLUME ["/rules"]
 VOLUME ["/traces"]
 

--- a/docker/tester/root/runners/deb.Dockerfile
+++ b/docker/tester/root/runners/deb.Dockerfile
@@ -15,7 +15,7 @@ RUN dpkg -i /falco-${FALCO_VERSION}-x86_64.deb
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/falco/falco.yaml > /etc/falco/falco.yaml.new \
     && mv /etc/falco/falco.yaml.new /etc/falco/falco.yaml
 
-VOLUME ["/rules"]
-VOLUME ["/traces"]
+COPY rules/*.yaml /rules/
+COPY trace_files/*.scap /traces/
 
 CMD ["/usr/bin/falco"]

--- a/docker/tester/root/runners/rpm.Dockerfile
+++ b/docker/tester/root/runners/rpm.Dockerfile
@@ -16,7 +16,7 @@ RUN yum install -y /falco-${FALCO_VERSION}-x86_64.rpm
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/falco/falco.yaml > /etc/falco/falco.yaml.new \
     && mv /etc/falco/falco.yaml.new /etc/falco/falco.yaml
 
-VOLUME ["/rules"]
-VOLUME ["/traces"]
+COPY rules/*.yaml /rules/
+COPY trace_files/*.scap /traces/
 
 CMD ["/usr/bin/falco"]

--- a/docker/tester/root/runners/rpm.Dockerfile
+++ b/docker/tester/root/runners/rpm.Dockerfile
@@ -1,0 +1,27 @@
+FROM centos:7
+
+LABEL maintainer="opensource@sysdig.com"
+
+ARG FALCO_VERSION=
+RUN test -n FALCO_VERSION
+ENV FALCO_VERSION ${FALCO_VERSION}
+
+RUN yum update -y
+RUN yum install epel-release -y
+
+ADD falco-${FALCO_VERSION}-x86_64.rpm /
+RUN yum install -y /falco-${FALCO_VERSION}-x86_64.rpm
+
+# Change the falco config within the container to enable ISO 8601 output.
+RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/falco/falco.yaml > /etc/falco/falco.yaml.new \
+    && mv /etc/falco/falco.yaml.new /etc/falco/falco.yaml
+
+# # The local container also copies some test trace files and
+# # corresponding rules that are used when running regression tests.
+# COPY source/testrules/*.yaml /rules/
+# COPY traces/*.scap /traces/
+
+VOLUME ["/rules"]
+VOLUME ["/traces"]
+
+CMD ["/usr/bin/falco"]

--- a/docker/tester/root/runners/rpm.Dockerfile
+++ b/docker/tester/root/runners/rpm.Dockerfile
@@ -16,11 +16,6 @@ RUN yum install -y /falco-${FALCO_VERSION}-x86_64.rpm
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/falco/falco.yaml > /etc/falco/falco.yaml.new \
     && mv /etc/falco/falco.yaml.new /etc/falco/falco.yaml
 
-# # The local container also copies some test trace files and
-# # corresponding rules that are used when running regression tests.
-# COPY source/testrules/*.yaml /rules/
-# COPY traces/*.scap /traces/
-
 VOLUME ["/rules"]
 VOLUME ["/traces"]
 

--- a/docker/tester/root/usr/bin/entrypoint
+++ b/docker/tester/root/usr/bin/entrypoint
@@ -43,24 +43,21 @@ clean_image() {
 
 case "$CMD" in
 "test")
-    if [ ! -d "$BUILD_DIR/$BUILD_TYPE/docker/local" ]; then
-        echo "Missing $BUILD_DIR/$BUILD_TYPE/docker/local directory." >&2
-        exit 1
-    fi
     if [ -z "$FALCO_VERSION" ]; then
         echo "Automatically figuring out Falco version."
-        FALCO_VERSION=$($BUILD_DIR/$BUILD_TYPE/userspace/falco/falco --version | cut -d' ' -f3 | tr -d '\r')
+        FALCO_VERSION=$("$BUILD_DIR/$BUILD_TYPE/userspace/falco/falco" --version | cut -d' ' -f3 | tr -d '\r')
+        echo "Falco version: $FALCO_VERSION"
     fi
     if [ -z "$FALCO_VERSION" ]; then
         echo "Falco version cannot be guessed, please provide it with the FALCO_VERSION environment variable." >&2
         exit 1
     fi
-    
+
     # build docker images
     build_image "$BUILD_DIR" "$BUILD_TYPE" "$FALCO_VERSION" "deb"
     build_image "$BUILD_DIR" "$BUILD_TYPE" "$FALCO_VERSION" "rpm"
 
-    # check that source directory contains Falco and sysdig
+    # check that source directory contains Falco
     if [ ! -d "$SOURCE_DIR/falco/test" ]; then
         echo "Missing $SOURCE_DIR/falco/test directory." >&2
         exit 1
@@ -68,7 +65,7 @@ case "$CMD" in
 
     # run tests
     echo "Running regression tests ..."
-    cd `$SOURCE_DIR/falco/test`
+    cd "$SOURCE_DIR/falco/test"
     ./run_regression_tests.sh "$BUILD_DIR/$BUILD_TYPE"
 
     # clean docker images

--- a/docker/tester/root/usr/bin/entrypoint
+++ b/docker/tester/root/usr/bin/entrypoint
@@ -17,6 +17,30 @@ case "$BUILD_TYPE" in
     ;;
 esac
 
+build_image() {
+    BUILD_DIR=$1
+    BUILD_TYPE=$2
+    FALCO_VERSION=$3
+    PACKAGE_TYPE=$4
+    PACKAGE="$BUILD_DIR/$BUILD_TYPE/falco-$FALCO_VERSION-x86_64.${PACKAGE_TYPE}"
+    if [ ! -f "$PACKAGE" ]; then
+        echo "Package not found: ${PACKAGE}." >&2
+        exit 1
+    fi
+    DOCKER_IMAGE_NAME="falcosecurity/falco:test-${PACKAGE_TYPE}"
+    echo "Building local docker image $DOCKER_IMAGE_NAME from latest ${PACKAGE_TYPE} package..."
+
+    mkdir -p /packages
+    cp "$PACKAGE" /packages
+    docker build -f "/runners/$PACKAGE_TYPE.Dockerfile" --build-arg FALCO_VERSION="$FALCO_VERSION" -t "$DOCKER_IMAGE_NAME" /packages
+}
+
+clean_image() {
+    PACKAGE_TYPE=$1
+    DOCKER_IMAGE_NAME="falcosecurity/falco:test-${PACKAGE_TYPE}"
+    docker rmi -f "$DOCKER_IMAGE_NAME"
+}
+
 case "$CMD" in
 "test")
     if [ ! -d "$BUILD_DIR/$BUILD_TYPE/docker/local" ]; then
@@ -58,27 +82,3 @@ case "$CMD" in
     exec "$CMD" "$@"
     ;;
 esac
-
-build_image() {
-    BUILD_DIR=$1
-    BUILD_TYPE=$2
-    FALCO_VERSION=$3
-    PACKAGE_TYPE=$4
-    PACKAGE="$BUILD_DIR/$BUILD_TYPE/falco-$FALCO_VERSION-x86_64.${PACKAGE_TYPE}"
-    if [ ! -f "$PACKAGE" ]; then
-        echo "Package not found: ${PACKAGE}." >&2
-        exit 1
-    fi
-    DOCKER_IMAGE_NAME="falcosecurity/falco:test-${PACKAGE_TYPE}"
-    echo "Building local docker image $DOCKER_IMAGE_NAME from latest ${PACKAGE_TYPE} package..."
-
-    mkdir -p /packages
-    cp "$PACKAGE" /packages
-    docker build -f "/runners/$PACKAGE_TYPE.Dockerfile" --build-arg FALCO_VERSION="$FALCO_VERSION" -t "$DOCKER_IMAGE_NAME" /packages
-}
-
-clean_image() {
-    PACKAGE_TYPE=$1
-    DOCKER_IMAGE_NAME="falcosecurity/falco:test-${PACKAGE_TYPE}"
-    docker rmi -f "$DOCKER_IMAGE_NAME"
-}

--- a/docker/tester/root/usr/bin/entrypoint
+++ b/docker/tester/root/usr/bin/entrypoint
@@ -30,9 +30,11 @@ build_image() {
     DOCKER_IMAGE_NAME="falcosecurity/falco:test-${PACKAGE_TYPE}"
     echo "Building local docker image $DOCKER_IMAGE_NAME from latest ${PACKAGE_TYPE} package..."
 
-    mkdir -p /packages
-    cp "$PACKAGE" /packages
-    docker build -f "/runners/$PACKAGE_TYPE.Dockerfile" --build-arg FALCO_VERSION="$FALCO_VERSION" -t "$DOCKER_IMAGE_NAME" /packages
+    mkdir -p /runner-rootfs
+    cp "$PACKAGE" /runner-rootfs
+    cp -R "$SOURCE_DIR/falco/test/rules" /runner-rootfs
+    cp -R "$SOURCE_DIR/falco/test/trace_files" /runner-rootfs
+    docker build -f "/runners/$PACKAGE_TYPE.Dockerfile" --build-arg FALCO_VERSION="$FALCO_VERSION" -t "$DOCKER_IMAGE_NAME" /runner-rootfs
 }
 
 clean_image() {

--- a/docker/tester/root/usr/bin/entrypoint
+++ b/docker/tester/root/usr/bin/entrypoint
@@ -7,7 +7,7 @@ BUILD_DIR=/build
 CMD=${1:-test}
 shift
 
-# Build type can be "debug" or "release", fallbacks to "release" by default
+# build type can be "debug" or "release", fallbacks to "release" by default
 BUILD_TYPE=$(echo "$BUILD_TYPE" | tr "[:upper:]" "[:lower:]")
 case "$BUILD_TYPE" in
 "debug")
@@ -31,26 +31,25 @@ case "$CMD" in
         echo "Falco version cannot be guessed, please provide it with the FALCO_VERSION environment variable." >&2
         exit 1
     fi
-    PACKAGE="$BUILD_DIR/$BUILD_TYPE/falco-$FALCO_VERSION-x86_64.deb"
-    if [ ! -f "$PACKAGE" ]; then
-        echo "Package(s) not found." >&2
-        exit 1
-    fi
-    DOCKER_IMAGE_NAME="falcosecurity/falco:test"
-    echo "Building local docker image $DOCKER_IMAGE_NAME from latest debian package..."
-    cp "$PACKAGE" $BUILD_DIR/$BUILD_TYPE/docker/local
-    cd $BUILD_DIR/$BUILD_TYPE/docker/local
-    docker build --build-arg FALCO_VERSION="$FALCO_VERSION" -t "$DOCKER_IMAGE_NAME" .
+    
+    # build docker images
+    build_image "$BUILD_DIR" "$BUILD_TYPE" "$FALCO_VERSION" "deb"
+    build_image "$BUILD_DIR" "$BUILD_TYPE" "$FALCO_VERSION" "rpm"
 
-    # Check that source directory contains Falco and sysdig
+    # check that source directory contains Falco and sysdig
     if [ ! -d "$SOURCE_DIR/falco/test" ]; then
         echo "Missing $SOURCE_DIR/falco/test directory." >&2
         exit 1
     fi
+
+    # run tests
     echo "Running regression tests ..."
-    cd $SOURCE_DIR/falco/test
-    ./run_regression_tests.sh $BUILD_DIR/$BUILD_TYPE
-    docker rmi "$DOCKER_IMAGE_NAME" || true
+    cd `$SOURCE_DIR/falco/test`
+    ./run_regression_tests.sh "$BUILD_DIR/$BUILD_TYPE"
+
+    # clean docker images
+    clean_image "deb"
+    clean_image "rpm"
     ;;
 "bash")
     CMD=/bin/bash
@@ -59,3 +58,27 @@ case "$CMD" in
     exec "$CMD" "$@"
     ;;
 esac
+
+build_image() {
+    BUILD_DIR=$1
+    BUILD_TYPE=$2
+    FALCO_VERSION=$3
+    PACKAGE_TYPE=$4
+    PACKAGE="$BUILD_DIR/$BUILD_TYPE/falco-$FALCO_VERSION-x86_64.${PACKAGE_TYPE}"
+    if [ ! -f "$PACKAGE" ]; then
+        echo "Package not found: ${PACKAGE}." >&2
+        exit 1
+    fi
+    DOCKER_IMAGE_NAME="falcosecurity/falco:test-${PACKAGE_TYPE}"
+    echo "Building local docker image $DOCKER_IMAGE_NAME from latest ${PACKAGE_TYPE} package..."
+
+    mkdir -p /packages
+    cp "$PACKAGE" /packages
+    docker build -f "/runners/$PACKAGE_TYPE.Dockerfile" --build-arg FALCO_VERSION="$FALCO_VERSION" -t "$DOCKER_IMAGE_NAME" /packages
+}
+
+clean_image() {
+    PACKAGE_TYPE=$1
+    DOCKER_IMAGE_NAME="falcosecurity/falco:test-${PACKAGE_TYPE}"
+    docker rmi -f "$DOCKER_IMAGE_NAME"
+}

--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -334,14 +334,15 @@ class FalcoTest(Test):
             res = process.run("docker rm falco-test", ignore_status=True)
 
             rules_dir = os.path.abspath(os.path.join(self.basedir, "./rules"))
-            conf_dir = os.path.abspath(os.path.join(self.basedir, "../"))
             traces_dir = os.path.abspath(os.path.join(self.basedir, "./trace_files"))
             self.falco_binary_path = "docker run --rm --name falco-test --privileged " \
                                      "-v /var/run/docker.sock:/host/var/run/docker.sock " \
                                      "-v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro " \
-                                     "-v /lib/modules:/host/lib/modules:ro -v {}:/root/.sysdig:ro -v " \
-                                     "/usr:/host/usr:ro {} {} falco".format(
-                                         self.module_dir, self.addl_docker_run_args, image)
+                                     "-v /lib/modules:/host/lib/modules:ro -v {}:/root/.sysdig:ro " \
+                                     "-v {}:/rules:ro " \
+                                     "-v {}:/traces:ro " \
+                                     "-v /usr:/host/usr:ro {} {} falco".format(
+                                         self.module_dir, rules_dir, traces_dir, self.addl_docker_run_args, image)
 
         elif self.package.endswith(".deb"):
             self.falco_binary_path = '/usr/bin/falco';

--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -333,16 +333,12 @@ class FalcoTest(Test):
             # doesn't have an -i equivalent.
             res = process.run("docker rm falco-test", ignore_status=True)
 
-            rules_dir = os.path.abspath(os.path.join(self.basedir, "./rules"))
-            traces_dir = os.path.abspath(os.path.join(self.basedir, "./trace_files"))
             self.falco_binary_path = "docker run --rm --name falco-test --privileged " \
                                      "-v /var/run/docker.sock:/host/var/run/docker.sock " \
                                      "-v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro " \
                                      "-v /lib/modules:/host/lib/modules:ro -v {}:/root/.sysdig:ro " \
-                                     "-v {}:/rules:ro " \
-                                     "-v {}:/traces:ro " \
                                      "-v /usr:/host/usr:ro {} {} falco".format(
-                                         self.module_dir, rules_dir, traces_dir, self.addl_docker_run_args, image)
+                                         self.module_dir, self.addl_docker_run_args, image)
 
         elif self.package.endswith(".deb"):
             self.falco_binary_path = '/usr/bin/falco';

--- a/test/falco_tests_package.yaml
+++ b/test/falco_tests_package.yaml
@@ -16,18 +16,18 @@
 #
 trace_files: !mux
 
-  docker_package:
-    package: docker:falcosecurity/falco:test
+  docker_deb_package:
+    package: docker:falcosecurity/falco:test-deb
     detect: True
     detect_level: WARNING
     rules_file: /rules/rule_names_with_spaces.yaml
     trace_file: /traces/cat_write.scap
     conf_file: /etc/falco/falco.yaml
 
-  centos_package:
-    package: falco*.rpm
+  docker_rpm_package:
+    package: docker:falcosecurity/falco:test-rpm
     detect: True
     detect_level: WARNING
-    rules_file:
-      - rules/rule_names_with_spaces.yaml
-    trace_file: trace_files/cat_write.scap
+    rules_file: /rules/rule_names_with_spaces.yaml
+    trace_file: /traces/cat_write.scap
+    conf_file: /etc/falco/falco.yaml


### PR DESCRIPTION
**ATTENTION**: this is blocking all the incoming PRs because we have a problem with the current tester image.

**What type of PR is this?**

/kind failing-test

**Any specific area of the project related to this PR?**

/area build
/area tests

**What this PR does / why we need it**:

Does two things:

- Introduces a new framework to run tests from packages directly in containers, one can add more instructions to the entrypoint to test to more different distributions
- Fixes the recent problems in building using the docker local image that was lacking the binutils dependency (and that was not needed for the tests)

**Which issue(s) this PR fixes**:

Fixes #1013 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
test: integration tests now can run on different distributions via docker containers, for now CentOS 7 and Ubuntu 18.04 with respective rpm and deb packages
```
