### PR TITLE
rule(Launch Package Management Process in Container): allow apk manifest

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2333,6 +2333,7 @@
     spawned_process
     and container
     and user.name != "_apt"
+    and not proc.cmdline startswith "apk manifest"
     and package_mgmt_procs
     and not package_mgmt_ancestor_procs
     and not user_known_package_manager_in_container


### PR DESCRIPTION
**What type of PR is this?**

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

The `apk manifest` command allows "Displaying checksums for files contained in a given package", according to the Alpine Linux [wiki](https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management).

This is a very harmless command, so the events that get raised because of that command aren't necessarily relevant. This PR filters out `apk manifest` usage.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
rule(Launch Package Management Process in Container): allow apk manifest
```
