### PR TITLE
docker minimal images need exact FALCO_VERSION

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,8 @@ jobs:
     docker:
       - image: docker:stable
     steps:
+      - attach_workspace:
+          at: /
       - checkout
       - setup_remote_docker
       - run:
@@ -214,7 +216,8 @@ jobs:
       - run:
           name: Build and publish minimal-dev
           command: |
-            docker build --build-arg VERSION_BUCKET=bin-dev -t falcosecurity/falco:master-minimal docker/minimal
+            FALCO_VERSION=$(sed -e 's/^"//' -e 's/"$//' <<< $(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3))
+            docker build --build-arg VERSION_BUCKET=bin-dev FALCO_VERSION=${FALCO_VERSION} -t falcosecurity/falco:master-minimal docker/minimal
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
             docker push falcosecurity/falco:master-minimal
       - run:
@@ -257,6 +260,8 @@ jobs:
     docker:
       - image: docker:stable
     steps:
+      - attach_workspace:
+          at: /
       - checkout
       - setup_remote_docker
       - run:
@@ -270,7 +275,8 @@ jobs:
       - run:
           name: Build and publish minimal
           command: |
-            docker build --build-arg VERSION_BUCKET=bin -t "falcosecurity/falco:${CIRCLE_TAG}-minimal" docker/minimal
+            FALCO_VERSION=$(sed -e 's/^"//' -e 's/"$//' <<< $(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3))
+            docker build --build-arg VERSION_BUCKET=bin FALCO_VERSION=${FALCO_VERSION} -t "falcosecurity/falco:${CIRCLE_TAG}-minimal" docker/minimal
             docker tag "falcosecurity/falco:${CIRCLE_TAG}-minimal" falcosecurity/falco:latest-minimal
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
             docker push "falcosecurity/falco:${CIRCLE_TAG}-minimal"


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug





**Any specific area of the project related to this PR?**

/area build


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Since `minimal` docker images fetch the falco binary from `bin` or `bin-dev` repositories they need to explicitly set the `FALCO_VERSION` variable.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:



```release-note
NONE
```
