### PR TITLE
chore(rules): add `renameat2` to `rename` macro

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -55,11 +55,12 @@
 - macro: proc_name_exists
   condition: (proc.name!="<NA>")
 
-# todo(leogr): we miss "renameat2", but it's not yet supported by sinsp
 - macro: rename
-  condition: evt.type in (rename, renameat)
+  condition: evt.type in (rename, renameat, renameat2)
+
 - macro: mkdir
   condition: evt.type in (mkdir, mkdirat)
+
 - macro: remove
   condition: evt.type in (rmdir, unlink, unlinkat)
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

Since https://github.com/falcosecurity/falco/pull/1355 we can use `renameat2` syscall.

**Which issue(s) this PR fixes**:

Partially #676

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
rule(macro `rename`): add `renameat2` syscall
```
