### PR TITLE
Falco version and driver version are not coupled anymore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,7 @@ jobs:
       - run:
           name: Build and publish slim
           command: |
-            docker build --build-arg VERSION_BUCKET=deb -t "falcosecurity/falco:${CIRCLE_TAG}-slim" docker/slim
+            docker build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "falcosecurity/falco:${CIRCLE_TAG}-slim" docker/slim
             docker tag "falcosecurity/falco:${CIRCLE_TAG}-slim" falcosecurity/falco:latest-slim
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
             docker push "falcosecurity/falco:${CIRCLE_TAG}-slim"
@@ -286,7 +286,7 @@ jobs:
       - run:
           name: Build and publish stable
           command: |
-            docker build --build-arg VERSION_BUCKET=deb -t "falcosecurity/falco:${CIRCLE_TAG}" docker/stable
+            docker build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "falcosecurity/falco:${CIRCLE_TAG}" docker/stable
             docker tag "falcosecurity/falco:${CIRCLE_TAG}" falcosecurity/falco:latest
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
             docker push "falcosecurity/falco:${CIRCLE_TAG}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,8 @@ jobs:
       - run:
           name: Build and publish slim-dev
           command: |
-            docker build --build-arg VERSION_BUCKET=deb-dev -t falcosecurity/falco:master-slim docker/slim
+            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
+            docker build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t falcosecurity/falco:master-slim docker/slim
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
             docker push falcosecurity/falco:master-slim
       - run:
@@ -223,7 +224,8 @@ jobs:
       - run:
           name: Build and publish dev
           command: |
-            docker build --build-arg VERSION_BUCKET=deb-dev -t falcosecurity/falco:master docker/stable
+            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
+            docker build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t falcosecurity/falco:master docker/stable
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
             docker push falcosecurity/falco:master
   # Publish the packages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ include(GetFalcoVersion)
 set(PACKAGE_NAME "falco")
 set(PROBE_NAME "falco-probe")
 set(PROBE_DEVICE_NAME "falco")
+set(DRIVER_LOOKUP_URL "https://s3.amazonaws.com/download.draios.com")
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX
       /usr

--- a/docker/local/docker-entrypoint.sh
+++ b/docker/local/docker-entrypoint.sh
@@ -29,7 +29,7 @@ if [[ -z "${SKIP_MODULE_LOAD}" ]]; then
         ln -s "$i" "/usr/src/$base"
     done
 
-    /usr/bin/falco-probe-loader
+    /usr/bin/falco-driver-loader
 fi
 
 exec "$@"

--- a/docker/rhel/docker-entrypoint.sh
+++ b/docker/rhel/docker-entrypoint.sh
@@ -29,7 +29,7 @@ if [[ -z "${SKIP_MODULE_LOAD}" ]]; then
         ln -s "$i" "/usr/src/$base"
     done
 
-    /usr/bin/falco-probe-loader
+    /usr/bin/falco-driver-loader
 fi
 
 exec "$@"

--- a/docker/stable/docker-entrypoint.sh
+++ b/docker/stable/docker-entrypoint.sh
@@ -29,7 +29,7 @@ if [[ -z "${SKIP_MODULE_LOAD}" ]]; then
         ln -s "$i" "/usr/src/$base"
     done
 
-    /usr/bin/falco-probe-loader
+    /usr/bin/falco-driver-loader
 fi
 
 exec "$@"

--- a/docker/tester/root/usr/bin/entrypoint
+++ b/docker/tester/root/usr/bin/entrypoint
@@ -47,7 +47,7 @@ case "$CMD" in
 "test")
     if [ -z "$FALCO_VERSION" ]; then
         echo "Automatically figuring out Falco version."
