### PR TITLE
fix(cmake/modules): update driver to support kernels 5.6.y

### DIFF
--- a/cmake/modules/sysdig.cmake
+++ b/cmake/modules/sysdig.cmake
@@ -26,8 +26,8 @@ file(MAKE_DIRECTORY ${SYSDIG_CMAKE_WORKING_DIR})
 # To update sysdig version for the next release, change the default below
 # In case you want to test against another sysdig version just pass the variable - ie., `cmake -DSYSDIG_VERSION=dev ..`
 if(NOT SYSDIG_VERSION)
-  set(SYSDIG_VERSION "a259b4bf49c3330d9ad6c3eed9eb1a31954259a6")
-  set(SYSDIG_CHECKSUM "SHA256=fdbeb8d182e6383fe89428e0934d521636068f62109c1b3ca11689d886458284")
+  set(SYSDIG_VERSION "47374b2b73734d509f3c99890c80be5242021c3d")
+  set(SYSDIG_CHECKSUM "SHA256=df73b5c69eca8880e30c618dc47b995140286b47fa845c97a3d7a6ddb2d6f1b1")
 endif()
 set(PROBE_VERSION "${SYSDIG_VERSION}")
 


### PR DESCRIPTION
Co-authored-by: Lorenzo Fontana <lo@linux.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>



**What type of PR is this?**

/kind bug





**Any specific area of the project related to this PR?**
/area build





**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1173 
Refs https://github.com/draios/sysdig/pull/1621

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix: support Falco driver on Linux kernels 5.6.y
```
