### PR TITLE
docker-entrypoint: Match /usr/bin/gcc version to kernel /proc/version

### DIFF
--- a/docker/driver-loader/docker-entrypoint.sh
+++ b/docker/driver-loader/docker-entrypoint.sh
@@ -25,4 +25,21 @@ do
     ln -s "$i" "/usr/src/$base"
 done
 
+GCC_AVAILABLE_VERSIONS=( $(ls /usr/bin | grep -Po "^gcc-\K[0-9]+") )
+GCC_MIN_VERSION="${GCC_AVAILABLE_VERSIONS[0]}"
+GCC_MAX_VERSION="${GCC_AVAILABLE_VERSIONS[-1]}"
+GCC_KERNEL_VERSION="$(grep -Po "gcc version \K[0-9]+" /proc/version 2>/dev/null)"
+
+if [[ $GCC_KERNEL_VERSION -lt $GCC_MIN_VERSION ]]; then
+    # Kernel version not parsed or lower than available gcc
+    GCC_KERNEL_VERSION="${GCC_MIN_VERSION}"
+elif [[ $GCC_KERNEL_VERSION -gt $GCC_MAX_VERSION ]]; then
+    # Kernel version higher than available gcc
+    GCC_KERNEL_VERSION="${GCC_MAX_VERSION}"
+fi
+
+echo "* Setting up link /usr/bin/gcc-${GCC_KERNEL_VERSION}->/usr/bin/gcc from /proc/version"
+
+ln -sf "/usr/bin/gcc-${GCC_KERNEL_VERSION}" "/usr/bin/gcc"
+
 /usr/bin/falco-driver-loader "$@"

--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -66,10 +66,6 @@ RUN curl -L -o cpp-5_5.5.0-12_amd64.deb https://dl.bintray.com/falcosecurity/dep
 	&& dpkg -i cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb \
 	&& rm -f cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb
 
-# Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
-# default to gcc-5.
-RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-5 /usr/bin/gcc
-
 RUN rm -rf /usr/bin/clang \
 	&& rm -rf /usr/bin/llc \
 	&& ln -s /usr/bin/clang-7 /usr/bin/clang \

--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:buster
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
@@ -23,6 +23,7 @@ RUN apt-get update \
 	curl \
 	dkms \
 	gnupg2 \
+	gcc-7 \
 	gcc \
 	jq \
 	libc6-dev \

--- a/docker/falco/docker-entrypoint.sh
+++ b/docker/falco/docker-entrypoint.sh
@@ -32,6 +32,23 @@ if [[ -z "${SKIP_DRIVER_LOADER}" ]] && [[ -z "${SKIP_MODULE_LOAD}" ]]; then
         ln -s "$i" "/usr/src/$base"
     done
 
+    GCC_AVAILABLE_VERSIONS=( $(ls /usr/bin | grep -Po "^gcc-\K[0-9]+") )
+    GCC_MIN_VERSION="${GCC_AVAILABLE_VERSIONS[0]}"
+    GCC_MAX_VERSION="${GCC_AVAILABLE_VERSIONS[-1]}"
+    GCC_KERNEL_VERSION="$(grep -Po "gcc version \K[0-9]+" /proc/version 2>/dev/null)"
+
+    if [[ $GCC_KERNEL_VERSION -lt $GCC_MIN_VERSION ]]; then
+        # Kernel version not parsed or lower than available gcc
+        GCC_KERNEL_VERSION="${GCC_MIN_VERSION}"
+    elif [[ $GCC_KERNEL_VERSION -gt $GCC_MAX_VERSION ]]; then
+        # Kernel version higher than available gcc
+        GCC_KERNEL_VERSION="${GCC_MAX_VERSION}"
+    fi
+
+    echo "* Setting up link /usr/bin/gcc-${GCC_KERNEL_VERSION}->/usr/bin/gcc from /proc/version"
+
+    ln -sf "/usr/bin/gcc-${GCC_KERNEL_VERSION}" "/usr/bin/gcc"
+
     /usr/bin/falco-driver-loader
 fi
 

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:buster
 
 LABEL usage="docker run -i -t -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --name NAME IMAGE"
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
@@ -22,6 +22,7 @@ RUN apt-get update \
 	curl \
 	dkms \
 	gnupg2 \
+	gcc-7 \
 	gcc \
 	jq \
 	libc6-dev \

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -75,10 +75,6 @@ RUN curl -L -o cpp-5_5.5.0-12_amd64.deb https://dl.bintray.com/falcosecurity/dep
 	&& dpkg -i cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb \
 	&& rm -f cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb
 
-# Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
-# default to gcc-5.
-RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-5 /usr/bin/gcc
-
 RUN rm -rf /usr/bin/clang \
 	&& rm -rf /usr/bin/llc \
 	&& ln -s /usr/bin/clang-7 /usr/bin/clang \

--- a/docker/local/docker-entrypoint.sh
+++ b/docker/local/docker-entrypoint.sh
@@ -28,6 +28,23 @@ if [[ -z "${SKIP_DRIVER_LOADER}" ]]; then
         ln -s "$i" "/usr/src/$base"
     done
 
+    GCC_AVAILABLE_VERSIONS=( $(ls /usr/bin | grep -Po "^gcc-\K[0-9]+") )
+    GCC_MIN_VERSION="${GCC_AVAILABLE_VERSIONS[0]}"
+    GCC_MAX_VERSION="${GCC_AVAILABLE_VERSIONS[-1]}"
+    GCC_KERNEL_VERSION="$(grep -Po "gcc version \K[0-9]+" /proc/version 2>/dev/null)"
+
+    if [[ $GCC_KERNEL_VERSION -lt $GCC_MIN_VERSION ]]; then
+        # Kernel version not parsed or lower than available gcc
+        GCC_KERNEL_VERSION="${GCC_MIN_VERSION}"
+    elif [[ $GCC_KERNEL_VERSION -gt $GCC_MAX_VERSION ]]; then
+        # Kernel version higher than available gcc
+        GCC_KERNEL_VERSION="${GCC_MAX_VERSION}"
+    fi
+
+    echo "* Setting up link /usr/bin/gcc-${GCC_KERNEL_VERSION}->/usr/bin/gcc from /proc/version"
+
+    ln -sf "/usr/bin/gcc-${GCC_KERNEL_VERSION}" "/usr/bin/gcc"
+
     /usr/bin/falco-driver-loader
 fi
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

dkms always seems to default to /usr/bin/gcc. The override built in the Dockerfile causes compilation problems with the Ubuntu 20.04 AMI kops is planning to moving to. (We've tested installing gcc-9 to the image, that doesn't seem to fix the problem)

Behavior:
* Match major gcc version with version stated in /proc/version whenever possible
* Use lowest installed version if kernel gcc version not found or lower (supersedes gcc-5 link in Dockerfile)
* Use highest installed gcc version if kernel gcc version higher (fixes problems with ubuntu focal AMI soon to be used by kops)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
docker-entrypoint: Match closest /usr/bin/gcc major version with version stated in /proc/version for module compilation
```
