### PR TITLE
Allow exact rule matches ruleset

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 #
-set(FALCO_TESTS_SOURCES test_base.cpp engine/test_token_bucket.cpp falco/test_webserver.cpp)
+set(FALCO_TESTS_SOURCES test_base.cpp engine/test_token_bucket.cpp engine/test_rulesets.cpp falco/test_webserver.cpp)
 
 set(FALCO_TESTED_LIBRARIES falco_engine)
 

--- a/tests/engine/test_rulesets.cpp
+++ b/tests/engine/test_rulesets.cpp
@@ -1,0 +1,261 @@
+/*
+Copyright (C) 2020 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "ruleset.h"
+#include <catch.hpp>
+
+static bool exact_match = true;
+static bool substring_match = false;
+static bool enabled = true;
+static bool disabled = false;
+static uint16_t default_ruleset = 0;
+static uint16_t non_default_ruleset = 3;
+static uint16_t other_non_default_ruleset = 2;
+static std::set<std::string> tags = {"some_tag", "some_other_tag"};
+static std::set<uint32_t> event_tags = {1};
+
+TEST_CASE("Should enable/disable for exact match w/ default ruleset", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *filter = new gen_event_filter();
+	string rule_name = "one_rule";
+
+	r.add(rule_name, tags, event_tags, filter);
+
+	r.enable("one_rule", exact_match, enabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
+
+	r.enable("one_rule", exact_match, disabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+}
+
+TEST_CASE("Should enable/disable for exact match w/ specific ruleset", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *filter = new gen_event_filter();
+	string rule_name = "one_rule";
+
+	r.add(rule_name, tags, event_tags, filter);
+
+	r.enable("one_rule", exact_match, enabled, non_default_ruleset);
+	REQUIRE(r.num_rules_for_ruleset(non_default_ruleset) == 1);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+	REQUIRE(r.num_rules_for_ruleset(other_non_default_ruleset) == 0);
+
+	r.enable("one_rule", exact_match, disabled, non_default_ruleset);
+	REQUIRE(r.num_rules_for_ruleset(non_default_ruleset) == 0);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+	REQUIRE(r.num_rules_for_ruleset(other_non_default_ruleset) == 0);
+}
+
+TEST_CASE("Should not enable for exact match different rule name", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *filter = new gen_event_filter();
+	string rule_name = "one_rule";
+
+	r.add(rule_name, tags, event_tags, filter);
+
+	r.enable("some_other_rule", exact_match, enabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+}
+
+TEST_CASE("Should enable/disable for exact match w/ substring and default ruleset", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *filter = new gen_event_filter();
+	string rule_name = "one_rule";
+
+	r.add(rule_name, tags, event_tags, filter);
+
+	r.enable("one_rule", substring_match, enabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
+
+	r.enable("one_rule", substring_match, disabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+}
+
+TEST_CASE("Should not enable for substring w/ exact_match", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *filter = new gen_event_filter();
+	string rule_name = "one_rule";
+
+	r.add(rule_name, tags, event_tags, filter);
+
+	r.enable("one_", exact_match, enabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+}
+
+TEST_CASE("Should enable/disable for prefix match w/ default ruleset", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *filter = new gen_event_filter();
+	string rule_name = "one_rule";
+
+	r.add(rule_name, tags, event_tags, filter);
+
+	r.enable("one_", substring_match, enabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
+
+	r.enable("one_", substring_match, disabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+}
+
+TEST_CASE("Should enable/disable for suffix match w/ default ruleset", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *filter = new gen_event_filter();
+	string rule_name = "one_rule";
+
+	r.add(rule_name, tags, event_tags, filter);
+
+	r.enable("_rule", substring_match, enabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
+
+	r.enable("_rule", substring_match, disabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+}
+
+TEST_CASE("Should enable/disable for substring match w/ default ruleset", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *filter = new gen_event_filter();
+	string rule_name = "one_rule";
+
+	r.add(rule_name, tags, event_tags, filter);
+
+	r.enable("ne_ru", substring_match, enabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
+
+	r.enable("ne_ru", substring_match, disabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+}
+
+TEST_CASE("Should enable/disable for substring match w/ specific ruleset", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *filter = new gen_event_filter();
+	string rule_name = "one_rule";
+
+	r.add(rule_name, tags, event_tags, filter);
+
+	r.enable("ne_ru", substring_match, enabled, non_default_ruleset);
+	REQUIRE(r.num_rules_for_ruleset(non_default_ruleset) == 1);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+	REQUIRE(r.num_rules_for_ruleset(other_non_default_ruleset) == 0);
+
+	r.enable("ne_ru", substring_match, disabled, non_default_ruleset);
+	REQUIRE(r.num_rules_for_ruleset(non_default_ruleset) == 0);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+	REQUIRE(r.num_rules_for_ruleset(other_non_default_ruleset) == 0);
+}
+
+TEST_CASE("Should enable/disable for tags w/ default ruleset", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *filter = new gen_event_filter();
+	string rule_name = "one_rule";
+	std::set<std::string> want_tags = {"some_tag"};
+
+	r.add(rule_name, tags, event_tags, filter);
+
+	r.enable_tags(want_tags, enabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
+
+	r.enable_tags(want_tags, disabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+}
+
+TEST_CASE("Should enable/disable for tags w/ specific ruleset", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *filter = new gen_event_filter();
+	string rule_name = "one_rule";
+	std::set<std::string> want_tags = {"some_tag"};
+
+	r.add(rule_name, tags, event_tags, filter);
+
+	r.enable_tags(want_tags, enabled, non_default_ruleset);
+	REQUIRE(r.num_rules_for_ruleset(non_default_ruleset) == 1);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+	REQUIRE(r.num_rules_for_ruleset(other_non_default_ruleset) == 0);
+
+	r.enable_tags(want_tags, disabled, non_default_ruleset);
+	REQUIRE(r.num_rules_for_ruleset(non_default_ruleset) == 0);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+	REQUIRE(r.num_rules_for_ruleset(other_non_default_ruleset) == 0);
+}
+
+TEST_CASE("Should not enable for different tags", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *filter = new gen_event_filter();
+	string rule_name = "one_rule";
+	std::set<std::string> want_tags = {"some_different_tag"};
+
+	r.add(rule_name, tags, event_tags, filter);
+
+	r.enable_tags(want_tags, enabled);
+	REQUIRE(r.num_rules_for_ruleset(non_default_ruleset) == 0);
+}
+
+TEST_CASE("Should enable/disable for overlapping tags", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *filter = new gen_event_filter();
+	string rule_name = "one_rule";
+	std::set<std::string> want_tags = {"some_tag", "some_different_tag"};
+
+	r.add(rule_name, tags, event_tags, filter);
+
+	r.enable_tags(want_tags, enabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
+
+	r.enable_tags(want_tags, disabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+}
+
+TEST_CASE("Should enable/disable for incremental adding tags", "[rulesets]")
+{
+	falco_ruleset r;
+	gen_event_filter *rule1_filter = new gen_event_filter();
+	string rule1_name = "one_rule";
+	std::set<std::string> rule1_tags = {"rule1_tag"};
+	r.add(rule1_name, rule1_tags, event_tags, rule1_filter);
+
+	gen_event_filter *rule2_filter = new gen_event_filter();
+	string rule2_name = "two_rule";
+	std::set<std::string> rule2_tags = {"rule2_tag"};
+	r.add(rule2_name, rule2_tags, event_tags, rule2_filter);
+
+	std::set<std::string> want_tags;
+
+	want_tags = rule1_tags;
+	r.enable_tags(want_tags, enabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
+
+	want_tags = rule2_tags;
+	r.enable_tags(want_tags, enabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 2);
+
+	r.enable_tags(want_tags, disabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
+
+	want_tags = rule1_tags;
+	r.enable_tags(want_tags, disabled);
+	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
+}

--- a/tests/engine/test_token_bucket.cpp
+++ b/tests/engine/test_token_bucket.cpp
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <memory>
+
 #include "token_bucket.h"
 #include <catch.hpp>
 
@@ -21,7 +23,7 @@ using namespace Catch::literals;
 
 TEST_CASE("token bucket default ctor", "[token_bucket]")
 {
-	auto tb = new token_bucket();
+	auto tb = std::make_shared<token_bucket>();
 
 	REQUIRE(tb->get_tokens() == 1);
 
@@ -38,7 +40,7 @@ TEST_CASE("token bucket default ctor", "[token_bucket]")
 TEST_CASE("token bucket ctor with custom timer", "[token_bucket]")
 {
 	auto t = []() -> uint64_t { return 22; };
-	auto tb = new token_bucket(t);
+	auto tb = std::make_shared<token_bucket>(t);
 
 	REQUIRE(tb->get_tokens() == 1);
 	REQUIRE(tb->get_last_seen() == 22);
@@ -46,7 +48,7 @@ TEST_CASE("token bucket ctor with custom timer", "[token_bucket]")
 
 TEST_CASE("token bucket with 2 tokens/sec rate, max 10 tokens", "[token_bucket]")
 {
-	auto tb = new token_bucket();
+	auto tb = std::make_shared<token_bucket>();
 	tb->init(2.0, 10, 1);
 
 	SECTION("claiming 5 tokens")

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -211,14 +211,29 @@ void falco_engine::load_rules_file(const string &rules_filename, bool verbose, b
 void falco_engine::enable_rule(const string &substring, bool enabled, const string &ruleset)
 {
 	uint16_t ruleset_id = find_ruleset_id(ruleset);
+	bool match_exact = false;
 
-	m_sinsp_rules->enable(substring, enabled, ruleset_id);
-	m_k8s_audit_rules->enable(substring, enabled, ruleset_id);
+	m_sinsp_rules->enable(substring, match_exact, enabled, ruleset_id);
+	m_k8s_audit_rules->enable(substring, match_exact, enabled, ruleset_id);
 }
 
 void falco_engine::enable_rule(const string &substring, bool enabled)
 {
 	enable_rule(substring, enabled, m_default_ruleset);
+}
+
+void falco_engine::enable_rule_exact(const string &rule_name, bool enabled, const string &ruleset)
+{
+	uint16_t ruleset_id = find_ruleset_id(ruleset);
+	bool match_exact = true;
+
+	m_sinsp_rules->enable(rule_name, match_exact, enabled, ruleset_id);
+	m_k8s_audit_rules->enable(rule_name, match_exact, enabled, ruleset_id);
+}
+
+void falco_engine::enable_rule_exact(const string &rule_name, bool enabled)
+{
+	enable_rule_exact(rule_name, enabled, m_default_ruleset);
 }
 
 void falco_engine::enable_rule_by_tag(const set<string> &tags, bool enabled, const string &ruleset)

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -85,6 +85,13 @@ public:
 	// Wrapper that assumes the default ruleset
 	void enable_rule(const std::string &substring, bool enabled);
 
+
+	// Like enable_rule, but the rule name must be an exact match.
+	void enable_rule_exact(const std::string &rule_name, bool enabled, const std::string &ruleset);
+
+	// Wrapper that assumes the default ruleset
+	void enable_rule_exact(const std::string &rule_name, bool enabled);
+
 	//
 	// Enable/Disable any rules with any of the provided tags (set, exact matches only)
 	//

--- a/userspace/engine/ruleset.cpp
+++ b/userspace/engine/ruleset.cpp
@@ -201,7 +201,7 @@ void falco_ruleset::add(string &name,
 	}
 }
 
-void falco_ruleset::enable(const string &substring, bool enabled, uint16_t ruleset)
+void falco_ruleset::enable(const string &substring, bool match_exact, bool enabled, uint16_t ruleset)
 {
 	while(m_rulesets.size() < (size_t)ruleset + 1)
 	{
@@ -212,7 +212,17 @@ void falco_ruleset::enable(const string &substring, bool enabled, uint16_t rules
 	{
 		bool matches;
 
-		matches = (substring == "" || (val.first.find(substring) != string::npos));
+		if(match_exact)
+		{
+			size_t pos = val.first.find(substring);
+
+			matches = (substring == "" || (pos == 0 &&
+						       substring.size() == val.first.size()));
+		}
+		else
+		{
+			matches = (substring == "" || (val.first.find(substring) != string::npos));
+		}
 
 		if(matches)
 		{

--- a/userspace/engine/ruleset.h
+++ b/userspace/engine/ruleset.h
@@ -45,8 +45,11 @@ public:
         // unnecessarily large vectors.
 
 	// Find those rules matching the provided substring and set
-	// their enabled status to enabled.
-	void enable(const std::string &substring, bool enabled, uint16_t ruleset = 0);
+	// their enabled status to enabled. If match_exact is true,
+	// substring must be an exact match for a given rule
+	// name. Otherwise, any rules having substring as a substring
+	// in the rule name are enabled/disabled.
+	void enable(const std::string &substring, bool match_exact, bool enabled, uint16_t ruleset = 0);
 
 	// Find those rules that have a tag in the set of tags and set
 	// their enabled status to enabled. Note that the enabled


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area examples

> /area rules

> /area integrations

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This adds unit tests for ruleset handling and adds the ability to only allow for exact matches when adding rules to the falco engine. The current behavior matches substrings. This is usually fine but there can be some cases where exact matches are better.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Add unit tests for ruleset handling, add ability to specify exact matches when adding rules to falco engine.
```
