### PR TITLE
fix: update k8s audit endpoint to /k8s-audit everywhere

### DIFF
--- a/test/confs/psp.yaml
+++ b/test/confs/psp.yaml
@@ -136,7 +136,7 @@ stdout_output:
 webserver:
   enabled: true
   listen_port: 8765
-  k8s_audit_endpoint: /k8s_audit
+  k8s_audit_endpoint: /k8s-audit
   ssl_enabled: false
   ssl_certificate: /etc/falco/falco.pem
 

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -32,7 +32,7 @@ falco_configuration::falco_configuration():
 	m_time_format_iso_8601(false),
 	m_webserver_enabled(false),
 	m_webserver_listen_port(8765),
-	m_webserver_k8s_audit_endpoint("/k8s_audit"),
+	m_webserver_k8s_audit_endpoint("/k8s-audit"),
 	m_webserver_ssl_enabled(false),
 	m_config(NULL)
 {
@@ -198,7 +198,7 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 
 	m_webserver_enabled = m_config->get_scalar<bool>("webserver", "enabled", false);
 	m_webserver_listen_port = m_config->get_scalar<uint32_t>("webserver", "listen_port", 8765);
-	m_webserver_k8s_audit_endpoint = m_config->get_scalar<string>("webserver", "k8s_audit_endpoint", "/k8s_audit");
+	m_webserver_k8s_audit_endpoint = m_config->get_scalar<string>("webserver", "k8s_audit_endpoint", "/k8s-audit");
 	m_webserver_ssl_enabled = m_config->get_scalar<bool>("webserver", "ssl_enabled", false);
 	m_webserver_ssl_certificate = m_config->get_scalar<string>("webserver", "ssl_certificate", "/etc/falco/falco.pem");
 


### PR DESCRIPTION
Co-Authored-By: Leonardo Di Donato <leodidonato@gmail.com>
Signed-off-by: Lorenzo Fontana <lo@linux.com>

**What type of PR is this?**


/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:


Related to #1026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
update: k8s audit endpoint now defaults to /k8s-audit everywhere
```
