### PR TITLE
fix --stats-interval flag for values >= 999 (ms)

### DIFF
--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -646,7 +646,7 @@ int falco_init(int argc, char **argv)
 						list_flds_source = optarg;
 					}
 				}
-				else if (string(long_options[long_index].name) == "stats_interval")
+				else if (string(long_options[long_index].name) == "stats-interval")
 				{
 					stats_interval = atoi(optarg);
 				}

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -140,9 +140,9 @@ static void usage()
 	   " -P, --pidfile <pid_file>      When run as a daemon, write pid to specified file\n"
        " -r <rules_file>               Rules file/directory (defaults to value set in configuration file, or /etc/falco_rules.yaml).\n"
        "                               Can be specified multiple times to read from multiple files/directories.\n"
-	   " -s <stats_file>               If specified, write statistics related to falco's reading/processing of events\n"
-	   "                               to this file. (Only useful in live mode).\n"
-	   " --stats_interval <msec>       When using -s <stats_file>, write statistics every <msec> ms.\n"
+	   " -s <stats_file>               If specified, append statistics related to Falco's reading/processing of events\n"
+	   "                               to this file (only useful in live mode).\n"
+	   " --stats-interval <msec>       When using -s <stats_file>, write statistics every <msec> ms.\n"
 	   "                               This uses signals, so don't recommend intervals below 200 ms.\n"
 	   "                               Defaults to 5000 (5 seconds).\n"
 	   " -S <len>, --snaplen <len>\n"
@@ -479,7 +479,7 @@ int falco_init(int argc, char **argv)
         {"print-base64", no_argument, 0, 'b'},
         {"print", required_argument, 0, 'p'},
         {"snaplen", required_argument, 0, 'S'},
-        {"stats_interval", required_argument, 0},
+        {"stats-interval", required_argument, 0},
         {"support", no_argument, 0},
         {"unbuffered", no_argument, 0, 'U'},
         {"validate", required_argument, 0, 'V'},
@@ -1264,7 +1264,7 @@ int falco_init(int argc, char **argv)
 		// Honor -M also when using a trace file.
 		// Since inspection stops as soon as all events have been consumed
 		// just await the given duration is reached, if needed.
-		if(!trace_filename.empty() && duration_to_tot>0) 
+		if(!trace_filename.empty() && duration_to_tot>0)
 		{
 			std::this_thread::sleep_for(std::chrono::seconds(duration_to_tot));
 		}

--- a/userspace/falco/statsfilewriter.cpp
+++ b/userspace/falco/statsfilewriter.cpp
@@ -58,8 +58,8 @@ bool StatsFileWriter::init(sinsp *inspector, string &filename, uint32_t interval
 		return false;
 	}
 
-	timer.it_value.tv_sec = 0;
-	timer.it_value.tv_usec = interval_msec * 1000;
+	timer.it_value.tv_sec = interval_msec / 1000;
+	timer.it_value.tv_usec = (interval_msec % 1000) * 1000;
 	timer.it_interval = timer.it_value;
 	if (setitimer(ITIMER_REAL, &timer, NULL) == -1)
 	{


### PR DESCRIPTION


**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

NONE

**What this PR does / why we need it**:

Renames `--stats_interval` to `--stats-interval` so to match the style of other long flags of the Falco CLI.

Fixes its behavior for values greater than 999 milliseconds.

**Which issue(s) this PR fixes**:



Fixes #1280 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:



```release-note
BREAKING CHANGE: --stats_interval is now --stats-interval
fix: --stats-interval correctly accepts values >= 999 (ms)
```
