### PR TITLE
rule(macro falco_privileged_images): add 'docker.io/falcosecurity/falco'

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1840,7 +1840,8 @@
     docker.io/sysdig/agent, docker.io/sysdig/falco, docker.io/sysdig/sysdig,
     gcr.io/google_containers/kube-proxy, docker.io/calico/node, quay.io/calico/node,
     docker.io/rook/toolbox, docker.io/cloudnativelabs/kube-router, docker.io/mesosphere/mesos-slave,
-    docker.io/docker/ucp-agent, sematext_images, k8s.gcr.io/kube-proxy
+    docker.io/docker/ucp-agent, sematext_images, k8s.gcr.io/kube-proxy,
+    docker.io/falcosecurity/falco
     ]
 
 - macro: falco_privileged_containers


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind rule-update

**Any specific area of the project related to this PR?**
/area rules

**What this PR does / why we need it**:
Add 'docker.io/falcosecurity/falco' image to  'falco_privileged_images' macro. This prevent messages like this when booting up falco :
```
Warning Pod started with privileged container (user=system:serviceaccount:kube-system:daemon-set-controller pod=falco-42brw ns=monitoring images=docker.io/falcosecurity/falco:0.24.0)
```

**Does this PR introduce a user-facing change?**:
```release-note
rule(macro falco_privileged_images): add 'docker.io/falcosecurity/falco'
```
