### PR TITLE
fix(falco-driver-loader): target for ubuntu is ubuntu-generic

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -131,7 +131,7 @@ get_target_id() {
 		if [[ $KERNEL_RELEASE == *"aws"* ]]; then
 			TARGET_ID="ubuntu-aws"
 		else
-			TARGET_ID="ubuntu"
+			TARGET_ID="ubuntu-generic"
 		fi
 		;;
 	(*)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

The upstream files for the generic Ubuntu kernel are all called ubuntu-generic instead of ubuntu
see: https://dl.bintray.com/falcosecurity/driver/96bd9bc560f67742738eb7255aeb4d03046b8045/

**Which issue(s) this PR fixes**:



Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
fix(scripts): upstream files (prebuilt drivers) for the generic Ubuntu kernel contains "ubuntu-generic"
```
