### PR TITLE
fix: use of "tag" instead of "tags" in default rules

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -450,7 +450,7 @@
     a shell configuration file has been modified (user=%user.name command=%proc.cmdline pcmdline=%proc.pcmdline file=%fd.name container_id=%container.id image=%container.image.repository)
   priority:
     WARNING
-  tag: [file, mitre_persistence]
+  tags: [file, mitre_persistence]
 
 # This rule is not enabled by default, as there are many legitimate
 # readers of shell config files. If you want to enable it, modify the
@@ -472,7 +472,7 @@
     a shell configuration file was read by a non-shell program (user=%user.name command=%proc.cmdline file=%fd.name container_id=%container.id image=%container.image.repository)
   priority:
     WARNING
-  tag: [file, mitre_discovery]
+  tags: [file, mitre_discovery]
 
 - macro: consider_all_cron_jobs
   condition: (never_true)
@@ -488,7 +488,7 @@
     file=%fd.name container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority:
     NOTICE
-  tag: [file, mitre_persistence]
+  tags: [file, mitre_persistence]
 
 # Use this to test whether the event occurred within a container.
 
@@ -2462,7 +2462,7 @@
     Shell history had been deleted or renamed (user=%user.name type=%evt.type command=%proc.cmdline fd.name=%fd.name name=%evt.arg.name path=%evt.arg.path oldpath=%evt.arg.oldpath %container.info)
   priority:
     WARNING
-  tag: [process, mitre_defense_evation]
+  tags: [process, mitre_defense_evation]
 
 # This rule is deprecated and will/should never be triggered. Keep it here for backport compatibility.
 # Rule Delete or rename shell history is the preferred rule to use now.
@@ -2475,7 +2475,7 @@
     Shell history had been deleted or renamed (user=%user.name type=%evt.type command=%proc.cmdline fd.name=%fd.name name=%evt.arg.name path=%evt.arg.path oldpath=%evt.arg.oldpath %container.info)
   priority:
     WARNING
-  tag: [process, mitre_defense_evation]
+  tags: [process, mitre_defense_evation]
 
 - macro: consider_all_chmods
   condition: (always_true)
@@ -2497,7 +2497,7 @@
     command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority:
     NOTICE
-  tag: [process, mitre_persistence]
+  tags: [process, mitre_persistence]
 
 - list: exclude_hidden_directories
   items: [/root/.cassandra]
@@ -2519,7 +2519,7 @@
     file=%fd.name newpath=%evt.arg.newpath container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority:
     NOTICE
-  tag: [file, mitre_persistence]
+  tags: [file, mitre_persistence]
 
 - list: remote_file_copy_binaries
   items: [rsync, scp, sftp, dcp]


### PR DESCRIPTION
Signed-off-by: Vicente Herrera <vicenteherrera@vicenteherrera.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area examples

/area rules

> /area integrations

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fix rules that used wrong 'tag' keyword to use the right one, 'tags'.

**Which issue(s) this PR fixes**:

Some rules where using 'tag' keyword instead of valid 'tags' keyword. That prevented using tags to filter them.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

After this change, when using command line switches -T to disable rules by certain tag, or -t to only run rules with a certain tag, a different set with more rules will match as now they are more rules correctly tagged.

**Does this PR introduce a user-facing change?**:

Yes

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix: -T (to disable rules by certain tag) or -t (to only run rules with a certain tag) work now
```
