### PR TITLE
Falco build for ARM armv7 armv6

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,13 @@
+# Build Directory
+
+This is a special directory that is used to compile Falco.
+The flags and their options are defined in `init.sh`.
+Please edit `init.sh` to your liking.
+
+Then build Falco from this directory.
+
+```
+./init.sh
+make all
+```
+

--- a/build/init.sh
+++ b/build/init.sh
@@ -17,6 +17,5 @@ cmake ../ \
       -DBUILD_WARNINGS_AS_ERRORS="OFF" \
       -DCMAKE_BUILD_TYPE="Release" \
       -DCMAKE_INSTALL_PREFIX="/usr" \
-      -DDRAIOS_DEBUG_FLAGS="-D_DEBUG" \
       -DFALCO_ETC_DIR="/etc/falco" \
       -DUSE_BUNDLED_DEPS=OFF

--- a/build/init.sh
+++ b/build/init.sh
@@ -12,12 +12,6 @@
 # specific language governing permissions and limitations under the License.
 #
 
-
-# @kris-nova We have experimental support for ARM and I have tested
-# on armv7. Please use this flag as experimental only.
-BUILD_ARM=false
-
-
 cmake ../ \
       -DBUILD_BPF=OFF \
       -DBUILD_WARNINGS_AS_ERRORS="OFF" \
@@ -27,9 +21,3 @@ cmake ../ \
       -DFALCO_ETC_DIR="/etc/falco" \
       -DUSE_BUNDLED_DEPS=OFF
 
-if [ BUILD_ARM ]; then
-   driver_config="./driver/src/driver_config.h"
-   if ! grep -q "CONFIG_ARM" $driver_config; then
-       printf "\n#define CONFIG_ARM\n\n" >> $driver_config
-   fi
-fi   

--- a/build/init.sh
+++ b/build/init.sh
@@ -15,9 +15,8 @@
 cmake ../ \
       -DBUILD_BPF=OFF \
       -DBUILD_WARNINGS_AS_ERRORS="OFF" \
-      -DCMAKE_BUILD_TYPE="debug" \
+      -DCMAKE_BUILD_TYPE="Release" \
       -DCMAKE_INSTALL_PREFIX="/usr" \
       -DDRAIOS_DEBUG_FLAGS="-D_DEBUG" \
       -DFALCO_ETC_DIR="/etc/falco" \
       -DUSE_BUNDLED_DEPS=OFF
-

--- a/build/init.sh
+++ b/build/init.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright (C) 2019 The Falco Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+
+# @kris-nova We have experimental support for ARM and I have tested
+# on armv7. Please use this flag as experimental only.
+BUILD_ARM=false
+
+
+cmake ../ \
+      -DBUILD_BPF=OFF \
+      -DBUILD_WARNINGS_AS_ERRORS="OFF" \
+      -DCMAKE_BUILD_TYPE="debug" \
+      -DCMAKE_INSTALL_PREFIX="/usr" \
+      -DDRAIOS_DEBUG_FLAGS="-D_DEBUG" \
+      -DFALCO_ETC_DIR="/etc/falco" \
+      -DUSE_BUNDLED_DEPS=OFF
+
+if [ BUILD_ARM ]; then
+   driver_config="./driver/src/driver_config.h"
+   if ! grep -q "CONFIG_ARM" $driver_config; then
+       printf "\n#define CONFIG_ARM\n\n" >> $driver_config
+   fi
+fi   


### PR DESCRIPTION
Adding some files to the build dir to make it easier to build Falco.
Right now checking out the repository on Linux is a bit confusing.
Now the cmake flags are defined in a convenience scripts /build/init.sh
So they can be easily switched while building.

Note that the true changes needed were mostly cosmetic and related to dependencies with Falco.

If you are using the Sysdig driver with Falco and would like to run Falco on a Raspberry Pi or another similar arm chip you will need to do a few things

## Ensure Linux Headers

Ensure you have the linux headers specific for your machine installed for the same kernel version you are using. For instance if you are running arch linux on ARM running on a Raspberry Pi 4 you are giving a few options.

```
[novix@novix build]$ pacaur -S linux-headers
:: There are 16 providers available for linux-headers:
:: Repository core
   1) linux-am33x-headers  2) linux-armv7-headers  3) linux-armv7-rc-headers  4) linux-clearfog-headers  5) linux-cubox-headers
   6) linux-headers-odroid  7) linux-headers-utilite-dt  8) linux-imx6-headers  9) linux-odroid-c1-headers  10) linux-odroid-xu3-headers
   11) linux-peach-headers  12) linux-raspberrypi-headers  13) linux-raspberrypi4-headers  14) linux-utilite-headers
   15) linux-veyron-headers  16) linux-zedboard-headers
```

I am running a raspberry pi 4, so I used `13)`. Use your best judgement here, and feel free to try other potential candidates if things aren't working well or are compiling to the wrong arch (for instance `12)` compiles Falco for armv6 wheras `13)` compiles falco for armv7.

Use `lscpu` to find out what chip you have. 

## Use the patched `libsinsp`

I opened up a PR here https://github.com/draios/sysdig/pull/1622 with changes for ARM. If you are trying to build this before that patch is merged you can manually make the change in `falco/build/sysdig-repo/sysdig-prefix/src/sysdig/userspace/libsinsp/cgroup_limits.cpp`

```
cd falco
emacs build/sysdig-repo/sysdig-prefix/src/sysdig/userspace/libsinsp/cgroup_limits.cpp
```

and change

```
constexpr const int64_t CGROUP_VAL_MAX = (1ULL << 42u) - 1;  
```

## Use the following cmake flags in the `init.sh` script in this PR


```
#!/bin/bash
#
# Copyright (C) 2019 The Falco Authors.
#
# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
# the License. You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
# specific language governing permissions and limitations under the License.
#


# @kris-nova We have experimental support for ARM and I have tested
# on armv7. Please use this flag as experimental only.
BUILD_ARM=true


cmake ../ \
      -DBUILD_BPF=OFF \
      -DBUILD_WARNINGS_AS_ERRORS="OFF" \
      -DCMAKE_BUILD_TYPE="debug" \
      -DCMAKE_INSTALL_PREFIX="/usr" \
      -DDRAIOS_DEBUG_FLAGS="-D_DEBUG" \
      -DFALCO_ETC_DIR="/etc/falco" \
      -DUSE_BUNDLED_DEPS=OFF

if [ BUILD_ARM ]; then
   driver_config="./driver/src/driver_config.h"
   if ! grep -q "CONFIG_ARM" $driver_config; then
       printf "\n#define CONFIG_ARM\n\n" >> $driver_config
   fi
fi 
```

Signed-off-by: Kris Nova <kris@nivenly.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

/kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area examples

> /area rules

> /area integrations

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #520
Fixes #586 


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Adding support for arm architecture for armv6 and armv7 chips (Tested with Raspberry Pi 3/4)
```
