### PR TITLE
update(.github): remove examples and integrations from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,11 +40,7 @@ Please remove the leading whitespace before the `/kind <>` you uncommented.
 
 > /area engine
 
-> /area examples
-
 > /area rules
-
-> /area integrations
 
 > /area tests
 


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>



**What type of PR is this?**



/kind documentation



**Any specific area of the project related to this PR?**



NONE

**What this PR does / why we need it**:

Cleanups the PR template. No more area/examples, and area/integrations as per recent discussions on Artifacts.

**Which issue(s) this PR fixes**:

Refs #1114 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
