### PR TITLE
rule(macro user_known_write_below_binary_dir_activities)

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -929,6 +929,12 @@
     NOTICE
   tags: [filesystem, mitre_persistence]
 
+# Users should overwrite this macro to specify conditions under which a
+# write under the binary dir is ignored. For example, it may be okay to
+# install a binary in the context of a ci/cd build.
+- macro: user_known_write_below_binary_dir_activities
+  condition: (never_true)
+
 - rule: Write below binary dir
   desc: an attempt to write to any file below a set of binary directories
   condition: >
@@ -937,6 +943,7 @@
     and not exe_running_docker_save
     and not python_running_get_pip
     and not python_running_ms_oms
+    and not user_known_write_below_binary_dir_activities
   output: >
     File below a known binary directory opened for writing (user=%user.name
     command=%proc.cmdline file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline gparent=%proc.aname[2] container_id=%container.id image=%container.image.repository)


### PR DESCRIPTION
**What type of PR is this?**

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

This macro is useful to allow binaries to be written under certain circumstances. For example, it may be fine to install a binary during a build in a ci/cd pipeline. A more concrete use-case would be the installation of [packer](https://www.packer.io/) by placing its binary inside the `/bin` directory, which is needed to build AMIs during builds.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
rule(macro user_known_write_below_binary_dir_activities): allow writing to a binary dir in some conditions
```
