### PR TITLE
Automatic cleanup of not recent Falco development release packages

### DIFF
--- a/.circleci/cleanup
+++ b/.circleci/cleanup
@@ -16,6 +16,9 @@ get_versions() {
     IFS=$'\n' read -r -d '' -a all < <(curl -s --header "Content-Type: application/json" "https://api.bintray.com/packages/falcosecurity/$1/falco" | jq -r '.versions | .[]' | tail -n "+$2")
 }
 
+# Remove all the versions (${all[@]} array).
+#
+# $1: repository containing the versions.
 rem_versions() {
     for i in "${!all[@]}";
     do
@@ -54,5 +57,5 @@ if [[ "${repo}" == "bin-dev" ]]; then
 fi
 
 get_versions "${repo}" ${skip}
-echo "# versions: ${#all[@]}"
+echo "number of versions to delete: ${#all[@]}"
 rem_versions "${repo}"

--- a/.circleci/cleanup
+++ b/.circleci/cleanup
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+usage() {
+    echo "usage: $0 -p 0987654321 -r <deb-dev|rpm-dev|bin-dev>"
+    exit 1
+}
+
+user=poiana
+
+# Get the versions to delete.
+#
+# $1: repository to lookup
+# $2: number of versions to skip.
+get_versions() {
+    # The API endpoint returns the Falco package versions sort by most recent.
+    IFS=$'\n' read -r -d '' -a all < <(curl -s --header "Content-Type: application/json" "https://api.bintray.com/packages/falcosecurity/$1/falco" | jq -r '.versions | .[]' | tail -n "+$2")
+}
+
+rem_versions() {
+    for i in "${!all[@]}";
+    do
+        JFROG_CLI_LOG_LEVEL=DEBUG jfrog bt vd --quiet --user "${user}" --key "${pass}" "falcosecurity/$1/falco/${all[$i]}"
+    done
+}
+
+while getopts ":p::r:" opt; do
+    case "${opt}" in
+        p )
+          pass=${OPTARG}
+          ;;
+        r )
+          repo="${OPTARG}"
+          [[ "${repo}" == "deb-dev" || "${repo}" == "rpm-dev" || "${repo}" == "bin-dev" ]] || usage
+          ;;
+        : )
+          echo "invalid option: ${OPTARG} requires an argument" 1>&2
+          exit 1
+          ;;
+        \?)
+          echo "invalid option: ${OPTARG}" 1>&2
+          exit 1
+          ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${pass}" ] || [ -z "${repo}" ]; then
+    usage
+fi
+
+skip=51
+if [[ "${repo}" == "bin-dev" ]]; then
+    skip=11
+fi
+
+get_versions "${repo}" ${skip}
+echo "# versions: ${#all[@]}"
+rem_versions "${repo}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,7 +282,7 @@ jobs:
             apk add --no-cache --update
             apk add curl jq
       - run:
-          name: Only keep the 10 most recet Falco development release tarballs
+          name: Only keep the 10 most recent Falco development release tarballs
           command: |
             .circleci/cleanup -p ${BINTRAY_SECRET} -r bin-dev
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,28 @@ jobs:
           command: |
             FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
             jfrog bt u /build/release/falco-${FALCO_VERSION}-x86_64.tar.gz falcosecurity/bin-dev/falco/${FALCO_VERSION} x86_64/ --user poiana --key ${BINTRAY_SECRET} --publish --override
+  # Clenup the Falco development release packages
+  "cleanup/packages-dev":
+    docker:
+      - image: docker.bintray.io/jfrog/jfrog-cli-go:latest
+    steps:
+      - run:
+          name: Prepare env
+          command: |
+            apk add --no-cache --update
+            apk add curl jq
+      - run:
+          name: Only keep the 10 most recet Falco development release tarballs
+          command: |
+            .circleci/cleanup -p ${BINTRAY_SECRET} -r bin-dev
+      - run:
+          name: Only keep the 50 most recent Falco development release RPMs
+          command: |
+            .circleci/cleanup -p ${BINTRAY_SECRET} -r rpm-dev
+      - run:
+          name: Only keep the 50 most recent Falco development release DEBs
+          command: |
+            .circleci/cleanup -p ${BINTRAY_SECRET} -r deb-dev
   # Publish docker packages
   "publish/docker-dev":
     docker:
@@ -402,6 +424,15 @@ workflows:
               only: master
           requires:
             - "rpm/sign"
+      - "cleanup/packages-dev":
+          context: falco
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: master
+          requires:
+            - "publish/packages-dev"
       - "publish/docker-dev":
           context: falco
           filters:


### PR DESCRIPTION


**What type of PR is this?**



/kind cleanup




**Any specific area of the project related to this PR?**



/area build





**What this PR does / why we need it**:

This PR implements what described into "Artifacts Cleanup" proposal (refs https://github.com/falcosecurity/falco/pull/1375).

In particular, it adds a CI job responsible for keeping only the most recent Falco development release packages and remove the others from bintray.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Not sure if this PR needs a release-note. For some aspects it's very user releated, for others not.

We'll decide together as usual.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
