### PR TITLE
correct k8s audit endpoint

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -139,7 +139,7 @@ stdout_output:
 webserver:
   enabled: true
   listen_port: 8765
-  k8s_audit_endpoint: /k8s_audit
+  k8s_audit_endpoint: /k8s-audit
   ssl_enabled: false
   ssl_certificate: /etc/falco/falco.pem
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR changes the value of `webserver.k8s_audit_endpoint` from `/k8s_audit` to `/k8s-audit`, because a path that contains an underscore (`_`) won't work when the audit sink webhook is configured with a [service reference](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#service-reference) (instead of an [URL](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#url)).

To reproduce the issue just `kubectl apply` the following example:

```yaml
apiVersion: auditregistration.k8s.io/v1alpha1
kind: AuditSink
metadata:
  name: falco-audit-sink
spec:
  policy:
    level: RequestResponse
    stages:
      - ResponseComplete
      - ResponseStarted
  webhook:
    throttle:
      qps: 10
      burst: 15
    clientConfig:
      service:
        namespace: default
        name: falco-service
        path: /k8s_audit
        port: 8765
```

Then you get the following error:
```
The AuditSink "falco-audit-sink" is invalid: spec.webhook.clientConfig.service.path: Invalid value: "/k8s_audit": segment[0]: a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- The helm chart has been using the correct endpoint (ie. `/k8s-audit`) since the initial k8s audit support (11 months ago, see [here](https://github.com/falcosecurity/charts/commit/8998e00bb1c5cde1ea05ec81c05a4fc9e338d0b4#diff-ba05023d0f1b5d4b64b6cad4cf9a7ecdR180)) and the latest version still has the correct endpoint
- This problem has already been fixed by https://github.com/falcosecurity/evolution/pull/26 with [this commit](https://github.com/falcosecurity/evolution/commit/e8702e017a9e8db824cb0ba4c9968c6d030dcf25#diff-d1da0c7edfcee3d07d603d990eeb7f05R142) in the `k8s-audit-only` example resources.


**Does this PR introduce a user-facing change?**:

```release-note
update(falco.yaml): `webserver.k8s_audit_endpoint` default value changed from `/k8s_audit` to `/k8s-audit`
```
