### PR TITLE
fixing curl command error 0 bytes for CDN download.

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -227,7 +227,7 @@ load_kernel_module() {
 	URL=$(echo "${DRIVERS_REPO}/${DRIVER_VERSION}/${FALCO_KERNEL_MODULE_FILENAME}" | sed s/+/%2B/g)
 
 	echo "* Trying to download prebuilt module from ${URL}"
-	if curl --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${URL}"; then
+	if curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${URL}"; then
 		echo "Download succeeded, loading module"
 		insmod "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}"
 		exit $?
@@ -340,7 +340,7 @@ load_bpf_probe() {
 			mkdir -p /tmp/kernel
 			cd /tmp/kernel || exit
 			cd "$(mktemp -d -p /tmp/kernel)" || exit
-			if ! curl -o kernel-sources.tgz --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" "${BPF_KERNEL_SOURCES_URL}"; then
+			if ! curl -L -o kernel-sources.tgz --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" "${BPF_KERNEL_SOURCES_URL}"; then
 				exit 1;
 			fi
 
@@ -380,7 +380,7 @@ load_bpf_probe() {
 
 		echo "* Trying to download a prebuilt eBPF probe from ${URL}"
 
-		curl --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${BPF_PROBE_FILENAME}" "${URL}"
+		curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${BPF_PROBE_FILENAME}" "${URL}"
 	fi
 
 	if [ -f "${HOME}/.falco/${BPF_PROBE_FILENAME}" ]; then


### PR DESCRIPTION
Signed-off-by: Stuxend <friquet@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area build
/area integrations

**What this PR does / why we need it**:
This PR fix a curl execution into falco-driver-loader. The command need -L to follow redirects, the URL "https://dl.bintray.com/falcosecurity/driver/XXXXX" it's a CDN, and the exact behaviour (whether you get redirected or not) might depend on your location, so to fix this we need to set the -L to curl cuz curl does not follow redirects by default.

**Which issue(s) this PR fixes**:
This PR fix a curl execution into falco-driver-loader. The command need -L to follow redirects, the URL "https://dl.bintray.com/falcosecurity/driver/XXXXX" it's a CDN, and the exact behaviour (whether you get redirected or not) might depend on your location, so to fix this we need to set the -L to curl cuz curl does not follow redirects by default.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
Just added the "-L" flag to follow redirects into curl for the CDN.
**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
