### PR TITLE
Verify checksum after downloading sysdig tarball

### DIFF
--- a/cmake/modules/sysdig-repo/CMakeLists.txt
+++ b/cmake/modules/sysdig-repo/CMakeLists.txt
@@ -22,12 +22,13 @@ include(ExternalProject)
 # In case you want to test against another sysdig version just pass the variable - ie., `cmake -DSYSDIG_VERSION=dev ..`
 if(NOT SYSDIG_VERSION)
   set(SYSDIG_VERSION "146a431edf95829ac11bfd9c85ba3ef08789bffe")
+  set(SYSDIG_CHECKSUM "SHA256=6e477ac5fe9d3110b870bd4495f01541373a008c375a1934a2d1c46798b6bad6")
 endif()
 
 ExternalProject_Add(
   sysdig
   URL "https://github.com/draios/sysdig/archive/${SYSDIG_VERSION}.tar.gz"
-  # URL_HASH SHA256=bd09607aa8beb863db07e695863f7dc543e2d39e7153005759d26a340ff66fa5
+  URL_HASH "${SYSDIG_CHECKSUM}"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""

--- a/cmake/modules/sysdig.cmake
+++ b/cmake/modules/sysdig.cmake
@@ -22,7 +22,7 @@ endif()
 
 file(MAKE_DIRECTORY ${SYSDIG_CMAKE_WORKING_DIR})
 # cd /path/to/build && cmake /path/to/source
-execute_process(COMMAND "${CMAKE_COMMAND}" ${SYSDIG_CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${SYSDIG_CMAKE_WORKING_DIR})
+execute_process(COMMAND "${CMAKE_COMMAND}" -DSYSDIG_VERSION=${SYSDIG_VERSION} ${SYSDIG_CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${SYSDIG_CMAKE_WORKING_DIR})
 
 # todo(leodido, fntlnz) > use the following one when CMake version will be >= 3.13
 


### PR DESCRIPTION
Also it seemed that any of value of -DSYSDIG_VERSION
failed to propagate, from first cmake to second cmake.

That is, trying to follow instructions didn't have any effect:
```Cmake
# To update sysdig version for the next release, change the default below
# In case you want to test against another sysdig version just pass the variable - ie., `cmake -DSYSDIG_VERSION=dev ..`
```
In the case of a custom version, the checksum is ignored.

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Avoids warning when building, and checks against corrupt download errors.

`warning: did not verify file - no URL_HASH specified?`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

The old commented out checksum is for some random `dev` version:

See 494edafdb19d7b3a6a432d89fbc31a6e82aa0ad6

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
