### PR TITLE
Add more functions to `banned.h`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@
   - [Pull Requests](#pull-requests)
     - [Commit convention](#commit-convention)
       - [Rule type](#rule-type)
+  - [Coding Guidelines](#coding-guidelines)
+    - [C++](#c)
   - [Developer Certificate Of Origin](#developer-certificate-of-origin)
 
 ## Code of Conduct
@@ -120,6 +122,13 @@ If you are changing only a macro, the commit will look like this:
 rule(macro user_known_write_monitored_dir_conditions): make sure conditions are great
 ```
 
+## Coding Guidelines
+
+### C++
+
+* File `userspace/engine/banned.h` defines some functions as invalid tokens. These functions are not allowed to be used in the codebase. Whenever creating a new cpp file, include the `"banned.h"` headers. This ensures that the banned functions are not compiled.
+
+  A complete list of banned functions can be found [here](./userspace/engine/banned.h).
 
 ## Developer Certificate Of Origin
 

--- a/userspace/engine/banned.h
+++ b/userspace/engine/banned.h
@@ -23,3 +23,24 @@ limitations under the License.
 
 #undef strcpy
 #define strcpy(a, b) BAN(strcpy)
+
+#undef vsprintf
+#define vsprintf(a, b, c) BAN(vsprintf)
+
+#undef sprintf
+#define sprintf(a, b, ...) BAN(sprintf)
+
+#undef strcat
+#define strcat(a, b) BAN(strcat)
+
+#undef strncat
+#define strncat(a, b, c) BAN(strncat)
+
+#undef strncpy
+#define strncpy(a, b, c) BAN(strncpy)
+
+#undef swprintf
+#define swprintf(a, b, c, ...) BAN(swprintf)
+
+#undef vswprintf
+#define vswprintf(a, b, c, d) BAN(vswprintf)

--- a/userspace/engine/banned.h
+++ b/userspace/engine/banned.h
@@ -21,14 +21,18 @@ limitations under the License.
 // function is used.
 #define BAN(function) using_##function##_is_banned
 
+// BAN_ALTERNATIVE is same as BAN but the message also provides an alternative
+// function that the user could use instead of the banned function.
+#define BAN_ALTERNATIVE(function, alternative) using_##function##_is_banned__use_##alternative##_instead
+
 #undef strcpy
 #define strcpy(a, b) BAN(strcpy)
 
 #undef vsprintf
-#define vsprintf(a, b, c) BAN(vsprintf)
+#define vsprintf(a, b, c) BAN_ALTERNATIVE(vsprintf, vsnprintf)
 
 #undef sprintf
-#define sprintf(a, b, ...) BAN(sprintf)
+#define sprintf(a, b, ...) BAN_ALTERNATIVE(sprintf, snprintf)
 
 #undef strcat
 #define strcat(a, b) BAN(strcat)
@@ -40,7 +44,7 @@ limitations under the License.
 #define strncpy(a, b, c) BAN(strncpy)
 
 #undef swprintf
-#define swprintf(a, b, c, ...) BAN(swprintf)
+#define swprintf(a, b, c, ...) BAN_ALTERNATIVE(swprintf, snprintf)
 
 #undef vswprintf
-#define vswprintf(a, b, c, d) BAN(vswprintf)
+#define vswprintf(a, b, c, d) BAN_ALTERNATIVE(vswprintf, vsnprintf)

--- a/userspace/engine/falco_common.cpp
+++ b/userspace/engine/falco_common.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 
 #include "config_falco_engine.h"
 #include "falco_common.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 std::vector<std::string> falco_common::priority_names = {
 	"Emergency",

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -32,7 +32,7 @@ extern "C" {
 }
 
 #include "utils.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 
 string lua_on_event = "on_event";

--- a/userspace/engine/falco_utils.cpp
+++ b/userspace/engine/falco_utils.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 */
 
 #include "falco_utils.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 namespace falco
 {

--- a/userspace/engine/formats.cpp
+++ b/userspace/engine/formats.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 
 #include "formats.h"
 #include "falco_engine.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 
 sinsp* falco_formats::s_inspector = NULL;

--- a/userspace/engine/json_evt.cpp
+++ b/userspace/engine/json_evt.cpp
@@ -21,7 +21,7 @@ limitations under the License.
 
 #include "falco_common.h"
 #include "json_evt.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 using json = nlohmann::json;
 using namespace std;

--- a/userspace/engine/rules.cpp
+++ b/userspace/engine/rules.cpp
@@ -24,7 +24,7 @@ extern "C" {
 }
 
 #include "falco_engine.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 const static struct luaL_reg ll_falco_rules [] =
 {

--- a/userspace/engine/ruleset.cpp
+++ b/userspace/engine/ruleset.cpp
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include "ruleset.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 using namespace std;
 

--- a/userspace/engine/token_bucket.cpp
+++ b/userspace/engine/token_bucket.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 
 #include "token_bucket.h"
 #include "utils.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 token_bucket::token_bucket():
 	token_bucket(sinsp_utils::get_current_time_ns)

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 
 #include "configuration.h"
 #include "logger.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 using namespace std;
 

--- a/userspace/falco/event_drops.cpp
+++ b/userspace/falco/event_drops.cpp
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include "event_drops.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 syscall_evt_drop_mgr::syscall_evt_drop_mgr():
 	m_num_syscall_evt_drops(0),

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -45,7 +45,7 @@ limitations under the License.
 #include "statsfilewriter.h"
 #include "webserver.h"
 #include "grpc_server.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 typedef function<void(sinsp* inspector)> open_t;
 

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 #include "formats.h"
 #include "logger.h"
 #include "falco_output_queue.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 using namespace std;
 using namespace falco::output;

--- a/userspace/falco/grpc_context.cpp
+++ b/userspace/falco/grpc_context.cpp
@@ -17,7 +17,7 @@ limitations under the License.
 #include <sstream>
 
 #include "grpc_context.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 falco::grpc::context::context(::grpc::ServerContext* ctx):
 	m_ctx(ctx)

--- a/userspace/falco/grpc_server.cpp
+++ b/userspace/falco/grpc_server.cpp
@@ -24,7 +24,7 @@ limitations under the License.
 #include "grpc_server.h"
 #include "grpc_context.h"
 #include "utils.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 #define REGISTER_STREAM(req, res, svc, rpc, impl, num)                                  \
 	std::vector<request_stream_context<req, res>> rpc##_contexts(num);         \

--- a/userspace/falco/grpc_server_impl.cpp
+++ b/userspace/falco/grpc_server_impl.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "grpc_server_impl.h"
 #include "falco_output_queue.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 bool falco::grpc::server_impl::is_running()
 {

--- a/userspace/falco/logger.cpp
+++ b/userspace/falco/logger.cpp
@@ -131,12 +131,8 @@ void falco_logger::log(int priority, const string msg)
 		{
 			char buf[sizeof "YYYY-MM-DDTHH:MM:SS-0000"];
 			struct tm *gtm = std::gmtime(&result);
-			if(gtm == NULL ||
-			   (strftime(buf, sizeof(buf), "%FT%T%z", gtm) == 0))
-			{
-				sprintf(buf, "N/A");
-			}
-			else
+			if(gtm != NULL &&
+			   (strftime(buf, sizeof(buf), "%FT%T%z", gtm) != 0))
 			{
 				fprintf(stderr, "%s: %s", buf, msg.c_str());
 			}

--- a/userspace/falco/logger.cpp
+++ b/userspace/falco/logger.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 #include "chisel_api.h"
 
 #include "falco_common.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 const static struct luaL_reg ll_falco [] =
 {

--- a/userspace/falco/statsfilewriter.cpp
+++ b/userspace/falco/statsfilewriter.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 #include <signal.h>
 
 #include "statsfilewriter.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 using namespace std;
 

--- a/userspace/falco/utils.cpp
+++ b/userspace/falco/utils.cpp
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include "utils.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 void falco::utils::read(const std::string& filename, std::string& data)
 {

--- a/userspace/falco/webserver.cpp
+++ b/userspace/falco/webserver.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 #include "falco_common.h"
 #include "webserver.h"
 #include "json_evt.h"
-#include "banned.h"
+#include "banned.h" // This raises a compilation error when certain functions are used
 
 using json = nlohmann::json;
 using namespace std;


### PR DESCRIPTION
These include:
* vsprintf()
* sprintf()
* strcat()
* strncat()
* strncpy()

This also changes `userspace/falco/logger.cpp` to remove a `sprintf`
statement. The statement did not affect the codebase in any form so
it was simply removed rather than being substituted.

Also adds `BAN_ALTERNATIVE` macro to `banned.h`. BAN_ALTERNATIVE is same as BAN but the message also provides an alternative function that the user could use instead of the banned function.

Fixes #1035

/kind feature

```release-note
NONE
```