### PR TITLE
falco-driver-loader: fix conflicting $1 argument usage

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -473,9 +473,8 @@ else
 	FALCO_DRIVER_CURL_OPTIONS=-fsS
 fi
 
-MAX_RMMOD_WAIT=60
-if [[ $# -ge 1 ]]; then
-	MAX_RMMOD_WAIT=$1
+if [[ -z "$MAX_RMMOD_WAIT" ]]; then
+	MAX_RMMOD_WAIT=60
 fi
 
 DRIVER_VERSION="@PROBE_VERSION@"


### PR DESCRIPTION
Signed-off-by: Antoine Deschênes <antoine@antoinedeschenes.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Argument parser conflicts with MAX_RMMOD_WAIT undocumented variable initialization always using the $1 argument.
MAX_RMMOD_WAIT can now be set using an environment variable

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Fix falco-driver-loader script crashing when using arguments
```
