### PR TITLE
Kh add rule detect ephemeral container

### DIFF
--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -217,6 +217,19 @@
   source: k8s_audit
   tags: [k8s]
 
+- macro: user_known_pod_debug_activities
+  condition: (k8s_audit_never_true)
+
+# Only works when feature gate EphemeralContainers is enabled
+- rule: EphemeralContainers Created
+  desc: >
+    Detect any ephemeral container created
+  condition: kevt and pod_subresource and kmodify and ka.target.subresource in (ephemeralcontainers) and not user_known_pod_debug_activities
+  output: Ephemeral container is created in pod (user=%ka.user.name pod=%ka.target.name ns=%ka.target.namespace ephemeral_container_name=%jevt.value[/requestObject/ephemeralContainers/0/name] ephemeral_container_image=%jevt.value[/requestObject/ephemeralContainers/0/image])
+  priority: NOTICE
+  source: k8s_audit
+  tags: [k8s]
+
 # In a local/user rules fie, you can append to this list to add additional allowed namespaces
 - list: allowed_namespaces
   items: [kube-system, kube-public, default]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

 /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

 /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Create a new rule to detect ephemeral container is created in a pod.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/
Audit log:
```
{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"Request","auditID":"b1737080-a7fd-44c5-87b5-3777dcf493c4","stage":"ResponseComplete","requestURI":"/api/v1/namespaces/default/pods/ubuntu-2/ephemeralcontainers","verb":"update","user":{"username":"admin","uid":"admin","groups":["system:masters","system:authenticated"]},"sourceIPs":["98.207.36.92"],"userAgent":"kubectl/v1.18.6 (darwin/amd64) kubernetes/dff82dc","objectRef":{"resource":"pods","namespace":"default","name":"ubuntu-2","apiVersion":"v1","subresource":"ephemeralcontainers"},"responseStatus":{"metadata":{},"code":200},"requestObject":{"kind":"EphemeralContainers","apiVersion":"v1","metadata":{"name":"ubuntu-2","creationTimestamp":null},"ephemeralContainers":[{"name":"debugger","image":"busybox","command":["sleep","3600"],"resources":{},"terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent","stdin":true,"tty":true}]},"requestReceivedTimestamp":"2020-07-31T21:45:48.728559Z","stageTimestamp":"2020-07-31T21:45:48.736514Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}
```

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rule (EphemeralContainers Created): add new rule to detect ephemeral container created
```
