### PR TITLE
Fix memory leaks in k8s audit and json events

### DIFF
--- a/userspace/engine/json_evt.cpp
+++ b/userspace/engine/json_evt.cpp
@@ -512,31 +512,27 @@ const json_event_filter_check::values_t &json_event_filter_check::extracted_valu
 
 bool json_event_filter_check::compare(gen_event *evt)
 {
-	json_event *jevt = (json_event *)evt;
+	auto jevt = (json_event *)evt;
 
 	uint32_t len;
 
-	const extracted_values_t *evalues = (const extracted_values_t *) extract(jevt, &len);
+	auto evalues = (const extracted_values_t *) extract(jevt, &len);
 	values_set_t setvals;
 
 	switch(m_cmpop)
 	{
 	case CO_EQ:
 		return evalues->second == m_values;
-		break;
 	case CO_NE:
 		return evalues->second != m_values;
-		break;
 	case CO_STARTSWITH:
 		return (evalues->first.size() == 1 &&
 			m_values.size() == 1 &&
 			evalues->first.at(0).startswith(*(m_values.begin())));
-		break;
 	case CO_CONTAINS:
 		return (evalues->first.size() == 1 &&
 			m_values.size() == 1 &&
 			evalues->first.at(0).contains(*(m_values.begin())));
-		break;
 	case CO_IN:
 		for(auto &item : evalues->second)
 		{
@@ -546,7 +542,6 @@ bool json_event_filter_check::compare(gen_event *evt)
 			}
 		}
 		return true;
-		break;
 	case CO_PMATCH:
 		for(auto &item : evalues->second)
 		{
@@ -559,19 +554,16 @@ bool json_event_filter_check::compare(gen_event *evt)
 			}
 		}
 		return true;
-		break;
 	case CO_INTERSECTS:
 		std::set_intersection(evalues->second.begin(), evalues->second.end(),
 				      m_values.begin(), m_values.end(),
 				      std::inserter(setvals, setvals.begin()));
-		return (setvals.size() > 0);
-		break;
+		return (!setvals.empty());
 	case CO_LT:
 		return (evalues->first.size() == 1 &&
 			m_values.size() == 1 &&
 			evalues->first.at(0).ptype() == m_values.begin()->ptype() &&
 			evalues->first.at(0) < *(m_values.begin()));
-		break;
 	case CO_LE:
 		return (evalues->first.size() == 1 &&
 			m_values.size() == 1 &&
@@ -589,11 +581,9 @@ bool json_event_filter_check::compare(gen_event *evt)
 			evalues->first.at(0).ptype() == m_values.begin()->ptype() &&
 			(evalues->first.at(0) > *(m_values.begin()) ||
 			 evalues->first.at(0) == *(m_values.begin())));
-		break;
 	case CO_EXISTS:
 		return (evalues->first.size() == 1 &&
 			(evalues->first.at(0) != json_event_filter_check::no_value));
-		break;
 	default:
 		throw falco_exception("filter error: unsupported comparison operator");
 	}

--- a/userspace/engine/json_evt.h
+++ b/userspace/engine/json_evt.h
@@ -193,7 +193,6 @@ public:
 	const values_t &extracted_values();
 
 protected:
-
 	// Subclasses can override this method, calling
 	// add_extracted_value to add extracted values.
 	virtual bool extract_values(json_event *jevt);
@@ -293,7 +292,7 @@ public:
 	jevt_filter_check();
 	virtual ~jevt_filter_check();
 
-        int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) final;
+	int32_t parse_field_name(const char* str, bool alloc_state, bool needed_for_filtering) final;
 
 	json_event_filter_check *allocate_new();
 

--- a/userspace/engine/json_evt.h
+++ b/userspace/engine/json_evt.h
@@ -282,7 +282,8 @@ private:
 
 	// If true, this filtercheck works on paths, which enables
 	// some extra bookkeeping to allow for path prefix searches.
-	bool m_uses_paths;
+	bool m_uses_paths = false;
+
 	path_prefix_search m_prefix_search;
 };
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Fixes the memory leak bug reported by many users on the Falco slack.

WRT I started doing some memory analysis on my dev environment and noticed a pattern I didn’t like:

All the snapshots I was able to take were showing a linear increase in memory usage

![image](https://user-images.githubusercontent.com/3083633/73941735-13cf7200-48ee-11ea-859f-e64285086e49.png)




Here’s an evidence of the leak, in how audit events are processed.

![image](https://user-images.githubusercontent.com/3083633/73941751-18942600-48ee-11ea-8b30-aad366c3ad39.png)




The problem I observed is that whenever the add_extracted_value function (https://github.com/falcosecurity/falco/blob/master/userspace/engine/json_evt.cpp#L629-L639) is called it adds an element to a list of strings. After that, old elements are never flushed. That leads to the memory leak we can see in the massif output above.




After some debugging, I noticed that add_extracted_value was only called when json_event_filter_check has m_uses_paths set to true. However, that value is never explicitly set to true in that codebase.

Then I noticed that whenever a new filtercheck is created (code : https://github.com/falcosecurity/falco/blob/master/userspace/engine/json_evt.cpp#L1379) the function allocate_new is called.

However, the created filter check does not contain false as a value for m_uses_paths but a numerical value. The reason for this is that while doing type conversion.
And since in C++ only zero is false and everything else is true that’s why we call add_extracted and have the memory leak.

This is the situation after my fix, as you can see the memory is pretty much always allocated and immediately released after processing.

![image](https://user-images.githubusercontent.com/3083633/73941649-ee426880-48ed-11ea-81b2-fede87aae748.png)


**Which issue(s) this PR fixes**:

Fixes #1040

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
fix: memory leak introduced in 0.18.0 happening while using json events and the kubernetes audit endpoint
```
