### PR TITLE
docker: migrate falco and local images to ubuntu:bionic

### DIFF
--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 	libc6-dev \
 	libelf-dev \
 	libmpx2 \
+	libssl1.0-dev \
 	llvm-7 \
 	netcat \
 	xz-utils \

--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -1,14 +1,15 @@
-FROM debian:stable
+FROM ubuntu:bionic
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
 LABEL usage="docker run -i -t --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc --name NAME IMAGE"
 
 ARG FALCO_VERSION=latest
+
+ENV FALCO_VERSION=${FALCO_VERSION}
 ARG VERSION_BUCKET=deb
 ENV VERSION_BUCKET=${VERSION_BUCKET}
 
-ENV FALCO_VERSION=${FALCO_VERSION}
 ENV HOST_ROOT /host
 ENV HOME /root
 
@@ -16,14 +17,22 @@ RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
+	ca-certificates \
+	gnupg2 \
+	&& echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" >> /etc/apt/sources.list \
+	&& apt-key adv --keyserver keyserver.ubuntu.com --recv 1E9377A2BA9EF27F \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends \
 	bash-completion \
 	bc \
 	clang-7 \
-	ca-certificates \
 	curl \
 	dkms \
-	gnupg2 \
-	gcc \
+	gcc-5 \
+	gcc-6 \
+	gcc-7 \
+	gcc-8 \
+	gcc-9 \
 	jq \
 	libc6-dev \
 	libelf-dev \
@@ -33,39 +42,6 @@ RUN apt-get update \
 	xz-utils \
 	&& rm -rf /var/lib/apt/lists/*
 
-# gcc 6 is no longer included in debian stable, but we need it to
-# build kernel modules on the default debian-based ami used by
-# kops. So grab copies we've saved from debian snapshots with the
-# prefix https://snapshot.debian.org/archive/debian/20170517T033514Z
-# or so.
-
-RUN curl -L -o cpp-6_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/cpp-6_6.3.0-18_amd64.deb \
-	&& curl -L -o gcc-6-base_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/gcc-6-base_6.3.0-18_amd64.deb \
-	&& curl -L -o gcc-6_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/gcc-6_6.3.0-18_amd64.deb \
-	&& curl -L -o libasan3_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libasan3_6.3.0-18_amd64.deb \
-	&& curl -L -o libcilkrts5_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libcilkrts5_6.3.0-18_amd64.deb \
-	&& curl -L -o libgcc-6-dev_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libgcc-6-dev_6.3.0-18_amd64.deb \
-	&& curl -L -o libubsan0_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libubsan0_6.3.0-18_amd64.deb \
-	&& curl -L -o libmpfr4_3.1.3-2_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libmpfr4_3.1.3-2_amd64.deb \
-	&& curl -L -o libisl15_0.18-1_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libisl15_0.18-1_amd64.deb \
-	&& dpkg -i cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb \
-	&& rm -f cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb
-
-# gcc 5 is no longer included in debian stable, but we need it to
-# build centos kernels, which are 3.x based and explicitly want a gcc
-# version 3, 4, or 5 compiler. So grab copies we've saved from debian
-# snapshots with the prefix https://snapshot.debian.org/archive/debian/20190122T000000Z.
-
-RUN curl -L -o cpp-5_5.5.0-12_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/cpp-5_5.5.0-12_amd64.deb \
-	&& curl -L -o gcc-5-base_5.5.0-12_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/gcc-5-base_5.5.0-12_amd64.deb \
-	&& curl -L -o gcc-5_5.5.0-12_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/gcc-5_5.5.0-12_amd64.deb \
-	&& curl -L -o libasan2_5.5.0-12_amd64.deb	https://dl.bintray.com/falcosecurity/dependencies/libasan2_5.5.0-12_amd64.deb \
-	&& curl -L -o libgcc-5-dev_5.5.0-12_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libgcc-5-dev_5.5.0-12_amd64.deb \
-	&& curl -L -o libisl15_0.18-4_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libisl15_0.18-4_amd64.deb \
-	&& curl -L -o libmpx0_5.5.0-12_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libmpx0_5.5.0-12_amd64.deb \
-	&& dpkg -i cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb \
-	&& rm -f cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb
-
 # Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
 # default to gcc-5.
 RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-5 /usr/bin/gcc