-        FALCO_VERSION=$("$BUILD_DIR/$BUILD_TYPE/userspace/falco/falco" --version | cut -d' ' -f3 | tr -d '\r')
+        FALCO_VERSION=$("$BUILD_DIR/$BUILD_TYPE/userspace/falco/falco" --version | head -n 1 | cut -d' ' -f3 | tr -d '\r')
         echo "Falco version: $FALCO_VERSION"
     fi
     if [ -z "$FALCO_VERSION" ]; then

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -23,7 +23,9 @@ file(COPY "${PROJECT_SOURCE_DIR}/scripts/debian/falco"
 file(COPY "${PROJECT_SOURCE_DIR}/scripts/rpm/falco"
 	DESTINATION "${PROJECT_BINARY_DIR}/scripts/rpm")
 
+configure_file(falco-driver-loader falco-driver-loader @ONLY)
+
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-	install(PROGRAMS ${PROJECT_SOURCE_DIR}/scripts/falco-probe-loader
+	install(PROGRAMS ${PROJECT_BINARY_DIR}/scripts/falco-driver-loader
 		DESTINATION ${FALCO_BIN_DIR})
 endif()

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -25,20 +25,20 @@
 #
 cos_version_greater()
 {
-	if [[ $cos_ver == $base_ver ]]; then
+	if [[ $cos_ver == "${base_ver}" ]]; then
 		return 0
 	fi
 
 	#
 	# COS build numbers are in the format x.y.z
 	#
-	a=`echo $cos_ver | cut -d. -f1`
-	b=`echo $cos_ver | cut -d. -f2`
-	c=`echo $cos_ver | cut -d. -f3`
+	a=$(echo "${cos_ver}" | cut -d. -f1)
+	b=$(echo "${cos_ver}" | cut -d. -f2)
+	c=$(echo "${cos_ver}" | cut -d. -f3)
 
-	d=`echo $base_ver | cut -d. -f1`
-	e=`echo $base_ver | cut -d. -f2`
-	f=`echo $base_ver | cut -d. -f3`
+	d=$(echo "${base_ver}" | cut -d. -f1)
+	e=$(echo "${base_ver}" | cut -d. -f2)
+	f=$(echo "${base_ver}" | cut -d. -f3)
 
 	# Test the first component
 	if [[ $a -gt $d ]]; then
@@ -74,16 +74,16 @@ get_kernel_config() {
 	elif [ -f "/boot/config-${KERNEL_RELEASE}" ]; then
 		echo "Found kernel config at /boot/config-${KERNEL_RELEASE}"
 		KERNEL_CONFIG_PATH=/boot/config-${KERNEL_RELEASE}
-	elif [ ! -z "${HOST_ROOT}" ] && [ -f "${HOST_ROOT}/boot/config-${KERNEL_RELEASE}" ]; then
+	elif [ -n "${HOST_ROOT}" ] && [ -f "${HOST_ROOT}/boot/config-${KERNEL_RELEASE}" ]; then
 		echo "Found kernel config at ${HOST_ROOT}/boot/config-${KERNEL_RELEASE}"
 		KERNEL_CONFIG_PATH="${HOST_ROOT}/boot/config-${KERNEL_RELEASE}"
 	elif [ -f "/usr/lib/ostree-boot/config-${KERNEL_RELEASE}" ]; then
 		echo "Found kernel config at /usr/lib/ostree-boot/config-${KERNEL_RELEASE}"
 		KERNEL_CONFIG_PATH="/usr/lib/ostree-boot/config-${KERNEL_RELEASE}"
-	elif [ ! -z "${HOST_ROOT}" ] && [ -f "${HOST_ROOT}/usr/lib/ostree-boot/config-${KERNEL_RELEASE}" ]; then
+	elif [ -n "${HOST_ROOT}" ] && [ -f "${HOST_ROOT}/usr/lib/ostree-boot/config-${KERNEL_RELEASE}" ]; then
 		echo "Found kernel config at ${HOST_ROOT}/usr/lib/ostree-boot/config-${KERNEL_RELEASE}"
 		KERNEL_CONFIG_PATH="${HOST_ROOT}/usr/lib/ostree-boot/config-${KERNEL_RELEASE}"
-	elif [ -f /lib/modules/${KERNEL_RELEASE}/config ]; then
+	elif [ -f "/lib/modules/${KERNEL_RELEASE}/config" ]; then
 		# this code works both for native host and agent container assuming that
 		# Dockerfile sets up the desired symlink /lib/modules -> $HOST_ROOT/lib/modules
 		echo "Found kernel config at /lib/modules/${KERNEL_RELEASE}/config"
@@ -96,13 +96,13 @@ get_kernel_config() {
 	fi
 
 	if [[ "${KERNEL_CONFIG_PATH}" == *.gz ]]; then
-	    HASH=$(zcat "${KERNEL_CONFIG_PATH}" | md5sum - | cut -d' ' -f1)
+		HASH=$(zcat "${KERNEL_CONFIG_PATH}" | md5sum - | cut -d' ' -f1)
 	else
-	    HASH=$(md5sum "${KERNEL_CONFIG_PATH}" | cut -d' ' -f1)
+		HASH=$(md5sum "${KERNEL_CONFIG_PATH}" | cut -d' ' -f1)
 	fi
 }
 
-load_kernel_probe() {
+load_kernel_module() {
 	if ! hash lsmod > /dev/null 2>&1; then
 		echo "This program requires lsmod"
 		exit 1
@@ -122,13 +122,13 @@ load_kernel_probe() {
 	rmmod "${PROBE_NAME}" 2>/dev/null
 	WAIT_TIME=0
 	KMOD_NAME=$(echo "${PROBE_NAME}" | tr "-" "_")
-	while lsmod | grep "${KMOD_NAME}" > /dev/null 2>&1 && [ $WAIT_TIME -lt $MAX_RMMOD_WAIT ]; do
+	while lsmod | grep "${KMOD_NAME}" > /dev/null 2>&1 && [ $WAIT_TIME -lt "${MAX_RMMOD_WAIT}" ]; do
 		if rmmod "${PROBE_NAME}" 2>/dev/null; then
 			echo "* Unloading ${PROBE_NAME} succeeded after ${WAIT_TIME}s"
 			break
 		fi
 		((++WAIT_TIME))
-		if (( $WAIT_TIME % 5 == 0 )); then
+		if (( WAIT_TIME % 5 == 0 )); then
 			echo "* ${PROBE_NAME} still loaded, waited ${WAIT_TIME}s (max wait ${MAX_RMMOD_WAIT}s)"
 		fi
 		sleep 1
@@ -144,20 +144,20 @@ load_kernel_probe() {
 		echo "* Skipping dkms install for UEK host"
 	else
 		echo "* Running dkms install for ${PACKAGE_NAME}"
-		if dkms install -m "${PACKAGE_NAME}" -v "${FALCO_VERSION}" -k "${KERNEL_RELEASE}"; then
+		if dkms install -m "${PACKAGE_NAME}" -v "${DRIVER_VERSION}" -k "${KERNEL_RELEASE}"; then
 			echo "* Trying to load a dkms ${PROBE_NAME}, if present"
 
-			if insmod "/var/lib/dkms/${PACKAGE_NAME}/${FALCO_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${PROBE_NAME}.ko" > /dev/null 2>&1; then
+			if insmod "/var/lib/dkms/${PACKAGE_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${PROBE_NAME}.ko" > /dev/null 2>&1; then
 				echo "${PROBE_NAME} found and loaded in dkms"
 				exit 0
-			elif insmod "/var/lib/dkms/${PACKAGE_NAME}/${FALCO_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${PROBE_NAME}.ko.xz" > /dev/null 2>&1; then
+			elif insmod "/var/lib/dkms/${PACKAGE_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${PROBE_NAME}.ko.xz" > /dev/null 2>&1; then
 				echo "${PROBE_NAME} found and loaded in dkms (xz)"
 				exit 0
 			else
 				echo "* Unable to insmod"
 			fi
 		else
-			DKMS_LOG="/var/lib/dkms/${PACKAGE_NAME}/${FALCO_VERSION}/build/make.log"
+			DKMS_LOG="/var/lib/dkms/${PACKAGE_NAME}/${DRIVER_VERSION}/build/make.log"
 			if [ -f "${DKMS_LOG}" ]; then
 				echo "* Running dkms build failed, dumping ${DKMS_LOG}"
 				cat "${DKMS_LOG}"
@@ -178,7 +178,7 @@ load_kernel_probe() {
 
 	get_kernel_config
 
-	local FALCO_PROBE_FILENAME="${PROBE_NAME}-${FALCO_VERSION}-${ARCH}-${KERNEL_RELEASE}-${HASH}.ko"
+	local FALCO_PROBE_FILENAME="${PROBE_NAME}-${DRIVER_VERSION}-${ARCH}-${KERNEL_RELEASE}-${HASH}.ko"
 
 	if [ -f "${HOME}/.falco/${FALCO_PROBE_FILENAME}" ]; then
 		echo "Found precompiled module at ~/.falco/${FALCO_PROBE_FILENAME}, loading module"
@@ -209,7 +209,8 @@ load_bpf_probe() {
 
 	get_kernel_config
 
-	if [ ! -z "${HOST_ROOT}" ] && [ -f "${HOST_ROOT}/etc/os-release" ]; then
+	if [ -n "${HOST_ROOT}" ] && [ -f "${HOST_ROOT}/etc/os-release" ]; then
+		# shellcheck source=/dev/null
 		. "${HOST_ROOT}/etc/os-release"
 
 		if [ "${ID}" == "cos" ]; then
@@ -217,24 +218,24 @@ load_bpf_probe() {
 		fi
 	fi
 
-	if [ ! -z "${HOST_ROOT}" ] && [ -f "${HOST_ROOT}/etc/VERSION" ]; then
+	if [ -n "${HOST_ROOT}" ] && [ -f "${HOST_ROOT}/etc/VERSION" ]; then
 		MINIKUBE=1
-		MINIKUBE_VERSION="$(cat ${HOST_ROOT}/etc/VERSION)"
+		MINIKUBE_VERSION="$(cat "${HOST_ROOT}/etc/VERSION")"
 	fi
 
-	local BPF_PROBE_FILENAME="${BPF_PROBE_NAME}-${FALCO_VERSION}-${ARCH}-${KERNEL_RELEASE}-${HASH}.o"
+	local BPF_PROBE_FILENAME="${BPF_PROBE_NAME}-${DRIVER_VERSION}-${ARCH}-${KERNEL_RELEASE}-${HASH}.o"
 
 	if [ ! -f "${HOME}/.falco/${BPF_PROBE_FILENAME}" ]; then
 
-	        local BPF_KERNEL_SOURCES_URL=""
+		local BPF_KERNEL_SOURCES_URL=""
 		local STRIP_COMPONENTS=1
 
-	        customize_kernel_build() {
-		    if [ -n "${KERNEL_EXTRA_VERSION}" ]; then
+		customize_kernel_build() {
+			if [ -n "${KERNEL_EXTRA_VERSION}" ]; then
 			sed -i "s/LOCALVERSION=\"\"/LOCALVERSION=\"${KERNEL_EXTRA_VERSION}\"/" .config
-		    fi
-		    make olddefconfig > /dev/null
-		    make modules_prepare > /dev/null
+			fi
+			make olddefconfig > /dev/null
+			make modules_prepare > /dev/null
 		}
 
 		if [ -n "${COS}" ]; then
@@ -245,35 +246,37 @@ load_bpf_probe() {
 			STRIP_COMPONENTS=0
 
 			customize_kernel_build() {
-			    pushd usr/src/* > /dev/null
+				pushd usr/src/* > /dev/null || exit
 
-			    # Note: this overrides the KERNELDIR set while untarring the tarball
-			    export KERNELDIR=`pwd`
+				# Note: this overrides the KERNELDIR set while untarring the tarball
+				KERNELDIR=$(pwd)
+				export KERNELDIR
 
-			    sed -i '/^#define randomized_struct_fields_start	struct {$/d' include/linux/compiler-clang.h
-			    sed -i '/^#define randomized_struct_fields_end	};$/d' include/linux/compiler-clang.h
+				sed -i '/^#define randomized_struct_fields_start	struct {$/d' include/linux/compiler-clang.h
+				sed -i '/^#define randomized_struct_fields_end	};$/d' include/linux/compiler-clang.h
 
-			    popd > /dev/null
+				popd > /dev/null || exit
 
-			    # Might need to configure our own sources depending on COS version
-			    cos_ver=${BUILD_ID}
-			    base_ver=11553.0.0
+				# Might need to configure our own sources depending on COS version
+				cos_ver=${BUILD_ID}
+				base_ver=11553.0.0
 
-			    cos_version_greater
-			    greater_ret=$?
+				cos_version_greater
+				greater_ret=$?
 
-			    if [[ greater_ret -eq 1 ]]; then
+				if [[ greater_ret -eq 1 ]]; then
 				export KBUILD_EXTRA_CPPFLAGS=-DCOS_73_WORKAROUND
-			    fi
-                        }
+				fi
+						}
 		fi
 
 		if [ -n "${MINIKUBE}" ]; then
 			echo "* Minikube detected (${MINIKUBE_VERSION}), using linux kernel sources for minikube kernel"
-			local kernel_version=$(uname -r)
-			local -r kernel_version_major=$(echo ${kernel_version} | cut -d. -f1)
-			local -r kernel_version_minor=$(echo ${kernel_version} | cut -d. -f2)
-			local -r kernel_version_patch=$(echo ${kernel_version} | cut -d. -f3)
+			local kernel_version
+			kernel_version=$(uname -r)
+			local -r kernel_version_major=$(echo "${kernel_version}" | cut -d. -f1)
+			local -r kernel_version_minor=$(echo "${kernel_version}" | cut -d. -f2)
+			local -r kernel_version_patch=$(echo "${kernel_version}" | cut -d. -f3)
 
 			if [ "${kernel_version_patch}" == "0" ]; then
 				kernel_version="${kernel_version_major}.${kernel_version_minor}"
@@ -283,7 +286,7 @@ load_bpf_probe() {
 		fi
 
 		if [ -n "${BPF_USE_LOCAL_KERNEL_SOURCES}" ]; then
-		        local -r kernel_version_major=$(uname -r | cut -d. -f1)
+			local -r kernel_version_major=$(uname -r | cut -d. -f1)
 			local -r kernel_version=$(uname -r | cut -d- -f1)
 			KERNEL_EXTRA_VERSION="-$(uname -r | cut -d- -f2)"
 
@@ -296,8 +299,8 @@ load_bpf_probe() {
 			echo "* Downloading ${BPF_KERNEL_SOURCES_URL}"
 
 			mkdir -p /tmp/kernel
-			cd /tmp/kernel
-			cd `mktemp -d -p /tmp/kernel`
+			cd /tmp/kernel || exit
+			cd "$(mktemp -d -p /tmp/kernel)" || exit
 			if ! curl -o kernel-sources.tgz --create-dirs "${FALCO_PROBE_CURL_OPTIONS}" "${BPF_KERNEL_SOURCES_URL}"; then
 				exit 1;
 			fi
@@ -306,13 +309,14 @@ load_bpf_probe() {
 
 			mkdir kernel-sources && tar xf kernel-sources.tgz -C kernel-sources --strip-components "${STRIP_COMPONENTS}"
 
-			cd kernel-sources
-			export KERNELDIR=`pwd`
+			cd kernel-sources || exit
+			KERNELDIR=$(pwd)
+			export KERNELDIR
 
 			if [[ "${KERNEL_CONFIG_PATH}" == *.gz ]]; then
-			    zcat "${KERNEL_CONFIG_PATH}" > .config
+				zcat "${KERNEL_CONFIG_PATH}" > .config
 			else
-			    cat "${KERNEL_CONFIG_PATH}" > .config
+				cat "${KERNEL_CONFIG_PATH}" > .config
 			fi
 
 			echo "* Configuring kernel"
@@ -321,10 +325,10 @@ load_bpf_probe() {
 
 		echo "* Trying to compile BPF probe ${BPF_PROBE_NAME} (${BPF_PROBE_FILENAME})"
 
-		make -C "/usr/src/${PACKAGE_NAME}-${FALCO_VERSION}/bpf" > /dev/null
+		make -C "/usr/src/${PACKAGE_NAME}-${DRIVER_VERSION}/bpf" > /dev/null
 
 		mkdir -p ~/.falco
-		mv "/usr/src/${PACKAGE_NAME}-${FALCO_VERSION}/bpf/probe.o" "${HOME}/.falco/${BPF_PROBE_FILENAME}"
+		mv "/usr/src/${PACKAGE_NAME}-${DRIVER_VERSION}/bpf/probe.o" "${HOME}/.falco/${BPF_PROBE_FILENAME}"
 
 		if [ -n "${BPF_KERNEL_SOURCES_URL}" ]; then
 			rm -r /tmp/kernel
@@ -363,7 +367,7 @@ load_bpf_probe() {
 ARCH=$(uname -m)
 KERNEL_RELEASE=$(uname -r)
 SCRIPT_NAME=$(basename "${0}")
-PROBE_URL=${PROBE_URL:-https://s3.amazonaws.com/download.draios.com}
+PROBE_URL=${PROBE_URL:-"@DRIVER_LOOKUP_URL@"}
 if [ -n "$PROBE_INSECURE_DOWNLOAD" ]
 then
 	FALCO_PROBE_CURL_OPTIONS=-fsSk
@@ -380,15 +384,13 @@ if [ -z "${PACKAGES_REPOSITORY}" ]; then
 	PACKAGES_REPOSITORY="stable"
 fi
 
-if [ "${SCRIPT_NAME}" = "falco-probe-loader" ]; then
-        if [ -z "$FALCO_VERSION" ]; then
-	    FALCO_VERSION=$(falco --version | cut -d' ' -f3)
-	fi
-	PROBE_NAME="falco-probe"
-	BPF_PROBE_NAME="falco-probe-bpf"
-	PACKAGE_NAME="falco"
+if [ "${SCRIPT_NAME}" = "falco-driver-loader" ]; then
+	DRIVER_VERSION="@PROBE_VERSION@"
+	PROBE_NAME="@PROBE_NAME@"
+	BPF_PROBE_NAME="@PROBE_NAME@-bpf"
+	PACKAGE_NAME="@PACKAGE_NAME@"
 else
-	echo "This script must be called as falco-probe-loader"
+	echo "This script must be called as falco-driver-loader"
 	exit 1
 fi
 
@@ -405,5 +407,5 @@ fi
 if [ -v FALCO_BPF_PROBE ] || [ "${1}" = "bpf" ]; then
 	load_bpf_probe
 else
-	load_kernel_probe
+	load_kernel_module
 fi

--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -397,7 +397,8 @@ class FalcoTest(Test):
                 os.remove(rmfile)
 
         if self.copy_local_driver:
-            verstr = subprocess.check_output([self.falco_binary_path, "--version"]).rstrip()
+            verlines = [str.strip() for str in subprocess.check_output([self.falco_binary_path, "--version"]).splitlines()]
+            verstr = verlines[0].decode("utf-8")
             self.log.info("verstr {}".format(verstr))
             falco_version = verstr.split(" ")[2]
             self.log.info("falco_version {}".format(falco_version))
@@ -406,7 +407,7 @@ class FalcoTest(Test):
             kernel_release = subprocess.check_output(["uname", "-r"]).rstrip()
             self.log.info("kernel release {}".format(kernel_release))
 
-            # falco-probe-loader has a more comprehensive set of ways to
+            # falco-driver-loader has a more comprehensive set of ways to
             # find the config hash. We only look at /boot/config-<kernel release>
             md5_output = subprocess.check_output(["md5sum", "/boot/config-{}".format(kernel_release)]).rstrip()
             config_hash = md5_output.split(" ")[0]

--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -23,7 +23,7 @@ import shutil
 import stat
 import subprocess
 import sys
-import urllib
+import urllib.request
 
 from avocado import Test
 from avocado import main
@@ -141,7 +141,7 @@ class FalcoTest(Test):
         else:
             detect_counts = {}
             for item in self.detect_counts:
-                for key, value in item.items():
+                for key, value in list(item.items()):
                     detect_counts[key] = value
             self.detect_counts = detect_counts
 
@@ -184,7 +184,7 @@ class FalcoTest(Test):
         else:
             outputs = []
             for item in self.outputs:
-                for key, value in item.items():
+                for key, value in list(item.items()):
                     output = {}
                     output['file'] = key
                     output['line'] = value
@@ -238,7 +238,7 @@ class FalcoTest(Test):
         self.log.debug("Expected events for rules: {}".format(self.rules_events))
         self.log.debug("Actual events for rules: {}".format(found_events))
 
-        for rule in found_events.keys():
+        for rule in list(found_events.keys()):
             if found_events.get(rule) != self.rules_events.get(rule):
                 self.fail("rule {}: expected events {} differs from actual events {}".format(rule, self.rules_events.get(rule), found_events.get(rule)))
 
@@ -277,7 +277,7 @@ class FalcoTest(Test):
 
         triggered_rules = match.group(1)
 
-        for rule, count in self.detect_counts.items():
+        for rule, count in list(self.detect_counts.items()):
             expected = '\s{}: (\d+)'.format(re.sub(r'([$\.*+?()[\]{}|^])', r'\\\1', rule))
             match = re.search(expected, triggered_rules)
 
@@ -440,7 +440,7 @@ class FalcoTest(Test):
             if not os.path.isfile(self.psp_conv_path):
                 self.log.info("Downloading {} to {}".format(self.psp_conv_url, self.psp_conv_path))
 
-                urllib.urlretrieve(self.psp_conv_url, self.psp_conv_path)
+                urllib.request.urlretrieve(self.psp_conv_url, self.psp_conv_path)
                 os.chmod(self.psp_conv_path, stat.S_IEXEC)
 
             conv_cmd = '{} convert psp --psp-path {} --rules-path {}'.format(

--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -175,7 +175,7 @@ class FalcoTest(Test):
         self.copy_local_driver = self.params.get('copy_local_driver', '*', default=False)
 
         # Used by possibly_copy_local_driver as well as docker run
-        self.module_dir = os.path.expanduser("~/.sysdig")
+        self.module_dir = os.path.expanduser("~/.falco")
 
         self.outputs = self.params.get('outputs', '*', default='')
 
@@ -335,7 +335,7 @@ class FalcoTest(Test):
             self.falco_binary_path = "docker run --rm --name falco-test --privileged " \
                                      "-v /var/run/docker.sock:/host/var/run/docker.sock " \
                                      "-v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro " \
-                                     "-v /lib/modules:/host/lib/modules:ro -v {}:/root/.sysdig:ro " \
+                                     "-v /lib/modules:/host/lib/modules:ro -v {}:/root/.falco:ro " \
                                      "-v /usr:/host/usr:ro {} {} falco".format(
                                          self.module_dir, self.addl_docker_run_args, image)
 
@@ -387,8 +387,7 @@ class FalcoTest(Test):
             res = process.run(cmdline, timeout=120, sudo=True)
 
     def possibly_copy_driver(self):
-        # Remove the contents of ~/.sysdig regardless of
-        # copy_local_driver.
+        # Remove the contents of ~/.falco regardless of copy_local_driver.
         self.log.debug("Checking for module dir {}".format(self.module_dir))
         if os.path.isdir(self.module_dir):
             self.log.info("Removing files below directory {}".format(self.module_dir))

--- a/userspace/falco/config_falco.h.in
+++ b/userspace/falco/config_falco.h.in
@@ -31,4 +31,5 @@ limitations under the License.
 #define FALCO_INSTALL_CONF_FILE "/etc/falco/falco.yaml"
 #define FALCO_SOURCE_LUA_DIR "${PROJECT_SOURCE_DIR}/userspace/falco/lua/"
 
-#define PROBE_NAME "${PROBE_NAME}"
+#define PROBE_NAME "@PROBE_NAME@"
+#define DRIVER_VERSION "@PROBE_VERSION@"

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -624,6 +624,7 @@ int falco_init(int argc, char **argv)
 				if(string(long_options[long_index].name) == "version")
 				{
 					printf("Falco version: %s\n", FALCO_VERSION);
+					printf("Driver version: %s\n", DRIVER_VERSION);
 					return EXIT_SUCCESS;
 				}
 				else if (string(long_options[long_index].name) == "cri")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

/area tests





**What this PR does / why we need it**:

This PR introduces some fixes and updates needed because the Falco version and the driver version are distinct values now.

So this PR mainly updates the `falco-probe-loader` script for this reason. Also renaming it to `falco-driver-loader`.
Futhermore, this script obtains now some values (like the `DRIVER_VERSION` variable value) at configuration time.

Finally it also ensures that the `FALCO_VERSION` env variable inside docker containers contains the same value returned by `falco --version`, not the docker image tag.

**Which issue(s) this PR fixes**:



Fixes #1107
Fixes #1110 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:



```release-note
update: falco-probe-loader script is falco-driver-loader now
new: falco version and driver version are distinct and not coupled anymore
fix: /usr/bin/falco-${DRIVER_VERSION} driver directory
fix: FALCO_VERSION env variable inside Falco containers contains the Falco version now (not the docker image tag)
```
