### PR TITLE
Provide and parse FALCO_VERSION_PRERELEASE part

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ workflows:
           filters:
             branches:
               only:
-                - feature/version-prerelease
+                - master
           requires:
             - "tests/integration"
       - "publish/packages-dev":
@@ -313,7 +313,7 @@ workflows:
           filters:
             branches:
               only:
-                - feature/version-prerelease
+                - master
           requires:
             - "rpm/sign"
       - "publish/docker-dev":
@@ -321,7 +321,7 @@ workflows:
           filters:
             branches:
               only:
-                - feature/version-prerelease
+                - master
           requires:
             - "publish/packages-dev"
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - feature/version-prerelease
           requires:
             - "tests/integration"
       - "publish/packages-dev":
@@ -313,7 +313,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - feature/version-prerelease
           requires:
             - "rpm/sign"
       - "publish/docker-dev":
@@ -321,7 +321,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - feature/version-prerelease
           requires:
             - "publish/packages-dev"
   release:

--- a/docker/minimal/Dockerfile
+++ b/docker/minimal/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04 as ubuntu
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
-ARG FALCO_VERSION=0.20.0
+ARG FALCO_VERSION
 ARG VERSION_BUCKET=bin
 
 ENV FALCO_VERSION=${FALCO_VERSION}

--- a/docker/slim/Dockerfile
+++ b/docker/slim/Dockerfile
@@ -4,8 +4,10 @@ LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
 LABEL RUN="docker run -i -t -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --name <name> <image>"
 
+ARG FALCO_VERSION=latest
 ARG VERSION_BUCKET=deb
 
+ENV FALCO_VERSION=${FALCO_VERSION}
 ENV VERSION_BUCKET=${VERSION_BUCKET}
 
 ENV HOST_ROOT /host
@@ -28,7 +30,7 @@ RUN apt-get update \
 RUN curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | apt-key add - \
   && echo "deb https://dl.bintray.com/falcosecurity/${VERSION_BUCKET} stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list \
   && apt-get update -y \
-  && apt-get install -y --no-install-recommends falco \
+  && if [ "$FALCO_VERSION" = "latest" ]; then apt-get install -y --no-install-recommends falco; else apt-get install -y --no-install-recommends falco=${FALCO_VERSION}; fi \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -4,9 +4,11 @@ LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
 LABEL usage="docker run -i -t -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --name NAME IMAGE"
 
+ARG FALCO_VERSION=latest
 ARG VERSION_BUCKET=deb
 ENV VERSION_BUCKET=${VERSION_BUCKET}
 
+ENV FALCO_VERSION=${FALCO_VERSION}
 ENV HOST_ROOT /host
 ENV HOME /root
 
@@ -76,7 +78,7 @@ RUN rm -rf /usr/bin/clang \
 RUN curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | apt-key add - \
 	&& echo "deb https://dl.bintray.com/falcosecurity/${VERSION_BUCKET} stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list \
 	&& apt-get update -y \
-	&& apt-get install -y --no-install-recommends falco \
+	&& if [ "$FALCO_VERSION" = "latest" ]; then apt-get install -y --no-install-recommends falco; else apt-get install -y --no-install-recommends falco=${FALCO_VERSION}; fi \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
**What type of PR is this?**



/kind bug

/kind feature




**Any specific area of the project related to this PR?**


/area build


**What this PR does / why we need it**:

It makes the build generate the FALCO_VERSION_PRERELEASE variable, too.
It contains the count of the commits from the last tag on the master.

So versions, from now one will be something like `0.20.0-48+86e6fe3`, where 48 is the number of commits from release `0.20.0`.

This also affects the Falco gRPC Version API, which will also return this new part of the version.

Moreover, having the prerelease version part that will automatically increment as soon we merge a new PR into the master, will fix the ordering of versions we currently have when installing Falco with `apt` or `yum` or `rpm`.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1087 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new: FALCO_VERSION_PRERELEASE contains the number of commits since last tag on the master
```
