### PR TITLE
correct stdout output buffering option

### DIFF
--- a/userspace/falco/lua/output.lua
+++ b/userspace/falco/lua/output.lua
@@ -18,7 +18,7 @@ local mod = {}
 local outputs = {}
 
 function mod.stdout(event, rule, source, priority, priority_num, msg, format, hostname, options)
-   mod.stdout_message(priority, priority_num, msg, outputs)
+   mod.stdout_message(priority, priority_num, msg, options)
 end
 
 function mod.stdout_message(priority, priority_num, msg, options)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

`buffered_output: false` was not honored for stdout. 

This PR corrects the argument wrongly passed to the `stdout_message` that caused the problem aforementioned.

**Which issue(s) this PR fixes**:

Fixes #1198
Fixes #1291

**Special notes for your reviewer**:

I will add some comments for further improvement.

/cc @fntlnz 
/cc @leodido 

/milestone 0.24.0

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/falco): correct options handling for `buffered_output: false` which was not honored for the `stdout` output
```
