### PR TITLE
Change chread namespace

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1551,7 +1551,7 @@
     and not proc.name in (user_known_change_thread_namespace_binaries)
     and not proc.name startswith "runc"
     and not proc.cmdline startswith "containerd"
-    and not proc.pname in (sysdigcloud_binaries, hyperkube, kubelet)
+    and not proc.pname in (sysdigcloud_binaries, hyperkube, kubelet, protokube, dockerd, tini, aws)
     and not python_running_sdchecks
     and not java_running_sdjagent
     and not kubelet_running_loopback

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -848,7 +848,8 @@
 - macro: exe_running_docker_save
   condition: >
     proc.name = "exe"
-    and proc.cmdline contains "/var/lib/docker"
+    and (proc.cmdline contains "/var/lib/docker"
+    or proc.cmdline contains "/var/run/docker")
     and proc.pname in (dockerd, docker)
 
 # Ideally we'd have a length check here as well but sysdig


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

**Editing the `exe_running_docker_save` macro**:
While using Falco, I noticed we were getting many events that were virtually identical to those that were previously filtered out by the `exe_running_docker_save` macro, but where the `cmdline` was something like `exe /var/run/docker/netns/cc5c7b9bb110 all false`. I believe this is caused by the use of docker-in-docker. This is removed by the new `or proc.cmdline contains "/var/run/docker"` part of the macro.

**`Change thread namespace` rule edit**:
These application binaries raise events in the `Change thread namespace` rule as part of their normal operation.

Here are more details regarding each binary :

- `protokube` : See [this](https://github.com/kubernetes/kops/tree/master/protokube)
- `dockerd` : The `dockerd` process name is whitelisted already in this
  rule, but not if it is the parent, which will happen if you are doing
  docker-in-docker.
- `tini` : See [this](https://github.com/krallin/tini)
- `aws` : This one I noticed because Falco itself uses the AWS CLI to
  send events to SNS, which was triggering this rule.

**Which issue(s) this PR fixes**:

None

**Does this PR introduce a user-facing change?**:

```release-note
Allow `protokube`, `dockerd`, `tini` and `aws` binaries to change thread namespace.
Edit `exe_running_docker_save` to filter out cmdlines containing `/var/run/docker`.
```
