### PR TITLE
Fix falco driver loader to follow redirects

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,8 +27,7 @@ Finally, on the proposed due date the assignees for the upcoming release proceed
 - Double-check if any hard-coded version number is present in the code, it should be not present anywhere:
     - If any, manually correct it then open an issue to automate version number bumping later
     - Versions table in the `README.md` update itself automatically
-- Generate the change log https://github.com/leodido/rn2md
-    - [leo/lore] gotta move this (and merge it with Lorenzo's one) into test-infra
+- Generate the change log https://github.com/leodido/rn2md, or https://fs.fntlnz.wtf/falco/milestones-changelog.txt for the lazy people (it updates every 5 minutes) 
 - Add the lastest changes on top the previous `CHANGELOG.md`
 - Submit a PR with the above modifications
 - Await PR approval
@@ -76,5 +75,5 @@ Let `x.y.z` the new version.
 
 Announce the new release to the world!
 
-- Send an announcement to cncf-falco-dev@lists.cncf.io
+- Send an announcement to cncf-falco-dev@lists.cncf.io (plain text, please)
 - Let folks in the slack #falco channel know about a new release came out

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2664,7 +2664,7 @@
   condition: (container.image.repository endswith "sysdig/agent" or container.image.repository endswith "falcosecurity/falco")
   append: false
 
-# The rule is disabled by default. 
+# The rule is disabled by default.
 # Note: falco will send DNS request to resolve miner pool domain which may trigger alerts in your environment.
 - rule: Detect outbound connections to common miner pool ports
   desc: Miners typically connect to miner pools on common ports.
@@ -2685,10 +2685,10 @@
   items: [docker, kubectl, crictl]
 
 # Whitelist for known docker client binaries run inside container
-# - k8s.gcr.io/fluentd-gcp-scaler in GCP/GKE 
+# - k8s.gcr.io/fluentd-gcp-scaler in GCP/GKE
 - macro: user_known_k8s_client_container
   condition: (k8s.ns.name="kube-system" and container.image.repository=k8s.gcr.io/fluentd-gcp-scaler)
-  
+ 
 - rule: The docker client is executed in a container
   desc: Detect a k8s client tool executed inside a container
   condition: spawned_process and container and not user_known_k8s_client_container and proc.name in (k8s_client_binaries)
@@ -2712,7 +2712,7 @@
   output: Packet socket was created in a container (user=%user.name command=%proc.cmdline socket_info=%evt.args container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority: NOTICE
   tags: [network, mitre_discovery]
-  
+ 
 # Change to (always_true) to enable rule 'Network connection outside local subnet'
 - macro: enabled_rule_network_only_subnet
   condition: (never_true)
@@ -2723,7 +2723,7 @@
 
 # Namespaces where the rule is enforce
 - list: namespace_scope_network_only_subnet
-  items: [] 
+  items: []
 
 - macro: network_local_subnet
   condition: >
@@ -2736,25 +2736,23 @@
 # # Add 'default' to namespace_scope_network_only_subnet
 # # Run:
 # kubectl run --generator=run-pod/v1 -n default -i --tty busybox --image=busybox --rm -- wget google.com -O /var/google.html
-# # Check logs running  
+# # Check logs running
 
 - rule: Network Connection outside Local Subnet
   desc: Detect traffic to image outside local subnet.
   condition: >
     enabled_rule_network_only_subnet and
-    inbound_outbound and 
+    inbound_outbound and
     container and
     not network_local_subnet and
     k8s.ns.name in (namespace_scope_network_only_subnet)
   output: >
     Network connection outside local subnet
-    (command=%proc.cmdline connection=%fd.name user=%user.name container_id=%container.id 
-    image=%container.image.repository namespace=%k8s.ns.name
-    fd.rip.name=%fd.rip.name fd.lip.name=%fd.lip.name fd.cip.name=%fd.cip.name fd.sip.name=%fd.sip.name)
+    (command=%proc.cmdline connection=%fd.name user=%user.name container_id=%container.id
+     image=%container.image.repository namespace=%k8s.ns.name
+     fd.rip.name=%fd.rip.name fd.lip.name=%fd.lip.name fd.cip.name=%fd.cip.name fd.sip.name=%fd.sip.name)
   priority: WARNING
   tags: [network]
-  
-
 
 - macro: allowed_port
   condition: (never_true)
@@ -2795,7 +2793,7 @@
   priority: WARNING
   tags: [network]
 
-- rule: Redirect stdout/stdin to network connection in container 
+- rule: Redirect STDOUT/STDIN to Network Connection in Container
   desc: Detect redirecting stdout/stdin to network connection in container (potential reverse shell).
   condition: evt.type=dup and evt.dir=> and container and fd.num in (0, 1, 2) and fd.type in ("ipv4", "ipv6")
   output: >

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -227,7 +227,7 @@ load_kernel_module() {
 	URL=$(echo "${DRIVERS_REPO}/${DRIVER_VERSION}/${FALCO_KERNEL_MODULE_FILENAME}" | sed s/+/%2B/g)
 
 	echo "* Trying to download prebuilt module from ${URL}"
-	if curl --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${URL}"; then
+	if curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${URL}"; then
 		echo "Download succeeded, loading module"
 		insmod "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}"
 		exit $?
@@ -340,7 +340,7 @@ load_bpf_probe() {
 			mkdir -p /tmp/kernel
 			cd /tmp/kernel || exit
 			cd "$(mktemp -d -p /tmp/kernel)" || exit
-			if ! curl -o kernel-sources.tgz --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" "${BPF_KERNEL_SOURCES_URL}"; then
+			if ! curl -L -o kernel-sources.tgz --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" "${BPF_KERNEL_SOURCES_URL}"; then
 				exit 1;
 			fi
 
@@ -380,7 +380,7 @@ load_bpf_probe() {
 
 		echo "* Trying to download a prebuilt eBPF probe from ${URL}"
 
-		curl --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${BPF_PROBE_FILENAME}" "${URL}"
+		curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${BPF_PROBE_FILENAME}" "${URL}"
 	fi
 
 	if [ -f "${HOME}/.falco/${BPF_PROBE_FILENAME}" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind bug
/kind feature
/area build
/area integrations

**What this PR does / why we need it**:
This PR fix a curl execution into falco-driver-loader. The command need -L to follow redirects, the URL "https://dl.bintray.com/falcosecurity/driver/XXXXX" it's a CDN, and the exact behaviour (whether you get redirected or not) might depend on your location, so to fix this we need to set the -L to curl cuz curl does not follow redirects by default.
**Which issue(s) this PR fixes**:
This PR fix a curl execution into falco-driver-loader. The command need -L to follow redirects, the URL "https://dl.bintray.com/falcosecurity/driver/XXXXX" it's a CDN, and the exact behaviour (whether you get redirected or not) might depend on your location, so to fix this we need to set the -L to curl cuz curl does not follow redirects by default.

**Does this PR introduce a user-facing change?**:
No. 

```release-note

NONE

```