### PR TITLE
fix driverloader dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,8 +231,7 @@ jobs:
       - run:
           name: Build and publish dev driverloader-dev
           command: |
-            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            docker build --build-arg FALCO_VERSION=${FALCO_VERSION} -t falcosecurity/driverloader:master docker/driverloader
+            docker build --build-arg FALCO_IMAGE_TAG=master -t falcosecurity/driverloader:master docker/driverloader
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
             docker push falcosecurity/driverloader:master
   # Publish the packages
@@ -301,7 +300,7 @@ jobs:
       - run:
           name: Build and publish driverloader
           command: |
-            docker build --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "falcosecurity/driverloader:${CIRCLE_TAG}" docker/driverloader
+            docker build --build-arg FALCO_IMAGE_TAG=${CIRCLE_TAG} -t "falcosecurity/driverloader:${CIRCLE_TAG}" docker/driverloader
             docker tag "falcosecurity/driverloader:${CIRCLE_TAG}" falcosecurity/driverloader:latest
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
             docker push "falcosecurity/driverloader:${CIRCLE_TAG}"

--- a/docker/driverloader/Dockerfile
+++ b/docker/driverloader/Dockerfile
@@ -1,11 +1,10 @@
-ARG FALCO_VERSION=latest
-FROM falcosecurity/falco:${FALCO_VERSION}
+ARG FALCO_IMAGE_TAG=latest
+FROM falcosecurity/falco:${FALCO_IMAGE_TAG}
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
 LABEL usage="docker run -i -t -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --name NAME IMAGE"
 
-ENV FALCO_VERSION=${FALCO_VERSION}
 ENV HOST_ROOT /host
 ENV HOME /root
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area examples

> /area rules

> /area integrations

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
The `publish/docker-dev` CI workflow is broken because of `FALCO_VERSION` does not match the image tag.

**Which issue(s) this PR fixes**:
[This](https://app.circleci.com/pipelines/github/falcosecurity/falco/360/workflows/7e514619-1052-4faa-9e4e-9266d28be246/jobs/1618)
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
~~`FALCO_VERSION` could be completely removed. I kept it because of the base image is declaring it [here](https://github.com/falcosecurity/falco/blob/24c0e80bd8e1a8b936f795260b1a9e1ce9e28599/docker/stable/Dockerfile#L11) and it's not the responsibility of the derived image deciding if `FALCO_VERSION` is used or not.~~

~~Later, if it was not used - as we suspect - , later we can clean it up from both images in another PR.~~

`FALCO_VERSION` is not needed here.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
