### PR TITLE
wip:fix(scripts): modprobe before starting Falco

### DIFF
--- a/scripts/debian/falco
+++ b/scripts/debian/falco
@@ -62,11 +62,11 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
+	if [ ! -d /sys/module/falco ]; then
+		/sbin/modprobe falco || exit 2
+	fi
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
 		|| return 1
-	if [ ! -d /sys/module/falco ]; then
-		/sbin/modprobe falco || exit 1
-	fi
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
 		$DAEMON_ARGS \
 		|| return 2

--- a/scripts/debian/falco
+++ b/scripts/debian/falco
@@ -21,7 +21,7 @@
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Falco syscall activity monitoring agent
+# Short-Description: Falco Cloud Native runtime security
 # Description:       Falco is a system activity monitoring agent
 #                    driven by system calls with support for containers.
 ### END INIT INFO

--- a/scripts/rpm/falco
+++ b/scripts/rpm/falco
@@ -52,10 +52,10 @@ start() {
     [ -x $exec ] || exit 5
     # [ -f $config ] || exit 6
     echo -n $"Starting $prog: "
-    daemon $exec --daemon --pidfile=$pidfile
     if [ ! -d /sys/module/falco ]; then
         /sbin/modprobe falco || return $?
     fi
+    daemon $exec --daemon --pidfile=$pidfile
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile

--- a/scripts/rpm/falco
+++ b/scripts/rpm/falco
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright (C) 2019 The Falco Authors.
+# Copyright (C) 2020 The Falco Authors.
 #
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,10 +18,10 @@
 #
 
 #
-# falco syscall monitoring agent
+# Falco Cloud Native runtime security
 #
 # chkconfig:   2345 55 45
-# description: Falco syscall monitoring agent
+# description: Falco Cloud Native runtime security
 #
 
 ### BEGIN INIT INFO


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> /area build

> /area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Running `modprobe` in deb/rpm scripts was originally introduced by https://github.com/falcosecurity/falco/commit/32f8e304eb1bd0ee427b763cdd450fa7d66b27e7 as backup mechanism since the Falco binary is loading the module by itself.

Anyway, we have noticed that the module is not loaded all the time (especially when the daemon starts during the boot process). 

TODO: We need to investigate more


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
/cc @fntlnz 

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix(scripts): run `modprobe` before starting Falco in deb/rpm scripts.
```
