### PR TITLE
Set module arguments via falco-driver-loader

### DIFF
--- a/docker/falco/docker-entrypoint.sh
+++ b/docker/falco/docker-entrypoint.sh
@@ -32,7 +32,7 @@ if [[ -z "${SKIP_DRIVER_LOADER}" ]] && [[ -z "${SKIP_MODULE_LOAD}" ]]; then
         ln -s "$i" "/usr/src/$base"
     done
 
-    /usr/bin/falco-driver-loader
+    /usr/bin/falco-driver-loader ${FALCO_DRIVER_LOADER_ARGS}
 fi
 
 exec "$@"

--- a/docker/local/docker-entrypoint.sh
+++ b/docker/local/docker-entrypoint.sh
@@ -28,7 +28,7 @@ if [[ -z "${SKIP_DRIVER_LOADER}" ]]; then
         ln -s "$i" "/usr/src/$base"
     done
 
-    /usr/bin/falco-driver-loader
+    /usr/bin/falco-driver-loader ${FALCO_DRIVER_LOADER_ARGS}
 fi
 
 exec "$@"

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -158,11 +158,11 @@ load_kernel_module_compile() {
 		echo "make CC=${CURRENT_GCC} \$@" >> /tmp/falco-dkms-make
 		chmod +x /tmp/falco-dkms-make
 		if dkms install --directive="MAKE='/tmp/falco-dkms-make'" -m "${DRIVER_NAME}" -v "${DRIVER_VERSION}" -k "${KERNEL_RELEASE}" 2>/dev/null; then
-			echo "* ${DRIVER_NAME} module installed in dkms, trying to insmod"				
-			if insmod "/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}.ko" > /dev/null 2>&1; then
+			echo "* ${DRIVER_NAME} module installed in dkms, trying to insmod"
+			if insmod "/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}.ko" "${MODULE_ARGS[@]}" > /dev/null 2>&1; then
 				echo "* Success: ${DRIVER_NAME} module found and loaded in dkms"
 				exit 0
-			elif insmod "/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}.ko.xz" > /dev/null 2>&1; then
+			elif insmod "/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}.ko.xz" "${MODULE_ARGS[@]}" > /dev/null 2>&1; then
 				echo "* Success: ${DRIVER_NAME} module found and loaded in dkms (xz)"
 				exit 0
 			else
@@ -192,7 +192,7 @@ load_kernel_module_download() {
 	echo "* Trying to download prebuilt module from ${URL}"
 	if curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${URL}"; then
 		echo "* Download succeeded"
-		insmod "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" && echo "* Success: ${DRIVER_NAME} module loaded"
+		insmod "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${MODULE_ARGS[@]}" && echo "* Success: ${DRIVER_NAME} module loaded"
 		exit $?
 	else
 		>&2 echo "Download failed, consider compiling your own ${DRIVER_NAME} module and loading it or getting in touch with the Falco community"
@@ -462,10 +462,11 @@ print_usage() {
 	echo "  bpf           eBPF probe"
 	echo ""
 	echo "Options:"
-	echo "  --help         show brief help"
-	echo "  --compile      try to compile the driver locally"
-	echo "  --download     try to download a prebuilt driver"
-	echo "  --source-only  skip execution and allow sourcing in another script"
+	echo "  --help                  show brief help"
+	echo "  --compile               try to compile the driver locally"
+	echo "  --download              try to download a prebuilt driver"
+	echo "  --source-only           skip execution and allow sourcing in another script"
+	echo "  --module-arg PARAM=VAL  set module argument (flag can be repeated)"
 	echo ""
 }
 
@@ -495,6 +496,7 @@ fi
 
 ENABLE_COMPILE=
 ENABLE_DOWNLOAD=
+MODULE_ARGS=( )
 
 has_args=
 has_opts=
@@ -530,6 +532,11 @@ while test $# -gt 0; do
 			source_only="true"
 			shift
 			;;
+		--module-arg)
+			shift
+			MODULE_ARGS+=( "$1" )
+			shift
+			;;
 		--*)
 			>&2 echo "Unknown option: $1"
 			print_usage
@@ -559,7 +566,7 @@ if [ -z "$source_only" ]; then
 		exit 1
 	fi
 
