### PR TITLE
Add a macro to whitelist system binaries using the network

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2007,13 +2007,18 @@
   condition: >
     (fd.sockfamily = ip and (system_procs or proc.name in (shell_binaries)))
     and (inbound_outbound)
-    and not proc.name in (systemd, hostid, id)
+    and not proc.name in (known_system_procs_network_activity_binaries)
     and not login_doing_dns_lookup
   output: >
     Known system binary sent/received network traffic
     (user=%user.name command=%proc.cmdline connection=%fd.name container_id=%container.id image=%container.image.repository)
   priority: NOTICE
   tags: [network, mitre_exfiltration]
+
+# This list allows easily whitelisting system proc names that are
+# expected to communicate on the network.
+- list: known_system_procs_network_activity_binaries
+  items: [systemd, hostid, id]
 
 # When filled in, this should look something like:
 # (proc.env contains "HTTP_PROXY=http://my.http.proxy.com ")

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2009,6 +2009,7 @@
     and (inbound_outbound)
     and not proc.name in (known_system_procs_network_activity_binaries)
     and not login_doing_dns_lookup
+    and not user_expected_system_procs_network_activity_conditions
   output: >
     Known system binary sent/received network traffic
     (user=%user.name command=%proc.cmdline connection=%fd.name container_id=%container.id image=%container.image.repository)
@@ -2019,6 +2020,13 @@
 # expected to communicate on the network.
 - list: known_system_procs_network_activity_binaries
   items: [systemd, hostid, id]
+
+# This macro allows specifying conditions under which a system binary
+# is allowed to communicate on the network. For instance, only specific
+# proc.cmdline values could be allowed to be more granular in what is
+# allowed.
+- macro: user_expected_system_procs_network_activity_conditions
+  condition: (never_true)
 
 # When filled in, this should look something like:
 # (proc.env contains "HTTP_PROXY=http://my.http.proxy.com ")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

This PR introduces two things : a list of allowed system binaries and a macro to allow certain system binaries to use the network under certain conditions.

The list is really just for convenience and is not meant to be overridden by users. It's something I noticed many other rules had and I figured it wouldn't hurt to add it here while I was adding the macro.

The macro is useful because someone might want to allow certain system procs to use the network under certain conditions. Our use-case is that we use a program output which publishes a message to an SNS topic in AWS to be picked up by our other tools. To do this, we use AWS CLI, which obviously needs to talk to the network. The issue is that Falco runs the command `sh -c aws cli ...` and that raises an event because `sh` is a shell binary. The macro resolves this because it allows us to whitelist the command we use (instead of whitelisting the entire `sh` binary).

**Which issue(s) this PR fixes**:

No issues open for this.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Add a macro to allow whitelisting system binaries using the network under specific conditions
```
