### PR TITLE
Rename BPF_PROBE and SYSDIG_BPF_PROBE to FALCO_BPF_PROBE and make the variable consistent

### DIFF
--- a/cmake/modules/sysdig-repo/CMakeLists.txt
+++ b/cmake/modules/sysdig-repo/CMakeLists.txt
@@ -31,4 +31,5 @@ ExternalProject_Add(
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
-  TEST_COMMAND "")
+  TEST_COMMAND ""
+  PATCH_COMMAND patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/patch/libscap.patch)

--- a/cmake/modules/sysdig-repo/patch/libscap.patch
+++ b/cmake/modules/sysdig-repo/patch/libscap.patch
@@ -1,0 +1,22 @@
+diff --git a/userspace/libscap/scap.c b/userspace/libscap/scap.c
+index 59b04e0a..bdc311cb 100644
+--- a/userspace/libscap/scap.c
++++ b/userspace/libscap/scap.c
+@@ -52,7 +52,7 @@ limitations under the License.
+ //#define NDEBUG
+ #include <assert.h>
+ 
+-static const char *SYSDIG_BPF_PROBE_ENV = "SYSDIG_BPF_PROBE";
++static const char *SYSDIG_BPF_PROBE_ENV = "FALCO_BPF_PROBE";
+ 
+ //
+ // Probe version string size
+@@ -171,7 +171,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
+ 				return NULL;
+ 			}
+ 
+-			snprintf(buf, sizeof(buf), "%s/.sysdig/%s-bpf.o", home, PROBE_NAME);
++			snprintf(buf, sizeof(buf), "%s/.falco/%s-bpf.o", home, PROBE_NAME);
+ 			bpf_probe = buf;
+ 		}
+ 	}

--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap-slim.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap-slim.yaml
@@ -39,7 +39,7 @@ spec:
 # Leave blank for the default probe location, or set to the path
 # of a precompiled probe.
 #          env:
-#          - name: BPF_PROBE
+#          - name: FALCO_BPF_PROBE
 #            value: ""
           args: [ "/usr/bin/falco", "--cri", "/host/run/containerd/containerd.sock", "-K", "/var/run/secrets/kubernetes.io/serviceaccount/token", "-k", "https://$(KUBERNETES_SERVICE_HOST)", "-pk"]
           volumeMounts:

--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
@@ -23,7 +23,7 @@ spec:
 # Leave blank for the default probe location, or set to the path
 # of a precompiled probe.
 #          env:
-#          - name: BPF_PROBE
+#          - name: FALCO_BPF_PROBE
 #            value: ""
           args: [ "/usr/bin/falco", "--cri", "/host/run/containerd/containerd.sock", "-K", "/var/run/secrets/kubernetes.io/serviceaccount/token", "-k", "https://$(KUBERNETES_SERVICE_HOST)", "-pk"]
           volumeMounts:

--- a/scripts/falco-probe-loader
+++ b/scripts/falco-probe-loader
@@ -350,7 +350,7 @@ load_bpf_probe() {
 			echo "**********************************************************"
 		fi
 
-		echo "* BPF probe located, it's now possible to start sysdig"
+		echo "* BPF probe located, it's now possible to start falco"
 
 		ln -sf "${HOME}/.falco/${BPF_PROBE_FILENAME}" "${HOME}/.falco/${BPF_PROBE_NAME}.o"
 		exit $?
@@ -402,7 +402,7 @@ if ! hash curl > /dev/null 2>&1; then
 	exit 1
 fi
 
-if [ -v BPF_PROBE ] || [ "${1}" = "bpf" ]; then
+if [ -v FALCO_BPF_PROBE ] || [ "${1}" = "bpf" ]; then
 	load_bpf_probe
 else
 	load_kernel_probe


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**
NONE

**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:

Fixes #1049

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
BREAKING CHANGE: the SYSDIG_BPF_PROBE environment variable is now just BPF_PROBE (please update your systemd scripts or kubernetes deployments. 
```


# todo for the merge

- [x] Update the docs - [done](https://github.com/falcosecurity/falco-website/pull/134)
- [ ] Update helm charts
- [ ] Update falcoctl [here](https://github.com/falcosecurity/falcoctl/blob/b0d030c15ccaefb93d4a5b916f5e2e81b74a15ae/pkg/kubernetes/falco.go)