-	echo "* Running falco-driver-loader with: driver=$DRIVER, compile=${ENABLE_COMPILE:-"no"}, download=${ENABLE_DOWNLOAD:-"no"}"
+	echo "* Running falco-driver-loader with: driver=$DRIVER, compile=${ENABLE_COMPILE:-"no"}, download=${ENABLE_DOWNLOAD:-"no"}, module_args=(${MODULE_ARGS[@]})"
 	case $DRIVER in 
 		module)
 			load_kernel_module

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -159,14 +159,17 @@ load_kernel_module_compile() {
 		chmod +x /tmp/falco-dkms-make
 		if dkms install --directive="MAKE='/tmp/falco-dkms-make'" -m "${DRIVER_NAME}" -v "${DRIVER_VERSION}" -k "${KERNEL_RELEASE}" 2>/dev/null; then
 			echo "* ${DRIVER_NAME} module installed in dkms, trying to insmod"
-			if insmod "/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}.ko" "${MODULE_ARGS[@]}" > /dev/null 2>&1; then
-				echo "* Success: ${DRIVER_NAME} module found and loaded in dkms"
-				exit 0
-			elif insmod "/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}.ko.xz" "${MODULE_ARGS[@]}" > /dev/null 2>&1; then
-				echo "* Success: ${DRIVER_NAME} module found and loaded in dkms (xz)"
+			if OUTPUT="$(insmod "/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}.ko" "${MODULE_ARGS[@]}" 2>&1)"; then
+				echo "* Success: ${DRIVER_NAME} module found and loaded in dkms with arguments '${MODULE_ARGS[@]}'"
 				exit 0
 			else
-				echo "* Unable to insmod ${DRIVER_NAME} module"
+				echo "* Unable to insmod ${DRIVER_NAME} module with arguments '${MODULE_ARGS[@]}': ${OUTPUT}"
+			fi
+			if OUTPUT="$(insmod "/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}.ko.xz" "${MODULE_ARGS[@]}" 2>&1)"; then
+				echo "* Success: ${DRIVER_NAME} module found and loaded in dkms with arguments '${MODULE_ARGS[@]}' (xz)"
+				exit 0
+			else
+				echo "* Unable to insmod ${DRIVER_NAME} module with arguments '${MODULE_ARGS[@]}' (xz): ${OUTPUT}"
 			fi
 		else
 			DKMS_LOG="/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/build/make.log"
@@ -192,8 +195,14 @@ load_kernel_module_download() {
 	echo "* Trying to download prebuilt module from ${URL}"
 	if curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${URL}"; then
 		echo "* Download succeeded"
-		insmod "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${MODULE_ARGS[@]}" && echo "* Success: ${DRIVER_NAME} module loaded"
-		exit $?
+		if OUTPUT="$(insmod "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${MODULE_ARGS[@]}")"; then
+		  echo "* Success: ${DRIVER_NAME} module loaded with arguments '${MODULE_ARGS[@]}'"
+		  exit 0
+		else
+		  EXIT=$?
+		  echo "* Unable to insmod ${DRIVER_NAME} module with arguments '${MODULE_ARGS[@]}': ${OUTPUT}"
+		  exit $EXIT
+		fi
 	else
 		>&2 echo "Download failed, consider compiling your own ${DRIVER_NAME} module and loading it or getting in touch with the Falco community"
 		exit 1
@@ -243,10 +252,12 @@ load_kernel_module() {
 
 
 	echo "* Trying to load a system ${DRIVER_NAME} driver, if present"
-	if modprobe "${DRIVER_NAME}" > /dev/null 2>&1; then
-		echo "* Success: ${DRIVER_NAME} module found and loaded with modprobe"
+	if OUTPUT="$(modprobe "${DRIVER_NAME}" "${MODULE_ARGS[@]}" 2>&1)"; then
+		echo "* Success: ${DRIVER_NAME} module found and loaded with modprobe and arguments '${MODULE_ARGS[@]}'"
 		exit 0
-	fi		
+	else
+	  echo "* Unable to modprobe ${DRIVER_NAME} module with arguments '${MODULE_ARGS[@]}': ${OUTPUT}"
+	fi
 
 
 	echo "* Trying to find locally a prebuilt ${DRIVER_NAME} module for kernel ${KERNEL_RELEASE}, if present"
@@ -257,8 +268,15 @@ load_kernel_module() {
 
 	if [ -f "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" ]; then
 		echo "* Found a prebuilt module at ${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}, loading it"
-		insmod "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" && echo "* Success: ${DRIVER_NAME} module loaded"
-		exit $?
+
+		if OUTPUT="$(insmod "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${MODULE_ARGS[@]}")"; then
+		  echo "* Success: ${DRIVER_NAME} module loaded with arguments '${MODULE_ARGS[@]}'"
+		  exit 0
+		else
+		  EXIT=$?
+		  echo "* Unable to insmod ${DRIVER_NAME} module with arguments '${MODULE_ARGS[@]}': ${OUTPUT}"
+		  exit $EXIT
+		fi
 	fi
 
 	if [ -n "$ENABLE_DOWNLOAD" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

* Add `FALCO_DRIVER_LOADER_ARGS` variable to pass arguments to falco-driver-loader in docker images. (ex. `FALCO_DRIVER_LOADER_ARGS="--compile"`)
* Add `--module-arg` option to set kernel module args via `falco-driver-loader`. (ex. `falco-driver-loader --module-arg verbose=1 --module-arg max_consumers=2`
  This seems a little pointless at first, but we have an open PR on sysdig allowing an adjustable ring buffer size via kernel params

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
docker-entrypoint: Pass FALCO_DRIVER_LOADER_ARGS as falco-driver-loader arguments
falco-driver-loader: Add --module-arg option to set kernel module args
```
