### PR TITLE
Correct "drivers build gruid" URLs

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -224,7 +224,7 @@ load_kernel_module() {
 	fi
 
 	local URL
-	URL=$(echo "${DRIVERS_REPO}/kernel-module/${DRIVER_VERSION}/${FALCO_KERNEL_MODULE_FILENAME}" | sed s/+/%2B/g)
+	URL=$(echo "${DRIVERS_REPO}/${DRIVER_VERSION}/${FALCO_KERNEL_MODULE_FILENAME}" | sed s/+/%2B/g)
 
 	echo "* Trying to download prebuilt module from ${URL}"
 	if curl --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${URL}"; then
@@ -376,7 +376,7 @@ load_bpf_probe() {
 
 	if [ ! -f "${HOME}/.falco/${BPF_PROBE_FILENAME}" ]; then
 		local URL
-		URL=$(echo "${DRIVERS_REPO}/ebpf-probe/${DRIVER_VERSION}/${BPF_PROBE_FILENAME}" | sed s/+/%2B/g)
+		URL=$(echo "${DRIVERS_REPO}/${DRIVER_VERSION}/${BPF_PROBE_FILENAME}" | sed s/+/%2B/g)
 
 		echo "* Trying to download a prebuilt eBPF probe from ${URL}"
 


### PR DESCRIPTION
Co-authored-by: Lorenzo Fontana <lo@linux.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

NONE

**What this PR does / why we need it**:

It fixes the URL from which the `falco-driver-loader` script fetches the drivers.

In fact, the correct URL does not contain the distinction between the driver type (eBPF probe or kernel module): the structure is flat on the server.

Eg., 

https://dl.bintray.com/driver/$driver_version$/falco_$target$_$kernelrelease$_$kernelversion$.[ko|o]

**Which issue(s) this PR fixes**:

Fixes #1125 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
fix(scripts): fetch drivers (kernel module or eBPF probe) from correct URL
```
