### PR TITLE
Support for Kubernetes >= 1.16

### DIFF
--- a/integrations/k8s-using-daemonset/falco-event-generator-deployment.yaml
+++ b/integrations/k8s-using-daemonset/falco-event-generator-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: falco-event-generator-deployment

--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-account.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-account.yaml
@@ -7,7 +7,7 @@ metadata:
     role: security
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: falco-cluster-role
   labels:
@@ -21,7 +21,7 @@ rules:
     verbs: ["get"]
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: falco-cluster-role-binding
   namespace: default

--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap-slim.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap-slim.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: falco-daemonset
@@ -6,6 +6,10 @@ metadata:
     app: falco-example
     role: security
 spec:
+  selector:
+    matchLabels:
+      app: falco-example
+      role: security
   template:
     metadata:
       labels:

--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: falco-daemonset
@@ -6,6 +6,10 @@ metadata:
     app: falco-example
     role: security
 spec:
+  selector:
+    matchLabels:
+      app: falco-example
+      role: security
   template:
     metadata:
       labels:

--- a/integrations/k8s-using-daemonset/k8s-without-rbac/falco-daemonset.yaml
+++ b/integrations/k8s-using-daemonset/k8s-without-rbac/falco-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: falco
@@ -6,6 +6,11 @@ metadata:
     name: falco-daemonset
     app: demo
 spec:
+  selector:
+    matchLabels:
+      name: falco
+      app: demo
+      role: security
   template:
     metadata:
       labels:

--- a/integrations/k8s-using-deployment/falco-event-generator-deployment.yaml
+++ b/integrations/k8s-using-deployment/falco-event-generator-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: falco-event-generator-deployment

--- a/integrations/k8s-using-deployment/k8s-with-rbac/falco-k8s-audit-account.yaml
+++ b/integrations/k8s-using-deployment/k8s-with-rbac/falco-k8s-audit-account.yaml
@@ -7,7 +7,7 @@ metadata:
     role: security
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: falco-cluster-role
   labels:
@@ -21,7 +21,7 @@ rules:
     verbs: ["get"]
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: falco-cluster-role-binding
   namespace: default

--- a/integrations/k8s-using-deployment/k8s-with-rbac/falco-k8s-audit-deployment.yaml
+++ b/integrations/k8s-using-deployment/k8s-with-rbac/falco-k8s-audit-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: falco-k8s-audit


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area kubernetes

**What this PR does / why we need it**:

Support for Kubernetes 1.16 and 1.17 when deployed as DaemonSet.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1043
Fixes #993 

**Special notes for your reviewer**:

Removed deprecated Kubernetes 1.16 API resource versions.

Affected API:
- DaemonSet
- Deployment
- ClusterRole
- ClusterRoleBinding

Documentation:
- https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals
- https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.17.md#deprecations-and-removals

**Does this PR introduce a user-facing change?**:

NONE

**Release note**

```release-note
docs(integrations): update API resource versions to Kubernetes 1.16
```