### PR TITLE
rule(Container Drift Detected): detect new exec created in a container

### DIFF
--- a/cmake/modules/sysdig.cmake
+++ b/cmake/modules/sysdig.cmake
@@ -26,8 +26,8 @@ file(MAKE_DIRECTORY ${SYSDIG_CMAKE_WORKING_DIR})
 # To update sysdig version for the next release, change the default below
 # In case you want to test against another sysdig version just pass the variable - ie., `cmake -DSYSDIG_VERSION=dev ..`
 if(NOT SYSDIG_VERSION)
-  set(SYSDIG_VERSION "96bd9bc560f67742738eb7255aeb4d03046b8045")
-  set(SYSDIG_CHECKSUM "SHA256=766e8952a36a4198fd976b9d848523e6abe4336612188e4fc911e217d8e8a00d")
+  set(SYSDIG_VERSION "422ab408c5706fbdd45432646cc197eb79459169")
+  set(SYSDIG_CHECKSUM "SHA256=367db2a480bca327a46f901bcc8384f151231bcddba88c719a06cf13971f4ab5")
 endif()
 set(PROBE_VERSION "${SYSDIG_VERSION}")
 

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2814,6 +2814,34 @@
     Redirect stdout/stdin to network connection (user=%user.name %container.info process=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository fd.name=%fd.name fd.num=%fd.num fd.type=%fd.type fd.sip=%fd.sip)
   priority: WARNING
 
+# The two Container Drift rules below will fire when a new executable is created in a container. 
+# There are two ways to create executables - file is created with execution permissions or permissions change of existing file.
+# We will use a new sysdig filter, is_open_exec, to find all files creations with execution permission, and will trace all chmods in a container.
+# The use case we are targeting here is an attempt to execute code that was not shipped as part of a container (drift) - 
+# an activity that might be malicious or non-compliant.
+# Two things to pay attention to:
+#   1) In most cases, 'docker cp' will not be identified, but the assumption is that if an attacker gained access to the container runtime daemon, they are already privileged
+#   2) Drift rules will be noisy in environments in which containers are built (e.g. docker build) 
+
+- rule: Container Drift Detected (chmod)
+  desc: New executable created in a container due to chmod
+  condition: (chmod and consider_all_chmods and container and evt.rawres>=0 and
+       ((evt.arg.mode contains "S_IXUSR") or
+        (evt.arg.mode contains "S_IXGRP") or
+        (evt.arg.mode contains "S_IXOTH")))
+  output: Drift detected! New executable created in a container (user=%user.name command=%proc.cmdline filename=%evt.arg.filename name=%evt.arg.name mode=%evt.arg.mode event=%evt.type)
+  priority: ERROR
+  
+# ****************************************************************************
+# * "Container Drift Detected (open+create)" requires FALCO_ENGINE_VERSION 6 *
+# ****************************************************************************
+- rule: Container Drift Detected (open+create)
+  desc: New executable created in a container due to open+create
+  condition: (evt.type in (open,openat,creat) and evt.is_open_exec=true and container and evt.rawres>=0)
+  output: Drift detected! New executable created in a container (user=%user.name command=%proc.cmdline filename=%evt.arg.filename name=%evt.arg.name mode=%evt.arg.mode event=%evt.type)
+  priority: ERROR
+  
+
 # Application rules have moved to application_rules.yaml. Please look
 # there if you want to enable them by adding to
 # falco_rules.local.yaml.

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1356,6 +1356,9 @@
 - macro: runc_writing_exec_fifo
   condition: (proc.cmdline="runc:[1:CHILD] init" and fd.name=/exec.fifo)
 
+- macro: runc_writing_var_lib_docker
+  condition: (proc.cmdline="runc:[1:CHILD] init" and evt.arg.filename startswith /var/lib/docker)
+
 - rule: Write below root
   desc: an attempt to write to any file directly below / or /root
   condition: >
@@ -2502,7 +2505,7 @@
 - rule: Delete Bash History
   desc: Detect bash history deletion
   condition: >
