### PR TITLE
Create a macro to whitelist terminal usage in containers

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1929,12 +1929,18 @@
   priority: INFO
   tags: [users, mitre_remote_access_tools]
 
+# In some cases, a shell is expected to be run in a container. For example, configuration
+# management software may do this, which is expected.
+- macro: user_expected_terminal_shell_in_container_conditions
+  condition: (never_true)
+
 - rule: Terminal shell in container
   desc: A shell was used as the entrypoint/exec point into a container with an attached terminal.
   condition: >
     spawned_process and container
     and shell_procs and proc.tty != 0
     and container_entrypoint
+    and not user_expected_terminal_shell_in_container_conditions
   output: >
     A shell was spawned in a container with an attached terminal (user=%user.name %container.info
     shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

This PR simply adds a macro to allow exclusion conditions to be set for the `Terminal shell in container` rule. There are some use-cases under which this is normal and should be ignored. For example, some configuration management tools can be run inside docker and operate with an interactive terminal. Falco generates an alert from this, but it's expected to happen for the configuration manager, so it would be nice to be able to whitelist just the configuration management tool.

**Which issue(s) this PR fixes**:

No issues open for this.

**Does this PR introduce a user-facing change?**:

```release-note
rule(macro user_expected_terminal_shell_in_container_conditions): allow whitelisting terminals in containers under specific conditions
```