@@ -74,6 +50,12 @@ RUN rm -rf /usr/bin/clang \
 	&& rm -rf /usr/bin/llc \
 	&& ln -s /usr/bin/clang-7 /usr/bin/clang \
 	&& ln -s /usr/bin/llc-7 /usr/bin/llc
+
+# Some base images have an empty /lib/modules by default
+# If it's not empty, docker build will fail instead of
+# silently overwriting the existing directory
+RUN rm -df /lib/modules \
+	&& ln -s $HOST_ROOT/lib/modules /lib/modules
 
 RUN curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | apt-key add - \
 	&& echo "deb https://dl.bintray.com/falcosecurity/${VERSION_BUCKET} stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list \
@@ -87,21 +69,6 @@ RUN curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | apt-key add - \
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/falco/falco.yaml > /etc/falco/falco.yaml.new \
 	&& mv /etc/falco/falco.yaml.new /etc/falco/falco.yaml
 
-# Some base images have an empty /lib/modules by default
-# If it's not empty, docker build will fail instead of
-# silently overwriting the existing directory
-RUN rm -df /lib/modules \
-	&& ln -s $HOST_ROOT/lib/modules /lib/modules
-
-# debian:stable head contains binutils 2.31, which generates
-# binaries that are incompatible with kernels < 4.16. So manually
-# forcibly install binutils 2.30-22 instead.
-RUN curl -L -o binutils_2.30-22_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/binutils_2.30-22_amd64.deb \
-	&& curl -L -o libbinutils_2.30-22_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libbinutils_2.30-22_amd64.deb \
-	&& curl -L -o binutils-x86-64-linux-gnu_2.30-22_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/binutils-x86-64-linux-gnu_2.30-22_amd64.deb \
-	&& curl -L -o binutils-common_2.30-22_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/binutils-common_2.30-22_amd64.deb \
-	&& dpkg -i *binutils*.deb \
-	&& rm -f *binutils*.deb
 
 COPY ./docker-entrypoint.sh /
 

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -1,32 +1,40 @@
-FROM debian:stable
+FROM ubuntu:bionic
+
+LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
 LABEL usage="docker run -i -t -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --name NAME IMAGE"
-LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
 ARG FALCO_VERSION=
 RUN test -n FALCO_VERSION
 ENV FALCO_VERSION ${FALCO_VERSION}
 
 ENV HOST_ROOT /host
-
 ENV HOME /root
 
 RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
+	ca-certificates \
+	gnupg2 \
+	&& echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" >> /etc/apt/sources.list \
+	&& apt-key adv --keyserver keyserver.ubuntu.com --recv 1E9377A2BA9EF27F \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends \
 	bash-completion \
 	bc \
 	clang-7 \
-	ca-certificates \
 	curl \
 	dkms \
-	gnupg2 \
-	gcc \
+	gcc-5 \
+	gcc-6 \
+	gcc-7 \
+	gcc-8 \
+	gcc-9 \
 	jq \
 	libc6-dev \
 	libelf-dev \
-	libyaml-0-2 \
+	libmpx2 \
 	llvm-7 \
 	netcat \
 	xz-utils \
@@ -37,43 +45,10 @@ RUN apt-get update \
 	libatomic1 \
 	liblsan0 \
 	libtsan0 \
-	libmpx2 \
+	libyaml-0-2 \
 	libquadmath0 \
 	libcc1-0 \
 	&& rm -rf /var/lib/apt/lists/*
