### PR TITLE
Proposal for 2 new Falco rules for syscall source, and 4 for Kubernetes audit source.

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2696,6 +2696,89 @@
   priority: NOTICE
   tags: [network, mitre_discovery]
   
+# Change to (always_true) to enable rule 'Network connection outside local subnet'
+- macro: enabled_rule_network_only_subnet
+  condition: (never_true)
+
+# Images that are allowed to have outbound traffic
+- list: images_allow_network_outside_subnet
+  items: []
+
+# Namespaces where the rule is enforce
+- list: namespace_scope_network_only_subnet
+  items: [] 
+
+- macro: network_local_subnet
+  condition: >
+    fd.rnet in (rfc_1918_addresses) or
+    fd.ip = "0.0.0.0" or 
+    fd.net = "127.0.0.0/8"
+
+# # How to test:
+# # Change macro enabled_rule_network_only_subnet to condition: always_true
+# # Add 'default' to namespace_scope_network_only_subnet
+# # Run:
+# kubectl run --generator=run-pod/v1 -n default -i --tty busybox --image=busybox --rm -- wget google.com -O /var/google.html
+# # Check logs running  
+
+- rule: Network Connection outside Local Subnet
+  desc: Detect traffic to image outside local subnet.
+  condition: >
+    enabled_rule_network_only_subnet and
+    inbound_outbound and 
+    container and
+    not network_local_subnet and
+    k8s.ns.name in (namespace_scope_network_only_subnet)
+  output: >
+    Network connection outside local subnet
+    (command=%proc.cmdline connection=%fd.name user=%user.name container_id=%container.id 
+    image=%container.image.repository namespace=%k8s.ns.name
+    fd.rip.name=%fd.rip.name fd.lip.name=%fd.lip.name fd.cip.name=%fd.cip.name fd.sip.name=%fd.sip.name)
+  priority: WARNING
+  tags: [network]
+  
+
+
+- macro: allowed_port
+  condition: (never_true)
+
+- list: allowed_image
+  items: [] # add image to monitor, i.e.: bitnami/nginx
+
+- list: authorized_server_binaries
+  items: []  # add binary to allow, i.e.: nginx
+
+- list: authorized_server_port
+  items: [] # add port to allow, i.e.: 80
+
+# # How to test:
+# kubectl run --image=nginx nginx-app --port=80 --env="DOMAIN=cluster"
+# kubectl expose deployment nginx-app --port=80 --name=nginx-http --type=LoadBalancer
+# # On minikube:
+# minikube service nginx-http
+# # On general K8s:
+# kubectl get services
+# kubectl cluster-info
+# # Visit the Nginx service and port, should not fire.
+# # Change rule to different port, then different process name, and test again that it fires.
+
+- rule: Outbound or Inbound Traffic not to Authorized Server Process and Port
+  desc: Detect traffic that is not to authorized server process and port.
+  condition: >
+    allowed_port and
+    inbound_outbound and
+    container and
+    container.image.repository in (allowed_image) and
+    not proc.name in (authorized_server_binary) and
+    not fd.sport in (authorized_server_port)
+  output: >
+    Network connection outside authorized port and binary
+    (command=%proc.cmdline connection=%fd.name user=%user.name container_id=%container.id 
+    image=%container.image.repository)
+  priority: WARNING
+  tags: [network]
+
+
 
 # Application rules have moved to application_rules.yaml. Please look
 # there if you want to enable them by adding to

--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -420,19 +420,23 @@
   tags: [k8s]
 
 
-
+# This list includes some of the default user names for an administrator in several K8s installations
 - list: full_admin_k8s_users
-  items: ["admin", "kubernetes-admin",  "kubernetes-admin@kubernetes", "default", "kubernetes-admin@cluster.local", "minikube-user"]
+  items: ["admin", "kubernetes-admin",  "kubernetes-admin@kubernetes", "kubernetes-admin@cluster.local", "minikube-user"]
 
-- macro: allowed_full_admin_users
-  condition: (k8s_audit_always_true)
+# This rules detect an operation triggered by an user name that is 
+# included in the list of those that are default administrators upon 
+# cluster creation. This may signify a permission setting too broader. 
+# As we can't check for role of the user on a general ka.* event, this 
+# may or may not be an administrator. Customize the full_admin_k8s_users 
+# list to your needs, and activate at your discrection.
 
 # # How to test:
 # # Execute any kubectl command connected using default cluster user, as:
 # kubectl create namespace rule-test
 
 - rule: Full K8s Administrative Access
-  desc: Detect any k8s operation by an administrator with full access.
+  desc: Detect any k8s operation by a user name that may be an administrator with full access.
   condition: >
     kevt 
     and non_system_user 

--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -418,3 +418,110 @@
   priority: DEBUG
   source: k8s_audit
   tags: [k8s]
