### PR TITLE
correct rule conditions to support syscall variants 

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2238,7 +2238,7 @@
   desc: creating any files below /dev other than known programs that manage devices. Some rootkits hide files in /dev.
   condition: >
     fd.directory = /dev and
-    (evt.type = creat or (evt.type = open and evt.arg.flags contains O_CREAT))
+    (evt.type = creat or ((evt.type = open or evt.type = openat) and evt.arg.flags contains O_CREAT))
     and not proc.name in (dev_creation_binaries)
     and not fd.name in (allowed_dev_files)
     and not fd.name startswith /dev/tty

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -80,10 +80,10 @@
 
 - macro: bin_dir_mkdir
   condition: >
-    (evt.arg[1] startswith /bin/ or
-     evt.arg[1] startswith /sbin/ or
-     evt.arg[1] startswith /usr/bin/ or
-     evt.arg[1] startswith /usr/sbin/)
+     (evt.arg.path startswith /bin/ or
+     evt.arg.path startswith /sbin/ or
+     evt.arg.path startswith /usr/bin/ or
+     evt.arg.path startswith /usr/sbin/)
 
 - macro: bin_dir_rename
   condition: >

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -55,6 +55,7 @@
 - macro: proc_name_exists
   condition: (proc.name!="<NA>")
 
+# todo(leogr): we miss "renameat2", but it's not yet supported by sinsp
 - macro: rename
   condition: evt.type in (rename, renameat)
 - macro: mkdir
@@ -87,10 +88,22 @@
 
 - macro: bin_dir_rename
   condition: >
-    evt.arg[1] startswith /bin/ or
-    evt.arg[1] startswith /sbin/ or
-    evt.arg[1] startswith /usr/bin/ or
-    evt.arg[1] startswith /usr/sbin/
+     (evt.arg.path startswith /bin/ or
+     evt.arg.path startswith /sbin/ or
+     evt.arg.path startswith /usr/bin/ or
+     evt.arg.path startswith /usr/sbin/ or
+     evt.arg.name startswith /bin/ or
+     evt.arg.name startswith /sbin/ or
+     evt.arg.name startswith /usr/bin/ or
+     evt.arg.name startswith /usr/sbin/ or
+     evt.arg.oldpath startswith /bin/ or
+     evt.arg.oldpath startswith /sbin/ or
+     evt.arg.oldpath startswith /usr/bin/ or
+     evt.arg.oldpath startswith /usr/sbin/ or
+     evt.arg.newpath startswith /bin/ or
+     evt.arg.newpath startswith /sbin/ or
+     evt.arg.newpath startswith /usr/bin/ or
+     evt.arg.newpath startswith /usr/sbin/)
 
 - macro: etc_dir
   condition: fd.name startswith /etc/
@@ -1505,7 +1518,7 @@
 
 - rule: Modify binary dirs
   desc: an attempt to modify any file below a set of binary directories.
-  condition: (bin_dir_rename) and modify and not package_mgmt_procs and not exe_running_docker_save
+  condition: bin_dir_rename and modify and not package_mgmt_procs and not exe_running_docker_save
   output: >
     File below known binary directory renamed/removed (user=%user.name command=%proc.cmdline
     pcmdline=%proc.pcmdline operation=%evt.type file=%fd.name %evt.args container_id=%container.id image=%container.image.repository)


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes some rule/macro conditions to:

- [x] Make `Mkdir binary dirs` also work with `mkdirat` syscall
- [x] Make `Modify binary dirs` also work with `rename`, `renameat`, and `unlinkat` syscalls
- [x] Make `Create files below dev` also work with `openat` syscall

Additional context can be found in commits' messages.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

This is my first PR that fix the rules :)

*Test cases*

- `Mkdir binary dirs` with `mkdirat`
```shell
docker run --rm -it falcosecurity/event-generator:0.3.0 run syscall.MkdirBinaryDirs
```

- `Modify binary dirs` with `rename`
```shell
sudo touch /bin/test-falco-rules
sudo rename test-falco-rules test-falco-rules-renamed /bin/test-falco-rules
```

- `Modify binary dirs` with `renameat`
```shell
docker run --rm -it falcosecurity/event-generator:0.3.0 run syscall.ModifyBinaryDirs
```

- `Modify binary dirs` with `unlinkat`
```shell
sudo touch /bin/test-falco-rules
sudo rm /bin/test-falco-rules
```

- `Create files below dev` with `openat`
```shell
docker run --rm -it falcosecurity/event-generator:0.3.0 run syscall.CreateFilesBelowDev
```

*Additional notes*
There're still some missing syscalls that should be added but are not currently supported by sinsp, for example:
- `renameat2` ( see also https://github.com/draios/sysdig/issues/1603 )
- `openat2`

~~I will fill a separate issue for those~~ Reported on https://github.com/falcosecurity/falco/issues/676

*Related issues*
- https://github.com/falcosecurity/falco/issues/337
- An [experiment](https://github.com/falcosecurity/event-generator/tree/new/tester) to automatically test rules with the event-generator as suggested in https://github.com/falcosecurity/event-generator/issues/30

**Does this PR introduce a user-facing change?**:
```release-note
rule(Mkdir binary dirs): correct condition in macro `bin_dir_mkdir` to catch `mkdirat` syscall
rule(Modify binary dirs): correct condition in macro `bin_dir_rename` to catch `rename`, `renameat`, and `unlinkat` syscalls
rule(Create files below dev): correct condition to catch `openat` syscall
```