### PR TITLE
build: PROBE_VERSION must use the driver version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,6 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fno-strict-aliasing -DNDEBUG")
 include(GetFalcoVersion)
 
 set(PACKAGE_NAME "falco")
-set(PROBE_VERSION "${FALCO_VERSION}")
 set(PROBE_NAME "falco-probe")
 set(PROBE_DEVICE_NAME "falco")
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/cmake/modules/sysdig-repo/CMakeLists.txt
+++ b/cmake/modules/sysdig-repo/CMakeLists.txt
@@ -16,15 +16,6 @@ project(sysdig-repo NONE)
 
 include(ExternalProject)
 
-# The sysdig git reference (branch name, commit hash, or tag)
-
-# To update sysdig version for the next release, change the default below
-# In case you want to test against another sysdig version just pass the variable - ie., `cmake -DSYSDIG_VERSION=dev ..`
-if(NOT SYSDIG_VERSION)
-  set(SYSDIG_VERSION "146a431edf95829ac11bfd9c85ba3ef08789bffe")
-  set(SYSDIG_CHECKSUM "SHA256=6e477ac5fe9d3110b870bd4495f01541373a008c375a1934a2d1c46798b6bad6")
-endif()
-
 ExternalProject_Add(
   sysdig
   URL "https://github.com/draios/sysdig/archive/${SYSDIG_VERSION}.tar.gz"

--- a/cmake/modules/sysdig-repo/CMakeLists.txt
+++ b/cmake/modules/sysdig-repo/CMakeLists.txt
@@ -15,6 +15,7 @@ cmake_minimum_required(VERSION 3.5.1)
 project(sysdig-repo NONE)
 
 include(ExternalProject)
+message(STATUS "Driver version: ${SYSDIG_VERSION}")
 
 ExternalProject_Add(
   sysdig

--- a/cmake/modules/sysdig.cmake
+++ b/cmake/modules/sysdig.cmake
@@ -21,8 +21,19 @@ if(USE_BUNDLED_DEPS)
 endif()
 
 file(MAKE_DIRECTORY ${SYSDIG_CMAKE_WORKING_DIR})
+
+# The sysdig git reference (branch name, commit hash, or tag)
+# To update sysdig version for the next release, change the default below
+# In case you want to test against another sysdig version just pass the variable - ie., `cmake -DSYSDIG_VERSION=dev ..`
+if(NOT SYSDIG_VERSION)
+  set(SYSDIG_VERSION "be1ea2d9482d0e6e2cb14a0fd7e08cbecf517f94")
+  set(SYSDIG_CHECKSUM "SHA256=6e477ac5fe9d3110b870bd4495f01541373a008c375a1934a2d1c46798b6bad6")
+endif()
+set(PROBE_VERSION "${SYSDIG_VERSION}")
+
 # cd /path/to/build && cmake /path/to/source
 execute_process(COMMAND "${CMAKE_COMMAND}" -DSYSDIG_VERSION=${SYSDIG_VERSION} ${SYSDIG_CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${SYSDIG_CMAKE_WORKING_DIR})
+
 
 # todo(leodido, fntlnz) > use the following one when CMake version will be >= 3.13
 

--- a/cmake/modules/sysdig.cmake
+++ b/cmake/modules/sysdig.cmake
@@ -27,12 +27,12 @@ file(MAKE_DIRECTORY ${SYSDIG_CMAKE_WORKING_DIR})
 # In case you want to test against another sysdig version just pass the variable - ie., `cmake -DSYSDIG_VERSION=dev ..`
 if(NOT SYSDIG_VERSION)
   set(SYSDIG_VERSION "be1ea2d9482d0e6e2cb14a0fd7e08cbecf517f94")
-  set(SYSDIG_CHECKSUM "SHA256=6e477ac5fe9d3110b870bd4495f01541373a008c375a1934a2d1c46798b6bad6")
+  set(SYSDIG_CHECKSUM "SHA256=1c69363e4c36cdaeed413c2ef557af53bfc4bf1109fbcb6d6e18dc40fe6ddec8")
 endif()
 set(PROBE_VERSION "${SYSDIG_VERSION}")
 
 # cd /path/to/build && cmake /path/to/source
-execute_process(COMMAND "${CMAKE_COMMAND}" -DSYSDIG_VERSION=${SYSDIG_VERSION} ${SYSDIG_CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${SYSDIG_CMAKE_WORKING_DIR})
+execute_process(COMMAND "${CMAKE_COMMAND}" -DSYSDIG_VERSION=${SYSDIG_VERSION} -DSYSDIG_CHECKSUM=${SYSDIG_CHECKSUM} ${SYSDIG_CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${SYSDIG_CMAKE_WORKING_DIR})
 
 
 # todo(leodido, fntlnz) > use the following one when CMake version will be >= 3.13


### PR DESCRIPTION
The driver version was also setup in the wrong cmake file.

Co-Authored-By: Leonardo Di Donato <leodidonato@gmail.com>
Signed-off-by: Lorenzo Fontana <lo@linux.com>

**What type of PR is this?**

/kind bug


**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Passing `-DSYSDIG_VERSION` to cmake was not loading the variable in the inner makefile that we use to download the sinsp, scap and the driver.
This was leading to broken builds when such variable was passed.

Moreover, `PROBE_VERSION` must be set to the same version as the driver, because they are two separate projects with different release lifecycles now that Sysdig and Falco are 100% decoupled from an infrastructure and code point of view.

Also we bumped the driver version to benefit from https://github.com/draios/sysdig/pull/1595
Fixes #1073 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix: the Falco driver now compiles on >= 5.4 kernels
```
