### PR TITLE
rule(list allowed_k8s_users): add "kubernetes-admin" user

### DIFF
--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -46,6 +46,7 @@
 - list: allowed_k8s_users
   items: [
     "minikube", "minikube-user", "kubelet", "kops", "admin", "kube", "kube-proxy", "kube-apiserver-healthcheck",
+    "kubernetes-admin",
     vertical_pod_autoscaler_users,
     ]
 


### PR DESCRIPTION
**What type of PR is this?**

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

Since `kubernetes-admin` user is included in some k8s distribution by (it is also used by [kubadm](https://github.com/kubernetes/kubeadm) and [kind](https://github.com/kubernetes-sigs/kind)), I believe it should be included in the allowed k8s users' list.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1186

**Special notes for your reviewer**:

I've noticed that using kind. Without `kubernetes-admin`, Falco is triggering an alert for any activity performed by `kind`.

/milestone 0.25.0

**Does this PR introduce a user-facing change?**:


```release-note
rule(list allowed_k8s_users): add "kubernetes-admin" user
```
