### PR TITLE
feat(userspace): Add `banned.h` which includes banned functions.

### DIFF
--- a/userspace/engine/banned.h
+++ b/userspace/engine/banned.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2019 The Falco Authors
+Copyright (C) 2019 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,22 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "utils.h"
-#include "banned.h"
+#pragma once
 
-void falco::utils::read(const std::string& filename, std::string& data)
-{
-	std::ifstream file(filename.c_str(), std::ios::in);
+// BAN macro defines `function` as an invalid token that says using
+// the function is banned. This throws a compile time error when the
+// function is used.
+#define BAN(function) using_##function##_is_banned
 
-	if(file.is_open())
-	{
-		std::stringstream ss;
-		ss << file.rdbuf();
-
-		file.close();
-
-		data = ss.str();
-	}
-
-	return;
-}
+#undef strcpy
+#define strcpy(a, b) BAN(strcpy)

--- a/userspace/engine/falco_common.cpp
+++ b/userspace/engine/falco_common.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "config_falco_engine.h"
 #include "falco_common.h"
+#include "banned.h"
 
 std::vector<std::string> falco_common::priority_names = {
 	"Emergency",
@@ -117,4 +118,3 @@ void falco_common::add_lua_path(string &path)
 
 	lua_pop(m_ls, 1);
 }
-

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -32,6 +32,7 @@ extern "C" {
 }
 
 #include "utils.h"
+#include "banned.h"
 
 
 string lua_on_event = "on_event";

--- a/userspace/engine/falco_utils.cpp
+++ b/userspace/engine/falco_utils.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 */
 
 #include "falco_utils.h"
+#include "banned.h"
 
 namespace falco
 {

--- a/userspace/engine/formats.cpp
+++ b/userspace/engine/formats.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "formats.h"
 #include "falco_engine.h"
+#include "banned.h"
 
 
 sinsp* falco_formats::s_inspector = NULL;

--- a/userspace/engine/json_evt.cpp
+++ b/userspace/engine/json_evt.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include "falco_common.h"
 #include "json_evt.h"
+#include "banned.h"
 
 using json = nlohmann::json;
 using namespace std;

--- a/userspace/engine/rules.cpp
+++ b/userspace/engine/rules.cpp
@@ -24,6 +24,8 @@ extern "C" {
 }
 
 #include "falco_engine.h"
+#include "banned.h"
+
 const static struct luaL_reg ll_falco_rules [] =
 {
 	{"clear_filters", &falco_rules::clear_filters},
@@ -480,4 +482,3 @@ falco_rules::~falco_rules()
 	delete m_sinsp_lua_parser;
 	delete m_json_lua_parser;
 }
-

--- a/userspace/engine/ruleset.cpp
+++ b/userspace/engine/ruleset.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include "ruleset.h"
+#include "banned.h"
 
 using namespace std;
 

--- a/userspace/engine/token_bucket.cpp
+++ b/userspace/engine/token_bucket.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "token_bucket.h"
 #include "utils.h"
+#include "banned.h"
 
 token_bucket::token_bucket():
 	token_bucket(sinsp_utils::get_current_time_ns)

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 
 #include "configuration.h"
 #include "logger.h"
+#include "banned.h"
 
 using namespace std;
 

--- a/userspace/falco/event_drops.cpp
+++ b/userspace/falco/event_drops.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include "event_drops.h"
+#include "banned.h"
 
 syscall_evt_drop_mgr::syscall_evt_drop_mgr():
 	m_num_syscall_evt_drops(0),

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -45,6 +45,7 @@ limitations under the License.
 #include "statsfilewriter.h"
 #include "webserver.h"
 #include "grpc_server.h"
+#include "banned.h"
 
 typedef function<void(sinsp* inspector)> open_t;
 
@@ -895,7 +896,7 @@ int falco_init(int argc, char **argv)
 			printf("%s\n", support.dump().c_str());
 			goto exit;
 		}
-		
+
 		// read hostname
 		string hostname;
 		if(char* env_hostname = getenv("FALCO_GRPC_HOSTNAME"))

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include "formats.h"
 #include "logger.h"
 #include "falco_output_queue.h"
+#include "banned.h"
 
 using namespace std;
 using namespace falco::output;

--- a/userspace/falco/grpc_context.cpp
+++ b/userspace/falco/grpc_context.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include <sstream>
 
 #include "grpc_context.h"
+#include "banned.h"
 
 falco::grpc::context::context(::grpc::ServerContext* ctx):
 	m_ctx(ctx)

--- a/userspace/falco/grpc_server.cpp
+++ b/userspace/falco/grpc_server.cpp
@@ -24,6 +24,7 @@ limitations under the License.
 #include "grpc_server.h"
 #include "grpc_context.h"
 #include "utils.h"
+#include "banned.h"
 
 #define REGISTER_STREAM(req, res, svc, rpc, impl, num)                                  \
 	std::vector<request_stream_context<req, res>> rpc##_contexts(num);         \

--- a/userspace/falco/grpc_server_impl.cpp
+++ b/userspace/falco/grpc_server_impl.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include "grpc_server_impl.h"
 #include "falco_output_queue.h"
+#include "banned.h"
 
 bool falco::grpc::server_impl::is_running()
 {

--- a/userspace/falco/logger.cpp
+++ b/userspace/falco/logger.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include "chisel_api.h"
 
 #include "falco_common.h"
+#include "banned.h"
 
 const static struct luaL_reg ll_falco [] =
 {
@@ -158,5 +159,3 @@ void falco_logger::log(int priority, const string msg)
 		}
 	}
 }
-
-

--- a/userspace/falco/statsfilewriter.cpp
+++ b/userspace/falco/statsfilewriter.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <signal.h>
 
 #include "statsfilewriter.h"
+#include "banned.h"
 
 using namespace std;
 

--- a/userspace/falco/webserver.cpp
+++ b/userspace/falco/webserver.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 #include "falco_common.h"
 #include "webserver.h"
 #include "json_evt.h"
+#include "banned.h"
 
 using json = nlohmann::json;
 using namespace std;


### PR DESCRIPTION
This defines certain functions as invalid tokens, i.e., when
compiled, the compiler throws an error.

Currently only `strcpy` is included as a banned function.

/kind feature

Fixes #788

```release-note
NONE
```
