### PR TITLE
rule(Write below etc): allow snapd to write its unit files

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -219,7 +219,7 @@
 # The truncated dpkg-preconfigu is intentional, process names are
 # truncated at the sysdig level.
 - list: package_mgmt_binaries
-  items: [rpm_binaries, deb_binaries, update-alternat, gem, pip, pip3, sane-utils.post, alternatives, chef-client, apk]
+  items: [rpm_binaries, deb_binaries, update-alternat, gem, pip, pip3, sane-utils.post, alternatives, chef-client, apk, snapd]
 
 - macro: package_mgmt_procs
   condition: proc.name in (package_mgmt_binaries)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

In an AWS environment, snap can be used to install the SSM agent, which will write unit files under `etc`. This is the expected behaviour from snap.

See [the AWS docs](https://docs.aws.amazon.com/systems-manager/latest/userguide/agent-install-ubuntu.html) for more information.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
rule(Write below etc): allow snapd to write its unit files
```
