### PR TITLE
update: bump Falco engine version to 7

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 The Falco Authors.
+# Copyright (C) 2020 The Falco Authors.
 #
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@
 # change to this rules file, we'll uncomment this line and set it to
 # the falco engine version in use at the time.
 #
-#- required_engine_version: 2
+- required_engine_version: 7
 
 # Currently disabled as read/write are ignored syscalls. The nearly
 # similar open_write/open_read check for files being opened for

--- a/userspace/engine/falco_engine_version.h
+++ b/userspace/engine/falco_engine_version.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2019 The Falco Authors.
+Copyright (C) 2020 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ limitations under the License.
 
 // The version of rules/filter fields/etc supported by this falco
 // engine.
-#define FALCO_ENGINE_VERSION (6)
+#define FALCO_ENGINE_VERSION (7)
 
 // This is the result of running "falco --list -N | sha256sum" and
 // represents the fields supported by this version of falco. It's used


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind feature

**Any specific area of the project related to this PR?**

/area engine
/area rules

**What this PR does / why we need it**:

This PR bumps the engine version to the expected number (7), as per https://falco.org/docs/rules/#versioning

Furthermore, it also sets the `required_engine_version` to 7 in the rule files, to show the expected error when the ruleset does not match. Unfortunately, this must be set to the entire rule files (even though it's required just by few rules) since the [`required_engine_version` does not work on rule level](https://github.com/falcosecurity/falco/pull/1273#issuecomment-662406908) (thus the PR #1273 is blocked).

/milestone 0.26.0

**Which issue(s) this PR fixes**:

Fixes #1380
Fixes #1272

**Special notes for your reviewer**:

I'd propose closing the https://github.com/falcosecurity/falco/pull/1273 in favor of this since the current implementation does not support `required_engine_version` at rule level.

An alternative of setting the `required_engine_version` to 7 for the whole file is to create a rules file for every version depending on what are the supported fields, as initially proposed in [this comment](https://github.com/falcosecurity/falco/issues/1272#issuecomment-648015596). If we got consensus for this alternative, I will open another PR (since the main purpose of this PR is just to bump the engine version number and not to fix the whole problem).

Finally, this PR intentionally does not try to solve the other problem reported by https://github.com/falcosecurity/falco/issues/1277

/cc @fntlnz 
/cc @leodido
/cc @mstemm 

**Does this PR introduce a user-facing change?**:

```release-note
update: bump Falco engine version to 7
update: the required_engine_version is now on by default
```