### PR TITLE
rule(Write below root): use pmatch to check against known root direct…

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1361,7 +1361,7 @@
   condition: >
     root_dir and evt.dir = < and open_write
     and not fd.name in (known_root_files)
-    and not fd.directory in (known_root_directories)
+    and not fd.directory pmatch (known_root_directories)
     and not exe_running_docker_save
     and not gugent_writing_guestagent_log
     and not dse_writing_tmp


### PR DESCRIPTION
…ories

Signed-off-by: kaizhe <derek0405@gmail.com>


**What type of PR is this?**

 /kind rule-update

**Any specific area of the project related to this PR?**

 /area rules

**What this PR does / why we need it**:

When check against directories, we want to also check the subdirectories as well, so `in` is not the best option, use `pmatch` instead.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
rule(Write below root): use pmatch to check against known root directories
```