-    ((spawned_process and proc.name in (shred, rm, mv) and proc.args contains "bash_history") or 
+    ((spawned_process and proc.name in (shred, rm, mv) and proc.args contains "bash_history") or
      (open_write and fd.name contains "bash_history" and evt.arg.flags contains "O_TRUNC"))
   output: >
     Shell history had been deleted or renamed (user=%user.name type=%evt.type command=%proc.cmdline fd.name=%fd.name name=%evt.arg.name path=%evt.arg.path oldpath=%evt.arg.oldpath %container.info)
@@ -2726,7 +2729,7 @@
   output: Packet socket was created in a container (user=%user.name command=%proc.cmdline socket_info=%evt.args container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority: NOTICE
   tags: [network, mitre_discovery]
- 
+
 # Change to (always_true) to enable rule 'Network connection outside local subnet'
 - macro: enabled_rule_network_only_subnet
   condition: (never_true)
@@ -2742,7 +2745,7 @@
 - macro: network_local_subnet
   condition: >
     fd.rnet in (rfc_1918_addresses) or
-    fd.ip = "0.0.0.0" or 
+    fd.ip = "0.0.0.0" or
     fd.net = "127.0.0.0/8"
 
 # # How to test:
@@ -2802,7 +2805,7 @@
     not fd.sport in (authorized_server_port)
   output: >
     Network connection outside authorized port and binary
-    (command=%proc.cmdline connection=%fd.name user=%user.name container_id=%container.id 
+    (command=%proc.cmdline connection=%fd.name user=%user.name container_id=%container.id
     image=%container.image.repository)
   priority: WARNING
   tags: [network]
@@ -2814,33 +2817,45 @@
     Redirect stdout/stdin to network connection (user=%user.name %container.info process=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository fd.name=%fd.name fd.num=%fd.num fd.type=%fd.type fd.sip=%fd.sip)
   priority: WARNING
 
-# The two Container Drift rules below will fire when a new executable is created in a container. 
+# The two Container Drift rules below will fire when a new executable is created in a container.
 # There are two ways to create executables - file is created with execution permissions or permissions change of existing file.
 # We will use a new sysdig filter, is_open_exec, to find all files creations with execution permission, and will trace all chmods in a container.
-# The use case we are targeting here is an attempt to execute code that was not shipped as part of a container (drift) - 
+# The use case we are targeting here is an attempt to execute code that was not shipped as part of a container (drift) -
 # an activity that might be malicious or non-compliant.
 # Two things to pay attention to:
 #   1) In most cases, 'docker cp' will not be identified, but the assumption is that if an attacker gained access to the container runtime daemon, they are already privileged
-#   2) Drift rules will be noisy in environments in which containers are built (e.g. docker build) 
+#   2) Drift rules will be noisy in environments in which containers are built (e.g. docker build)
 
 - rule: Container Drift Detected (chmod)
   desc: New executable created in a container due to chmod
-  condition: (chmod and consider_all_chmods and container and evt.rawres>=0 and
-       ((evt.arg.mode contains "S_IXUSR") or
-        (evt.arg.mode contains "S_IXGRP") or
-        (evt.arg.mode contains "S_IXOTH")))
-  output: Drift detected! New executable created in a container (user=%user.name command=%proc.cmdline filename=%evt.arg.filename name=%evt.arg.name mode=%evt.arg.mode event=%evt.type)
+  condition: >
+    chmod and
+    consider_all_chmods and
+    container and
+    not runc_writing_exec_fifo and
+    not runc_writing_var_lib_docker and
+    evt.rawres>=0 and
+    ((evt.arg.mode contains "S_IXUSR") or
+    (evt.arg.mode contains "S_IXGRP") or
+    (evt.arg.mode contains "S_IXOTH"))
+  output: Drift detected (chmod), new executable created in a container (user=%user.name command=%proc.cmdline filename=%evt.arg.filename name=%evt.arg.name mode=%evt.arg.mode event=%evt.type)
   priority: ERROR
-  
+
 # ****************************************************************************
 # * "Container Drift Detected (open+create)" requires FALCO_ENGINE_VERSION 6 *
 # ****************************************************************************
 - rule: Container Drift Detected (open+create)
   desc: New executable created in a container due to open+create
-  condition: (evt.type in (open,openat,creat) and evt.is_open_exec=true and container and evt.rawres>=0)
-  output: Drift detected! New executable created in a container (user=%user.name command=%proc.cmdline filename=%evt.arg.filename name=%evt.arg.name mode=%evt.arg.mode event=%evt.type)
+  condition: >
+    evt.type in (open,openat,creat) and
+    evt.is_open_exec=true and
+    container and
+    not runc_writing_exec_fifo and
+    not runc_writing_var_lib_docker and
+    evt.rawres>=0
+  output: Drift detected (open+create), new executable created in a container (user=%user.name command=%proc.cmdline filename=%evt.arg.filename name=%evt.arg.name mode=%evt.arg.mode event=%evt.type)
   priority: ERROR
-  
+
 
 # Application rules have moved to application_rules.yaml. Please look
 # there if you want to enable them by adding to

--- a/userspace/engine/falco_engine_version.h
+++ b/userspace/engine/falco_engine_version.h
@@ -16,9 +16,9 @@ limitations under the License.
 
 // The version of rules/filter fields/etc supported by this falco
 // engine.
-#define FALCO_ENGINE_VERSION (5)
+#define FALCO_ENGINE_VERSION (6)
 
 // This is the result of running "falco --list -N | sha256sum" and
 // represents the fields supported by this version of falco. It's used
 // at build time to detect a changed set of fields.
-#define FALCO_FIELDS_CHECKSUM "ca9e75fa41fe4480cdfad8cf275cdbbc334e656569f070c066d87cbd2955c1ae"
+#define FALCO_FIELDS_CHECKSUM "2f324e2e66d4b423f53600e7e0fcf2f0ff72e4a87755c490f2ae8f310aba9386"


### PR DESCRIPTION
**What type of PR is this?**
 /kind rule-create

**Any specific area of the project related to this PR?**
/area rules 

**What this PR does / why we need it:**
The PR adds the ability to identify exec drift in containers and targets RCE use cases. Full explanation can be found in issue 1248.

**Which issue(s) this PR fixes:**
https://github.com/falcosecurity/falco/issues/1248

**Does this PR introduce a user-facing change?:**
New drift detection rules added
rule(Container Drift Detected): detect new exec created in a container

**Special notes for your reviewer:**
Using this rule will require Falco engine version 6. Any attempt to copy paste the rules to an older Falco version will result in rules compilation errors. 

In addition, the rule was built to address container run-time use cases, and will be a bit noisy in build environments that leverage containers. 

```release-note
rule(Container Drift Detected (chmod)): new rule to detect if an existing file get exec permissions in a container
rule(Container Drift Detected (open+create)): new rule to detect if a new file with execution permission is created in a container
```