+
+
+
+- list: full_admin_k8s_users
+  items: ["admin", "kubernetes-admin",  "kubernetes-admin@kubernetes", "default", "kubernetes-admin@cluster.local", "minikube-user"]
+
+- macro: allowed_full_admin_users
+  condition: (k8s_audit_always_true)
+
+# # How to test:
+# # Execute any kubectl command connected using default cluster user, as:
+# kubectl create namespace rule-test
+
+- rule: Full K8s Administrative Access
+  desc: Detect any k8s operation by an administrator with full access.
+  condition: >
+    kevt 
+    and non_system_user 
+    and ka.user.name in (admin_k8s_users) 
+    and not allowed_full_admin_users
+  output: K8s Operation performed by full admin user (user=%ka.user.name target=%ka.target.name/%ka.target.resource verb=%ka.verb uri=%ka.uri resp=%ka.response.code)
+  priority: WARNING
+  source: k8s_audit
+  tags: [k8s]
+
+
+
+- macro: ingress
+  condition: ka.target.resource=ingresses
+
+- macro: ingress_tls
+  condition: (jevt.value[/requestObject/spec/tls] exists)
+
+# # How to test:
+# # Create an ingress.yaml file with content:
+# apiVersion: networking.k8s.io/v1beta1
+# kind: Ingress
+# metadata:
+#   name: test-ingress
+#   annotations:
+#     nginx.ingress.kubernetes.io/rewrite-target: /
+# spec:
+#   rules:
+#   - http:
+#       paths:
+#       - path: /testpath
+#         backend:
+#           serviceName: test
+#           servicePort: 80
+# # Execute: kubectl apply -f ingress.yaml
+
+- rule: Ingress Object without TLS Certificate Created
+  desc: Detect any attempt to create an ingress without TLS certification.
+  condition: >
+    (kactivity and kcreate and ingress and response_successful and not ingress_tls)
+  output: >
+    K8s Ingress Without TLS Cert Created (user=%ka.user.name ingress=%ka.target.name
+    namespace=%ka.target.namespace)
+  source: k8s_audit    
+  priority: WARNING
+  tags: [k8s, network]
+
+
+
+- macro: node
+  condition: ka.target.resource=nodes
+
+- macro: allow_all_k8s_nodes
+  condition: (k8s_audit_always_true)
+
+- list: allowed_k8s_nodes
+  items: []
+
+# # How to test:
+# # Create a Falco monitored cluster with Kops
+# # Increase the number of minimum nodes with:
+# kops edit ig nodes
+# kops apply --yes
+
+- rule: Untrusted Node Successfully Joined the Cluster
+  desc: >
+    Detect a node successfully joined the cluster outside of the list of allowed nodes.
+  condition: >
+    kevt and node 
+    and kcreate 
+    and response_successful 
+    and not allow_all_k8s_nodes 
+    and not ka.target.name in (allowed_k8s_nodes)
+  output: Node not in allowed list successfully joined the cluster (user=%ka.user.name node=%ka.target.name)
+  priority: ERROR
+  source: k8s_audit
+  tags: [k8s]
+
+- rule: Untrusted Node Unsuccessfully Tried to Join the Cluster
+  desc: >
+    Detect an unsuccessful attempt to join the cluster for a node not in the list of allowed nodes.
+  condition: >
+    kevt and node 
+    and kcreate 
+    and not response_successful 
+    and not allow_all_k8s_nodes 
+    and not ka.target.name in (allowed_k8s_nodes)
+  output: Node not in allowed list tried unsuccessfully to join the cluster  (user=%ka.user.name node=%ka.target.name reason=%ka.response.reason)
+  priority: WARNING
+  source: k8s_audit
+  tags: [k8s]
+

--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -420,6 +420,10 @@
   tags: [k8s]
 
 
+# This macro disables following rule, change to k8s_audit_never_true to enable it
+- macro: allowed_full_admin_users
+  condition: (k8s_audit_always_true)
+
 # This list includes some of the default user names for an administrator in several K8s installations
 - list: full_admin_k8s_users
   items: ["admin", "kubernetes-admin",  "kubernetes-admin@kubernetes", "kubernetes-admin@cluster.local", "minikube-user"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
-->

**What type of PR is this?**
/kind feature
/kind rule-create

**Any specific area of the project related to this PR?**
/area rules

**What this PR does / why we need it**:

These proposed rules detect network and Kubernetes activity that, outside some whitelists, could indicate malicious activity. No other rules perform similar detections, and they are generic so everybody will benefit for having them in their Falco installation. See the proposed release notes for specific details.

**Which issue(s) this PR fixes**:

Fixes https://github.com/falcosecurity/falco/issues/1121

**Special notes for your reviewer**:

The Issue is just a description of the proposal of the rules, I don't know if it would have been better to just create de pull request only.

**Does this PR introduce a user-facing change?**:

Yes, new rules available in falco.yaml and k8s_audit_rules.yaml, one of the enabled by default: "Ingress Object without TLS Certificate Created"

```release-note

New Falco rules available:

* Full K8s Administrative Access: Detect any k8s operation by an administrator with full access.
* Ingress Object without TLS Certificate Created: Detect any attempt to create an ingress without TLS certification (rule enabled by default).
* Untrusted Node Successfully Joined the Cluster: Detect a node successfully joined the cluster outside of the list of allowed nodes.
* Untrusted Node Unsuccessfully Tried to Join the Cluster: Detect an unsuccessful attempt to join the cluster for a node not in the list of allowed nodes.
* Network Connection outside Local Subnet: Detect traffic to image outside local subnet.
Outbound or Inbound Traffic not to Authorized Server Process and Port: Detect traffic that is not to authorized server process and port.

```
