### PR TITLE
macro(exe_running_docker_save): add better support for centos

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -867,7 +867,7 @@
     proc.name = "exe"
     and (proc.cmdline contains "/var/lib/docker"
     or proc.cmdline contains "/var/run/docker")
-    and proc.pname in (dockerd, docker)
+    and proc.pname in (dockerd, docker, dockerd-current, docker-current)
 
 # Ideally we'd have a length check here as well but sysdig
 # filterchecks don't have operators like len()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug
/kind rule-update

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

dockerd and docker have "-current" suffix on centos and rhel. This
macro does not match causing false positives on multiple rules
using it

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
macro(exe_running_docker_save): add better support for centos
```
