### PR TITLE
Add missing privileges for the apps Kubernetes API group

### DIFF
--- a/integrations/k8s-using-daemonset/k8s-with-rbac/falco-account.yaml
+++ b/integrations/k8s-using-daemonset/k8s-with-rbac/falco-account.yaml
@@ -17,6 +17,9 @@ rules:
   - apiGroups: ["extensions",""]
     resources: ["nodes","namespaces","pods","replicationcontrollers","replicasets","services","daemonsets","deployments","events","configmaps"]
     verbs: ["get","list","watch"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets","deployments","replicasets","statefulsets"]
+    verbs: ["get","list","watch"]
   - nonResourceURLs: ["/healthz", "/healthz/*"]
     verbs: ["get"]
 ---

--- a/integrations/k8s-using-deployment/k8s-with-rbac/falco-k8s-audit-account.yaml
+++ b/integrations/k8s-using-deployment/k8s-with-rbac/falco-k8s-audit-account.yaml
@@ -17,6 +17,9 @@ rules:
   - apiGroups: ["extensions",""]
     resources: ["nodes","namespaces","pods","replicationcontrollers","replicasets","services","daemonsets","deployments","events","configmaps"]
     verbs: ["get","list","watch"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets","deployments","replicasets","statefulsets"]
+    verbs: ["get","list","watch"]
   - nonResourceURLs: ["/healthz", "/healthz/*"]
     verbs: ["get"]
 ---


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area integrations

**What this PR does / why we need it**:
In [falco/integrations/k8s-using-daemonset/k8s-with-rbac/falco-account.yaml](https://github.com/falcosecurity/falco/blob/master/integrations/k8s-using-daemonset/k8s-with-rbac/falco-account.yaml#L17), we create a ClusterRole for the Falco ServiceAccount. I reviewed our kube audit logs and saw that Falco was getting an access denied on:

- `watch` `/apis/apps/v1/watch/deployments?pretty=false`
- `watch` `/apis/apps/v1/watch/replicasets?pretty=false`
- `watch` `/apis/apps/v1/watch/daemonsets?pretty=false`

Falco tries those call over and over again which floods audit logs and I'm quite sure Falco is not working as expected without that privilege.

This PR adds the missing privileges and we stop seeing errors in Kubernetes audit logs. We also expect Falco to work a little bit better with those privileges.

**Which issue(s) this PR fixes**:
Fixes #1064

**Does this PR introduce a user-facing change?**:
```release-note
Added missing privileges for the apps Kubernetes API group in the falco-cluster-role when using RBAC.
```
