### PR TITLE
build: libyaml in bundled deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,12 +160,7 @@ ExternalProject_Add(
   INSTALL_COMMAND "")
 
 # libyaml
-find_library(LIBYAML_LIB NAMES libyaml.so)
-if(LIBYAML_LIB)
-  message(STATUS "Found libyaml: lib: ${LIBYAML_LIB}")
-else()
-  message(FATAL_ERROR "Couldn't find system libyaml")
-endif()
+include(libyaml)
 
 # lyaml
 set(LYAML_SRC "${PROJECT_BINARY_DIR}/lyaml-prefix/src/lyaml/ext/yaml")

--- a/cmake/modules/CPackConfig.cmake
+++ b/cmake/modules/CPackConfig.cmake
@@ -30,7 +30,7 @@ set(CPACK_GENERATOR DEB RPM TGZ)
 set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
 set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://www.falco.org")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "dkms (>= 2.1.0.0), libyaml-0-2")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "dkms (>= 2.1.0.0)")
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
     "${CMAKE_BINARY_DIR}/scripts/debian/postinst;${CMAKE_BINARY_DIR}/scripts/debian/prerm;${CMAKE_BINARY_DIR}/scripts/debian/postrm;${PROJECT_SOURCE_DIR}/cmake/cpack/debian/conffiles"
 )

--- a/cmake/modules/CPackConfig.cmake
+++ b/cmake/modules/CPackConfig.cmake
@@ -37,7 +37,7 @@ set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
 
 set(CPACK_RPM_PACKAGE_LICENSE "Apache v2.0")
 set(CPACK_RPM_PACKAGE_URL "https://www.falco.org")
-set(CPACK_RPM_PACKAGE_REQUIRES "dkms, kernel-devel, libyaml, ncurses")
+set(CPACK_RPM_PACKAGE_REQUIRES "dkms, kernel-devel, ncurses")
 set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_BINARY_DIR}/scripts/rpm/postinstall")
 set(CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${CMAKE_BINARY_DIR}/scripts/rpm/preuninstall")
 set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${CMAKE_BINARY_DIR}/scripts/rpm/postuninstall")

--- a/cmake/modules/libyaml.cmake
+++ b/cmake/modules/libyaml.cmake
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2020 The Falco Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+if(NOT USE_BUNDLED_DEPS)
+    find_library(LIBYAML_LIB NAMES libyaml.so)
+    if(LIBYAML_LIB)
+    message(STATUS "Found libyaml: lib: ${LIBYAML_LIB}")
+    else()
+    message(FATAL_ERROR "Couldn't find system libyaml")
+    endif()
+else()
+    set(LIBYAML_SRC "${PROJECT_BINARY_DIR}/libyaml-prefix/src/libyaml")
+    message(STATUS "Using bundled libyaml in '${LIBYAML_SRC}'")
+    set(LIBYAML_LIB "${LIBYAML_SRC}/src/.libs/libyaml.a")
+    ExternalProject_Add(
+    libyaml
+    URL "https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz"
+    URL_HASH "SHA256=c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"
+    CONFIGURE_COMMAND ./configure --enable-static=true --enable-shared=false
+    BUILD_COMMAND ${CMD_MAKE} 
+    BUILD_IN_SOURCE 1
+    INSTALL_COMMAND "")
+endif()

--- a/docker/no-driver/Dockerfile
+++ b/docker/no-driver/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /
 ADD https://bintray.com/api/ui/download/falcosecurity/${VERSION_BUCKET}/x86_64/falco-${FALCO_VERSION}-x86_64.tar.gz /
 
 RUN apt-get update -y && \
-    apt-get install -y libyaml-0-2 binutils && \
+    apt-get install -y binutils && \
     tar -xvf falco-${FALCO_VERSION}-x86_64.tar.gz && \
     rm -f falco-${FALCO_VERSION}-x86_64.tar.gz && \
     mv falco-${FALCO_VERSION}-x86_64 falco && \
@@ -42,9 +42,6 @@ COPY --from=ubuntu /lib/x86_64-linux-gnu/libanl.so.1 \
 
 COPY --from=ubuntu /usr/lib/x86_64-linux-gnu/libstdc++.so.6 \
     /usr/lib/x86_64-linux-gnu/libstdc++.so.6
-
-COPY --from=ubuntu /usr/lib/x86_64-linux-gnu/libyaml-0.so.2.0.5 \
-    /usr/lib/x86_64-linux-gnu/libyaml-0.so.2
 
 COPY --from=ubuntu /etc/ld.so.cache \
     /etc/nsswitch.conf \

--- a/docker/tester/root/runners/deb.Dockerfile
+++ b/docker/tester/root/runners/deb.Dockerfile
@@ -6,7 +6,7 @@ RUN test -n FALCO_VERSION
 ENV FALCO_VERSION ${FALCO_VERSION}
 
 RUN apt update -y
-RUN apt install dkms libyaml-0-2 -y
+RUN apt install dkms -y
 
 ADD falco-${FALCO_VERSION}-x86_64.deb /
 RUN dpkg -i /falco-${FALCO_VERSION}-x86_64.deb

--- a/docker/tester/root/runners/tar.gz.Dockerfile
+++ b/docker/tester/root/runners/tar.gz.Dockerfile
@@ -6,7 +6,7 @@ RUN test -n FALCO_VERSION
 ENV FALCO_VERSION ${FALCO_VERSION}
 
 RUN apt update -y
-RUN apt install dkms libyaml-0-2 curl -y
+RUN apt install dkms curl -y
 
 ADD falco-${FALCO_VERSION}-x86_64.tar.gz /
 RUN cp -R /falco-${FALCO_VERSION}-x86_64/* /

--- a/test/driver-loader/runner/Dockerfile
+++ b/test/driver-loader/runner/Dockerfile
@@ -10,7 +10,6 @@ ENV HOST_ROOT=/host
 RUN apt-get update -y
 RUN apt-get install -y --no-install-recommends \
 	ca-certificates \
-	libyaml-0-2 \
 	dkms \
 	curl \
 	gcc \

--- a/userspace/engine/CMakeLists.txt
+++ b/userspace/engine/CMakeLists.txt
@@ -23,6 +23,10 @@ set(FALCO_ENGINE_SOURCE_FILES
 add_library(falco_engine STATIC ${FALCO_ENGINE_SOURCE_FILES})
 add_dependencies(falco_engine njson lyaml lpeg string-view-lite)
 
+if(USE_BUNDLED_DEPS)
+  add_dependencies(falco_engine libyaml)
+endif()
+
 target_include_directories(
   falco_engine
   PUBLIC


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>

**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**


/area build



**What this PR does / why we need it**:

There's no reason we rely on system libyaml when we release since it doesn't add many MB to the build and doesn't require a long time to build either.


**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
new: libyaml is now bundled in the release process. Users can now avoid installing libyaml directly when getting Falco from the official release.
```
