### PR TITLE
update: bump sysdig to 0.27.0

### DIFF
--- a/cmake/modules/sysdig.cmake
+++ b/cmake/modules/sysdig.cmake
@@ -26,8 +26,8 @@ file(MAKE_DIRECTORY ${SYSDIG_CMAKE_WORKING_DIR})
 # To update sysdig version for the next release, change the default below
 # In case you want to test against another sysdig version just pass the variable - ie., `cmake -DSYSDIG_VERSION=dev ..`
 if(NOT SYSDIG_VERSION)
-  set(SYSDIG_VERSION "85c88952b018fdbce2464222c3303229f5bfcfad")
-  set(SYSDIG_CHECKSUM "SHA256=6c3f5f2d699c9540e281f50cbc5cb6b580f0fc689798bc65d4a77f57f932a71c")
+  set(SYSDIG_VERSION "113c22c4693fac5cc2db1b115c2f1ee0b6b701b7")
+  set(SYSDIG_CHECKSUM "SHA256=48fb9ec586ec217d8509e4d20a94e911a9679c78ddc23877d07c6dda26ff34db")
 endif()
 set(PROBE_VERSION "${SYSDIG_VERSION}")
 


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>


**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:


Fixes #1354

**Special notes for your reviewer**:

Updating this dependency is very important to obtain builds of the driver on 5.8.x kernels.

Here is the change set:
```
113c22c4693fac5cc2db1b115c2f1ee0b6b701b7 (tag: agent/10.4.0, tag: 0.27.0, origin/master, origin/agent-release-10.4.0) better detection of critical logs in the inspect chisel
c42155dc7d5dfd68b0dd2e27937fec90c6f804fa Make probe builder failures non-fatal
2691cbc66c7faa973333d65a69909be06be21c18 Fix kmod build on Linux 5.8 (#1672)
3193643d8eceb9ce92675049974559ddef11f697 Implement registration of pending conns for audit tap (#1668)
a4513a98246d83a2bf5dac1af8ef9fa5fabaf7d0 Fix merge failure for driver code (#1663)
81b298af0f36ce05485fb7164969344cfe1ce1f1 (tag: agent/10.3.0) build: CMake error only if the build was requested in the main source directory.
f7991caf64d1f69d27d18233551b9cdc1f442eca update(userspace/libsinsp): consider all the errors while converting them to string.
daa2ae6d71731fc1e721ddbdcc14f3ad9dd388d5 update(driver): move all the renameat2 mappings to the end of the respective tables
9861d5846377b30cfc4756f6dac04c8e0196aebf update(driver): __NR_ia32_renameat2 exclusion
f0bf26959c6a9bd1856d45ee5c80448201124f08 update(driver): renameat2 support
84b5744ea530a25e0cdfe7149f32c7563deedb71 update(driver/bpf): do not redefine always inline if it's already defined.
6a5b84599c7ec025b639e054bd1b6092b325f148 Change probe download url (#1652)
```

So I wrote the changelog based on that.

**Does this PR introduce a user-facing change?**:


```release-note
update: renameat2 syscall support
update: support for 5.8.x kernels
```