-
-# gcc 6 is no longer included in debian stable, but we need it to
-# build kernel modules on the default debian-based ami used by
-# kops. So grab copies we've saved from debian snapshots with the
-# prefix https://snapshot.debian.org/archive/debian/20170517T033514Z
-# or so.
-
-RUN curl -L -o cpp-6_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/cpp-6_6.3.0-18_amd64.deb \
-	&& curl -L -o gcc-6-base_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/gcc-6-base_6.3.0-18_amd64.deb \
-	&& curl -L -o gcc-6_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/gcc-6_6.3.0-18_amd64.deb \
-	&& curl -L -o libasan3_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libasan3_6.3.0-18_amd64.deb \
-	&& curl -L -o libcilkrts5_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libcilkrts5_6.3.0-18_amd64.deb \
-	&& curl -L -o libgcc-6-dev_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libgcc-6-dev_6.3.0-18_amd64.deb \
-	&& curl -L -o libubsan0_6.3.0-18_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libubsan0_6.3.0-18_amd64.deb \
-	&& curl -L -o libmpfr4_3.1.3-2_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libmpfr4_3.1.3-2_amd64.deb \
-	&& curl -L -o libisl15_0.18-1_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libisl15_0.18-1_amd64.deb \
-	&& dpkg -i cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb \
-	&& rm -f cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb
-
-# gcc 5 is no longer included in debian stable, but we need it to
-# build centos kernels, which are 3.x based and explicitly want a gcc
-# version 3, 4, or 5 compiler. So grab copies we've saved from debian
-# snapshots with the prefix https://snapshot.debian.org/archive/debian/20190122T000000Z.
-
-RUN curl -L -o cpp-5_5.5.0-12_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/cpp-5_5.5.0-12_amd64.deb \
-	&& curl -L -o gcc-5-base_5.5.0-12_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/gcc-5-base_5.5.0-12_amd64.deb \
-	&& curl -L -o gcc-5_5.5.0-12_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/gcc-5_5.5.0-12_amd64.deb \
-	&& curl -L -o libasan2_5.5.0-12_amd64.deb	https://dl.bintray.com/falcosecurity/dependencies/libasan2_5.5.0-12_amd64.deb \
-	&& curl -L -o libgcc-5-dev_5.5.0-12_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libgcc-5-dev_5.5.0-12_amd64.deb \
-	&& curl -L -o libisl15_0.18-4_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libisl15_0.18-4_amd64.deb \
-	&& curl -L -o libmpx0_5.5.0-12_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libmpx0_5.5.0-12_amd64.deb \
-	&& dpkg -i cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb \
-	&& rm -f cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb
 
 # Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
 # default to gcc-5.
@@ -96,17 +71,8 @@ RUN dpkg -i /falco-${FALCO_VERSION}-x86_64.deb
 # Change the falco config within the container to enable ISO 8601
 # output.
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/falco/falco.yaml > /etc/falco/falco.yaml.new \
-    && mv /etc/falco/falco.yaml.new /etc/falco/falco.yaml
+	&& mv /etc/falco/falco.yaml.new /etc/falco/falco.yaml
 
-# debian:stable head contains binutils 2.31, which generates
-# binaries that are incompatible with kernels < 4.16. So manually
-# forcibly install binutils 2.30-22 instead.
-RUN curl -L -o binutils_2.30-22_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/binutils_2.30-22_amd64.deb \
-	&& curl -L -o libbinutils_2.30-22_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/libbinutils_2.30-22_amd64.deb \
-	&& curl -L -o binutils-x86-64-linux-gnu_2.30-22_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/binutils-x86-64-linux-gnu_2.30-22_amd64.deb \
-	&& curl -L -o binutils-common_2.30-22_amd64.deb https://dl.bintray.com/falcosecurity/dependencies/binutils-common_2.30-22_amd64.deb \
-	&& dpkg -i *binutils*.deb \
-	&& rm -f *binutils*.deb
 
 # The local container also copies some test trace files and
 # corresponding rules that are used when running regression tests.

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update \
 	libc6-dev \
 	libelf-dev \
 	libmpx2 \
+	libssl1.0-dev \
 	llvm-7 \
 	netcat \
 	xz-utils \


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind feature

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

* gcc 5 to 8 coming from base repositories (removes gcc 5 and 6 workarounds)
* gcc 9 installed from Canonical-maintained PPA (ex. Ubuntu Focal hosts)
* bionic uses binutils 2.30 (removes workaround)
* reworked falco and local images to make diff easier between images
* adds libssl1.0-dev to allow the webserver SSL mode to work until static linking is implemented

**Which issue(s) this PR fixes**:

Fixes #860 
Maybe #1390
Maybe #1433 

**Special notes for your reviewer**:

gcc-9 coming from PPA suggested here: https://wiki.ubuntu.com/ToolChain#PPA_packages

**Does this PR introduce a user-facing change?**:


```release-note
docker: migrate falco and local images to ubuntu:bionic
```
