### PR TITLE
fix(userspace/falco): do not always rethrow the exception

### DIFF
--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -1143,11 +1143,14 @@ int falco_init(int argc, char **argv)
 					// Try to insert the Falco kernel module
 					if(system("modprobe " PROBE_NAME " > /dev/null 2> /dev/null"))
 					{
-						falco_logger::log(LOG_ERR, "Unable to load the driver. Exiting.\n");
+						falco_logger::log(LOG_ERR, "Unable to load the driver.\n");
 					}
 					open_f(inspector);
+				} 
+				else 
+				{
+					rethrow_exception(current_exception());
 				}
-				rethrow_exception(current_exception());
 			}
 		}
 


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**Any specific area of the project related to this PR?**

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

We have noticed that the kernel module was not loaded always when using Falco deb/rpm packages.
When we had investigated the fallback mechanism included in those scripts (see #1365 ) we then noticed that the Falco binary is loading the module by itself at some point.
Unfortunately, the implementation was thrown an exception even if it was able to load the module correctly.

This PR just fixes the case when `open_f` works after `modprobe` thus the exception must not be thrown and the execution can continue normally.



**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1347

**Special notes for your reviewer**:

/milestone 0.25.0
/cc @fntlnz 

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix(userspace/falco): correct the fallback mechanism for loading the kernel module
```
