### PR TITLE
Check keepalive first, and throttle try_pop

### DIFF
--- a/userspace/falco/grpc_server_impl.cpp
+++ b/userspace/falco/grpc_server_impl.cpp
@@ -40,13 +40,14 @@ void falco::grpc::server_impl::subscribe(const stream_context& ctx, const output
 		// Start or continue streaming
 		// todo(leodido) > check for m_status == stream_context::STREAMING?
 		// todo(leodido) > set m_stream
-		if(output::queue::get().try_pop(res) && !req.keepalive())
+		if(!req.keepalive() && output::queue::get().try_pop(res))
 		{
 			ctx.m_has_more = true;
 			return;
 		}
-		while(is_running() && !output::queue::get().try_pop(res) && req.keepalive())
+		while(is_running() && req.keepalive() && !output::queue::get().try_pop(res))
 		{
+			usleep(200);
 		}
 
 		ctx.m_has_more = !is_running() ? false : req.keepalive();


### PR DESCRIPTION
Signed-off-by: Chris Meyer <scallopboat@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind bug
<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**
/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Reduces the CPU usage of falco when the grpc server is enabled to ~15%.

**Which issue(s) this PR fixes**:
Fixes #1126 
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:
Submitted as a potential (short term?) fix.  It'd likely be better to refactor such that a sleep isn't needed by using a local queue as suggested on 05-20-20 call, but wanted to submit this option regardless.

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix: High CPU usage when grpc server is enabled [#1126]
```