### PR TITLE
gRPC auto threadiness

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -182,7 +182,7 @@ http_output:
 # grpc:
 #   enabled: true
 #   bind_address: "0.0.0.0:5060"
-#   threadiness: 8
+#   threadiness: 0
 #   private_key: "/etc/falco/certs/server.key"
 #   cert_chain: "/etc/falco/certs/server.crt"
 #   root_certs: "/etc/falco/certs/ca.crt"
@@ -191,7 +191,8 @@ http_output:
 grpc:
   enabled: false
   bind_address: "unix:///var/run/falco.sock"
-  threadiness: 8
+  # when threadiness is 0, Falco automatically guesses it depending on the number of online cores
+  threadiness: 0
 
 # gRPC output service.
 # By default it is off.

--- a/falco.yaml
+++ b/falco.yaml
@@ -182,6 +182,7 @@ http_output:
 # grpc:
 #   enabled: true
 #   bind_address: "0.0.0.0:5060"
+#   # when threadiness is 0, Falco sets it by automatically figuring out the number of online cores
 #   threadiness: 0
 #   private_key: "/etc/falco/certs/server.key"
 #   cert_chain: "/etc/falco/certs/server.crt"

--- a/userspace/engine/falco_utils.cpp
+++ b/userspace/engine/falco_utils.cpp
@@ -52,6 +52,12 @@ std::string wrap_text(const std::string& str, uint32_t initial_pos, uint32_t ind
 	return ret;
 }
 
+uint32_t hardware_concurrency()
+{
+	auto hc = std::thread::hardware_concurrency();
+	return hc ? hc : 1;
+}
+
 void readfile(const std::string& filename, std::string& data)
 {
 	std::ifstream file(filename.c_str(), std::ios::in);

--- a/userspace/engine/falco_utils.h
+++ b/userspace/engine/falco_utils.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <thread>
 #include <nonstd/string_view.hpp>
 
 #pragma once
@@ -34,6 +35,9 @@ namespace utils
 std::string wrap_text(const std::string& str, uint32_t initial_pos, uint32_t indent, uint32_t line_len);
 
 void readfile(const std::string& filename, std::string& data);
+
+uint32_t hardware_concurrency();
+
 namespace network
 {
 static const std::string UNIX_SCHEME("unix://");

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2019 The Falco Authors.
+Copyright (C) 2020 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ limitations under the License.
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "falco_utils.h"
 
 #include "configuration.h"
 #include "logger.h"
@@ -148,11 +149,12 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 
 	m_grpc_enabled = m_config->get_scalar<bool>("grpc", "enabled", false);
 	m_grpc_bind_address = m_config->get_scalar<string>("grpc", "bind_address", "0.0.0.0:5060");
-	m_grpc_threadiness = m_config->get_scalar<uint32_t>("grpc", "threadiness", 8); // todo > limit it to avoid overshubscription? std::thread::hardware_concurrency()
+	m_grpc_threadiness = m_config->get_scalar<uint32_t>("grpc", "threadiness", 0);
 	if(m_grpc_threadiness == 0)
 	{
-		throw logic_error("error reading config file (" + m_config_file + "): gRPC threadiness must be greater than 0");
+		m_grpc_threadiness = falco::utils::hardware_concurrency();
 	}
+	// todo > else limit threadiness to avoid oversubscription?
 	m_grpc_private_key = m_config->get_scalar<string>("grpc", "private_key", "/etc/falco/certs/server.key");
 	m_grpc_cert_chain = m_config->get_scalar<string>("grpc", "cert_chain", "/etc/falco/certs/server.crt");
 	m_grpc_root_certs = m_config->get_scalar<string>("grpc", "root_certs", "/etc/falco/certs/ca.crt");

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -206,7 +206,7 @@ public:
 	bool m_time_format_iso_8601;
 
 	bool m_grpc_enabled;
-	int m_grpc_threadiness;
+	uint32_t m_grpc_threadiness;
 	std::string m_grpc_bind_address;
 	std::string m_grpc_private_key;
 	std::string m_grpc_cert_chain;

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -1206,6 +1206,7 @@ int falco_init(int argc, char **argv)
 		// gRPC server
 		if(config.m_grpc_enabled)
 		{
+			falco_logger::log(LOG_INFO, "gRPC server threadiness equals to " + to_string(config.m_grpc_threadiness) + "\n");
 			// TODO(fntlnz,leodido): when we want to spawn multiple threads we need to have a queue per thread, or implement
 			// different queuing mechanisms, round robin, fanout? What we want to achieve?
 			grpc_server.init(


### PR DESCRIPTION
**What type of PR is this?**


/kind feature

**Any specific area of the project related to this PR?**

NONE

**What this PR does / why we need it**:

This PR updates the `threadiness` configuration default value of the gRPC configuration block.

Now, the `threadiness` field is `0` by default, which means "auto".
Thus, by default, Falco will set the threadiness of the gRPC server to the number of online cores.

This is the default behavior because it has proven to behave better in the recent tests both me and @fntlnz have done.



**Which issue(s) this PR fixes**:

NONE



**Special notes for your reviewer**:

When Falco is not able to guess the number of online cores (this can happen for various reasons), the threadiness will be set to 1 which we consider the safer value and also avoids oversubscription.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new: auto threadiness for gRPC server
update: default threadiness to 0 ("auto" behavior)
```
