### PR TITLE
rule(macro user_known_set_setuid_or_setgid_bit_conditions): create macro

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2514,6 +2514,12 @@
 - list: user_known_chmod_applications
   items: [hyperkube, kubelet]
 
+# This macro should be overridden in user rules as needed. This is useful if a given application
+# should not be ignored alltogether with the user_known_chmod_applications list, but only in
+# specific conditions.
+- macro: user_known_set_setuid_or_setgid_bit_conditions
+  condition: (never_true)
+
 - rule: Set Setuid or Setgid bit
   desc: >
     When the setuid or setgid bits are set for an application,
@@ -2523,6 +2529,7 @@
     consider_all_chmods and chmod and (evt.arg.mode contains "S_ISUID" or evt.arg.mode contains "S_ISGID")
     and not proc.name in (user_known_chmod_applications)
     and not exe_running_docker_save
+    and not user_known_set_setuid_or_setgid_bit_conditions
   output: >
     Setuid or setgid bit is set via chmod (fd=%evt.arg.fd filename=%evt.arg.filename mode=%evt.arg.mode user=%user.name process=%proc.name
     command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

This macro will be useful because it will make it possible to filter out
events with a higher degree of granularity than is currently possible
for the `Set Setuid or Setgid bit` rule.

For example, if some application is expected to set the setuid or the
setgid bit under a specific condition, like if it's started with a
specific command, then the `user_known_chmod_applications` list is not
enough because we don't want to filter out _all_ events by this
application, only specific ones. This macro allows that.

A concrete example of this is when using docker-in-docker : the `dockerd` process is triggering the `Set Setuid or Setgid bit` rule and every time it does, `proc.cmdline` is the same. This is expected in our case, but we don't want to just ignore _all_ events from `dockerd` within this rule, just this specific one with this specific `proc.cmdline` value.

**Which issue(s) this PR fixes**:

None

**Does this PR introduce a user-facing change?**:

```release-note
rule(macro user_known_set_setuid_or_setgid_bit_conditions): create macro
```
