### PR TITLE
rule(macro `root_dir`): correct macro to exactly match the `/root` dir and not other with just `/root` as a prefix

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -110,7 +110,7 @@
 
 # This detects writes immediately below / or any write anywhere below /root
 - macro: root_dir
-  condition: ((fd.directory=/ or fd.name startswith /root) and fd.name contains "/")
+  condition: ((fd.directory=/ or fd.name startswith /root/) and fd.name contains "/")
 
 - list: shell_binaries
   items: [ash, bash, csh, ksh, sh, tcsh, zsh, dash]

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -110,7 +110,7 @@
 
 # This detects writes immediately below / or any write anywhere below /root
 - macro: root_dir
-  condition: ((fd.directory=/ or fd.name startswith /root/) and fd.name contains "/")
+  condition: (fd.directory=/ or fd.name startswith /root/)
 
 - list: shell_binaries
   items: [ash, bash, csh, ksh, sh, tcsh, zsh, dash]


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

:point_right: #1141

**Which issue(s) this PR fixes**:

Fixes #1141

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
rule(macro `root_dir`): correct macro to exactly match the `/root` dir and not other with just `/root` as a prefix  
```
