### PR TITLE
Base64 format fix

### DIFF
--- a/userspace/engine/formats.cpp
+++ b/userspace/engine/formats.cpp
@@ -145,11 +145,13 @@ int falco_formats::format_event (lua_State *ls)
 	if(strcmp(source, "syscall") == 0)
 	{
 		try {
+			// This is "output"
 			s_formatters->tostring((sinsp_evt *) evt, sformat, &line);
 
 			if(s_json_output)
 			{
-				switch(s_inspector->get_buffer_format())
+				sinsp_evt::param_fmt cur_fmt = s_inspector->get_buffer_format();
+				switch(cur_fmt)
 				{
 					case sinsp_evt::PF_NORMAL:
 						s_inspector->set_buffer_format(sinsp_evt::PF_JSON);
@@ -170,6 +172,7 @@ int falco_formats::format_event (lua_State *ls)
 						// do nothing
 						break;
 				}
+				// This is output fields
 				s_formatters->tostring((sinsp_evt *) evt, sformat, &json_line);
 
 				// The formatted string might have a leading newline. If it does, remove it.
@@ -177,8 +180,7 @@ int falco_formats::format_event (lua_State *ls)
 				{
 					json_line.erase(0, 1);
 				}
-
-				s_inspector->set_buffer_format(sinsp_evt::PF_NORMAL);
+				s_inspector->set_buffer_format(cur_fmt);
 			}
 		}
 		catch (sinsp_exception& e)


### PR DESCRIPTION


**What type of PR is this?**

/kind bug



**Any specific area of the project related to this PR?**


/area engine


**What this PR does / why we need it**:

This PR deprecates PR #988 fixing the issue with base64 format (with/without json enabled).

**Which issue(s) this PR fixes**:

Fixes #987 


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:



```release-note
fix: the base64 output format (-b) now works with both json and normal output.
```
