### PR TITLE
fix: HOST_ROOT environment variable detection

### DIFF
--- a/cmake/modules/sysdig-repo/patch/libscap.patch
+++ b/cmake/modules/sysdig-repo/patch/libscap.patch
@@ -1,5 +1,5 @@
 diff --git a/userspace/libscap/scap.c b/userspace/libscap/scap.c
-index 59b04e0a..bdc311cb 100644
+index e9faea51..a1b3b501 100644
 --- a/userspace/libscap/scap.c
 +++ b/userspace/libscap/scap.c
 @@ -52,7 +52,7 @@ limitations under the License.
@@ -20,3 +20,12 @@ index 59b04e0a..bdc311cb 100644
  			bpf_probe = buf;
  		}
  	}
+@@ -1808,7 +1808,7 @@ int32_t scap_disable_dynamic_snaplen(scap_t* handle)
+ 
+ const char* scap_get_host_root()
+ {
+-	char* p = getenv("SYSDIG_HOST_ROOT");
++	char* p = getenv("HOST_ROOT");
+ 	static char env_str[SCAP_MAX_PATH_SIZE + 1];
+ 	static bool inited = false;
+ 	if (! inited) {


### PR DESCRIPTION
The HOST_ROOT environment variable was incorrectly detected when
deploying Falco inside a container.

Co-Authored-By: Leonardo Di Donato <leodidonato@gmail.com>
Signed-off-by: Lorenzo Fontana <lo@linux.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #1084 
Fixes #865 
Fixes #1075 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix: HOST_ROOT environment variable detection
```
