### PR TITLE
K8s env, best practice, container.info over container.id

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -368,7 +368,7 @@
 - rule: Disallowed SSH Connection
   desc: Detect any new ssh connection to a host other than those in an allowed group of hosts
   condition: (inbound_outbound) and ssh_port and not allowed_ssh_hosts
-  output: Disallowed SSH Connection (command=%proc.cmdline connection=%fd.name user=%user.name user_loginuid=%user.loginuid container_id=%container.id image=%container.image.repository)
+  output: Disallowed SSH Connection (command=%proc.cmdline connection=%fd.name user=%user.name user_loginuid=%user.loginuid %container.info image=%container.image.repository)
   priority: NOTICE
   tags: [network, mitre_remote_service]
 
@@ -399,7 +399,7 @@
     ((fd.sip in (allowed_outbound_destination_ipaddrs)) or
      (fd.snet in (allowed_outbound_destination_networks)) or
      (fd.sip.name in (allowed_outbound_destination_domains)))
-  output: Disallowed outbound connection destination (command=%proc.cmdline connection=%fd.name user=%user.name user_loginuid=%user.loginuid container_id=%container.id image=%container.image.repository)
+  output: Disallowed outbound connection destination (command=%proc.cmdline connection=%fd.name user=%user.name user_loginuid=%user.loginuid %container.info image=%container.image.repository)
   priority: NOTICE
   tags: [network]
 
@@ -422,7 +422,7 @@
     ((fd.cip in (allowed_inbound_source_ipaddrs)) or
      (fd.cnet in (allowed_inbound_source_networks)) or
      (fd.cip.name in (allowed_inbound_source_domains)))
-  output: Disallowed inbound connection source (command=%proc.cmdline connection=%fd.name user=%user.name user_loginuid=%user.loginuid container_id=%container.id image=%container.image.repository)
+  output: Disallowed inbound connection source (command=%proc.cmdline connection=%fd.name user=%user.name user_loginuid=%user.loginuid %container.info image=%container.image.repository)
   priority: NOTICE
   tags: [network]
 
@@ -461,7 +461,7 @@
     and not proc.name in (shell_binaries)
     and not exe_running_docker_save
   output: >
-    a shell configuration file has been modified (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pcmdline=%proc.pcmdline file=%fd.name container_id=%container.id image=%container.image.repository)
+    a shell configuration file has been modified (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pcmdline=%proc.pcmdline file=%fd.name %container.info image=%container.image.repository)
   priority:
     WARNING
   tags: [file, mitre_persistence]
@@ -483,7 +483,7 @@
      fd.directory in (shell_config_directories)) and
     (not proc.name in (shell_binaries))
   output: >
-    a shell configuration file was read by a non-shell program (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline file=%fd.name container_id=%container.id image=%container.image.repository)
+    a shell configuration file was read by a non-shell program (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline file=%fd.name %container.info image=%container.image.repository)
   priority:
     WARNING
   tags: [file, mitre_discovery]
@@ -503,7 +503,7 @@
     not user_known_cron_jobs
   output: >
     Cron jobs were scheduled to run (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline
-    file=%fd.name container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
+    file=%fd.name %container.info container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority:
     NOTICE
   tags: [file, mitre_persistence]
@@ -513,7 +513,7 @@
 # When displaying container information in the output field, use
 # %container.info, without any leading term (file=%fd.name
 # %container.info user=%user.name user_loginuid=%user.loginuid, and not file=%fd.name
-# container=%container.info user=%user.name user_loginuid=%user.loginuid). The output will change
+# %container.info user=%user.name user_loginuid=%user.loginuid). The output will change
 # based on the context and whether or not -pk/-pm/-pc was specified on
 # the command line.
 - macro: container
@@ -957,7 +957,7 @@
     and not exe_running_docker_save
     and not user_known_update_package_registry
   output: >
-    Repository files get updated (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pcmdline=%proc.pcmdline file=%fd.name newpath=%evt.arg.newpath container_id=%container.id image=%container.image.repository)
+    Repository files get updated (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pcmdline=%proc.pcmdline file=%fd.name newpath=%evt.arg.newpath %container.info image=%container.image.repository)
   priority:
     NOTICE
   tags: [filesystem, mitre_persistence]
@@ -979,7 +979,7 @@
     and not user_known_write_below_binary_dir_activities
   output: >
     File below a known binary directory opened for writing (user=%user.name user_loginuid=%user.loginuid
-    command=%proc.cmdline file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline gparent=%proc.aname[2] container_id=%container.id image=%container.image.repository)
+    command=%proc.cmdline file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline gparent=%proc.aname[2] %container.info image=%container.image.repository)
   priority: ERROR
   tags: [filesystem, mitre_persistence]
 
@@ -1037,7 +1037,7 @@
     and not user_known_write_monitored_dir_conditions
   output: >
     File below a monitored directory opened for writing (user=%user.name user_loginuid=%user.loginuid
-    command=%proc.cmdline file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline gparent=%proc.aname[2] container_id=%container.id image=%container.image.repository)
+    command=%proc.cmdline file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline gparent=%proc.aname[2] %container.info image=%container.image.repository)
   priority: ERROR
   tags: [filesystem, mitre_persistence]
 
@@ -1060,7 +1060,7 @@
      not proc.name in (ssh_binaries))
   output: >
     ssh-related file/directory read by non-ssh program (user=%user.name user_loginuid=%user.loginuid
-    command=%proc.cmdline file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline container_id=%container.id image=%container.image.repository)
+    command=%proc.cmdline file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline %container.info image=%container.image.repository)
   priority: ERROR
   tags: [filesystem, mitre_discovery]
 
@@ -1337,7 +1337,7 @@
 - rule: Write below etc
   desc: an attempt to write to any file below /etc
   condition: write_etc_common
-  output: "File below /etc opened for writing (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline parent=%proc.pname pcmdline=%proc.pcmdline file=%fd.name program=%proc.name gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] container_id=%container.id image=%container.image.repository)"
+  output: "File below /etc opened for writing (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline parent=%proc.pname pcmdline=%proc.pcmdline file=%fd.name program=%proc.name gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] %container.info image=%container.image.repository)"
   priority: ERROR
   tags: [filesystem, mitre_persistence]
 
@@ -1434,7 +1434,7 @@
     and not known_root_conditions
     and not user_known_write_root_conditions
     and not user_known_write_below_root_activities
-  output: "File below / or /root opened for writing (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline parent=%proc.pname file=%fd.name program=%proc.name container_id=%container.id image=%container.image.repository)"
+  output: "File below / or /root opened for writing (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline parent=%proc.pname file=%fd.name program=%proc.name %container.info image=%container.image.repository)"
   priority: ERROR
   tags: [filesystem, mitre_persistence]
 
@@ -1452,7 +1452,7 @@
   condition: sensitive_files and open_read and server_procs and not proc_is_new and proc.name!="sshd" and not user_known_read_sensitive_files_activities
   output: >
     Sensitive file opened for reading by trusted program after startup (user=%user.name user_loginuid=%user.loginuid
-    command=%proc.cmdline parent=%proc.pname file=%fd.name parent=%proc.pname gparent=%proc.aname[2] container_id=%container.id image=%container.image.repository)
+    command=%proc.cmdline parent=%proc.pname file=%fd.name parent=%proc.pname gparent=%proc.aname[2] %container.info image=%container.image.repository)
   priority: WARNING
   tags: [filesystem, mitre_credential_access]
 
@@ -1513,7 +1513,7 @@
     and not user_read_sensitive_file_containers
   output: >
     Sensitive file opened for reading by non-trusted program (user=%user.name user_loginuid=%user.loginuid program=%proc.name
-    command=%proc.cmdline file=%fd.name parent=%proc.pname gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] container_id=%container.id image=%container.image.repository)
+    command=%proc.cmdline file=%fd.name parent=%proc.pname gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] %container.info image=%container.image.repository)
   priority: WARNING
   tags: [filesystem, mitre_credential_access, mitre_discovery]
 
@@ -1537,7 +1537,7 @@
     and not exe_running_docker_save
     and not amazon_linux_running_python_yum
     and not user_known_write_rpm_database_activities
-  output: "Rpm database opened for writing by a non-rpm program (command=%proc.cmdline file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline container_id=%container.id image=%container.image.repository)"
+  output: "Rpm database opened for writing by a non-rpm program (command=%proc.cmdline file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline %container.info image=%container.image.repository)"
   priority: ERROR
   tags: [filesystem, software_mgmt, mitre_persistence]
 
@@ -1576,7 +1576,7 @@
     and not user_known_db_spawned_processes
   output: >
     Database-related program spawned process other than itself (user=%user.name user_loginuid=%user.loginuid
-    program=%proc.cmdline parent=%proc.pname container_id=%container.id image=%container.image.repository)
+    program=%proc.cmdline parent=%proc.pname %container.info image=%container.image.repository)
   priority: NOTICE
   tags: [process, database, mitre_execution]
 
@@ -1588,7 +1588,7 @@
   condition: bin_dir_rename and modify and not package_mgmt_procs and not exe_running_docker_save and not user_known_modify_bin_dir_activities
   output: >
     File below known binary directory renamed/removed (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline
-    pcmdline=%proc.pcmdline operation=%evt.type file=%fd.name %evt.args container_id=%container.id image=%container.image.repository)
+    pcmdline=%proc.pcmdline operation=%evt.type file=%fd.name %evt.args %container.info image=%container.image.repository)
   priority: ERROR
   tags: [filesystem, mitre_persistence]
 
@@ -1600,7 +1600,7 @@
   condition: mkdir and bin_dir_mkdir and not package_mgmt_procs and not user_known_mkdir_bin_dir_activities
   output: >
     Directory below known binary directory created (user=%user.name user_loginuid=%user.loginuid
-    command=%proc.cmdline directory=%evt.arg.path container_id=%container.id image=%container.image.repository)
+    command=%proc.cmdline directory=%evt.arg.path %container.info image=%container.image.repository)
   priority: ERROR
   tags: [filesystem, mitre_persistence]
 
@@ -1645,7 +1645,7 @@
     and not user_known_change_thread_namespace_activities
   output: >
     Namespace change (setns) by unexpected program (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline
-    parent=%proc.pname %container.info container_id=%container.id image=%container.image.repository:%container.image.tag)
+    parent=%proc.pname %container.info image=%container.image.repository:%container.image.tag)
   priority: NOTICE
   tags: [process, mitre_privilege_escalation, mitre_lateral_movement]
 
@@ -1792,7 +1792,7 @@
   output: >
     Shell spawned by untrusted binary (user=%user.name user_loginuid=%user.loginuid shell=%proc.name parent=%proc.pname
     cmdline=%proc.cmdline pcmdline=%proc.pcmdline gparent=%proc.aname[2] ggparent=%proc.aname[3]
-    aname[4]=%proc.aname[4] aname[5]=%proc.aname[5] aname[6]=%proc.aname[6] aname[7]=%proc.aname[7] container_id=%container.id image=%container.image.repository)
+    aname[4]=%proc.aname[4] aname[5]=%proc.aname[5] aname[6]=%proc.aname[6] aname[7]=%proc.aname[7] %container.info image=%container.image.repository)
   priority: DEBUG
   tags: [shell, mitre_execution]
 
@@ -2041,7 +2041,7 @@
 - rule: System user interactive
   desc: an attempt to run interactive commands by a system (i.e. non-login) user
   condition: spawned_process and system_users and interactive and not user_known_system_user_login
-  output: "System user ran an interactive command (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline container_id=%container.id image=%container.image.repository)"
+  output: "System user ran an interactive command (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline %container.info image=%container.image.repository)"
   priority: INFO
   tags: [users, mitre_remote_access_tools]
 
@@ -2059,7 +2059,7 @@
     and not user_expected_terminal_shell_in_container_conditions
   output: >
     A shell was spawned in a container with an attached terminal (user=%user.name user_loginuid=%user.loginuid %container.info
-    shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository)
+    shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty %container.info image=%container.image.repository)
   priority: NOTICE
   tags: [container, shell, mitre_execution]
 
@@ -2134,7 +2134,7 @@
     and not user_expected_system_procs_network_activity_conditions
   output: >
     Known system binary sent/received network traffic
-    (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline connection=%fd.name container_id=%container.id image=%container.image.repository)
+    (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline connection=%fd.name %container.info image=%container.image.repository)
   priority: NOTICE
   tags: [network, mitre_exfiltration]
 
@@ -2172,7 +2172,7 @@
     proc.env icontains HTTP_PROXY
   output: >
     Program run with disallowed HTTP_PROXY environment variable
-    (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline env=%proc.env parent=%proc.pname container_id=%container.id image=%container.image.repository)
+    (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline env=%proc.env parent=%proc.pname %container.info image=%container.image.repository)
   priority: NOTICE
   tags: [host, users]
 
@@ -2195,7 +2195,7 @@
      and interpreted_procs)
   output: >
     Interpreted program received/listened for network traffic
-    (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline connection=%fd.name container_id=%container.id image=%container.image.repository)
+    (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline connection=%fd.name %container.info image=%container.image.repository)
   priority: NOTICE
   tags: [network, mitre_exfiltration]
 
@@ -2206,7 +2206,7 @@
      and interpreted_procs)
   output: >
     Interpreted program performed outgoing network connection
-    (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline connection=%fd.name container_id=%container.id image=%container.image.repository)
+    (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline connection=%fd.name %container.info image=%container.image.repository)
   priority: NOTICE
   tags: [network, mitre_exfiltration]
 
@@ -2247,7 +2247,7 @@
   condition: (inbound_outbound) and do_unexpected_udp_check and fd.l4proto=udp and not expected_udp_traffic
   output: >
     Unexpected UDP Traffic Seen
-    (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline connection=%fd.name proto=%fd.l4proto evt=%evt.type %evt.args container_id=%container.id image=%container.image.repository)
+    (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline connection=%fd.name proto=%fd.l4proto evt=%evt.type %evt.args %container.info image=%container.image.repository)
   priority: NOTICE
   tags: [network, mitre_exfiltration]
 
@@ -2307,7 +2307,7 @@
     and not user_known_non_sudo_setuid_conditions
   output: >
     Unexpected setuid call by non-sudo, non-root program (user=%user.name user_loginuid=%user.loginuid cur_uid=%user.uid parent=%proc.pname
-    command=%proc.cmdline uid=%evt.arg.uid container_id=%container.id image=%container.image.repository)
+    command=%proc.cmdline uid=%evt.arg.uid %container.info image=%container.image.repository)
   priority: NOTICE
   tags: [users, mitre_privilege_escalation]
 
@@ -2359,7 +2359,7 @@
     and not fd.name in (allowed_dev_files)
     and not fd.name startswith /dev/tty
     and not user_known_create_files_below_dev_activities
-  output: "File created below /dev by untrusted program (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline file=%fd.name container_id=%container.id image=%container.image.repository)"
+  output: "File created below /dev by untrusted program (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline file=%fd.name %container.info image=%container.image.repository)"
   priority: ERROR
   tags: [filesystem, mitre_persistence]
 
@@ -2447,7 +2447,7 @@
 - rule: Unexpected K8s NodePort Connection
   desc: Detect attempts to use K8s NodePorts from a container
   condition: (inbound_outbound) and fd.sport >= 30000 and fd.sport <= 32767 and container and not nodeport_containers
-  output: Unexpected K8s NodePort Connection (command=%proc.cmdline connection=%fd.name container_id=%container.id image=%container.image.repository)
+  output: Unexpected K8s NodePort Connection (command=%proc.cmdline connection=%fd.name %container.info image=%container.image.repository)
   priority: NOTICE
   tags: [network, k8s, container, mitre_port_knocking]
 
@@ -2478,7 +2478,7 @@
     and not user_known_package_manager_in_container
   output: >
     Package management process launched in container (user=%user.name user_loginuid=%user.loginuid
-    command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
+    command=%proc.cmdline %container.info container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority: ERROR
   tags: [process, mitre_persistence]
 
@@ -2492,7 +2492,7 @@
     )
   output: >
     Netcat runs inside container that allows remote code execution (user=%user.name user_loginuid=%user.loginuid
-    command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
+    command=%proc.cmdline %container.info container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority: WARNING
   tags: [network, process, mitre_execution]
 
@@ -2505,7 +2505,7 @@
     spawned_process and container and network_tool_procs and not user_known_network_tool_activities
   output: >
     Network tool launched in container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline parent_process=%proc.pname
-    container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
+    %container.info container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority: NOTICE
   tags: [network, process, mitre_discovery, mitre_exfiltration]
 
@@ -2560,7 +2560,7 @@
     )
   output: >
     Grep private keys or passwords activities found
-    (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline container_id=%container.id container_name=%container.name
+    (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline %container.info container_name=%container.name
     image=%container.image.repository:%container.image.tag)
   priority:
     WARNING
@@ -2594,7 +2594,7 @@
     not trusted_logging_images and
     not allowed_clear_log_files
   output: >
-    Log files were tampered (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline file=%fd.name container_id=%container.id image=%container.image.repository)
+    Log files were tampered (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline file=%fd.name %container.info image=%container.image.repository)
   priority:
     WARNING
   tags: [file, mitre_defense_evasion]
@@ -2612,7 +2612,7 @@
   desc: Detect process running to clear bulk data from disk
   condition: spawned_process and clear_data_procs and not user_known_remove_data_activities
   output: >
-    Bulk data has been removed from disk (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline file=%fd.name container_id=%container.id image=%container.image.repository)
+    Bulk data has been removed from disk (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline file=%fd.name %container.info image=%container.image.repository)
   priority:
     WARNING
   tags: [process, mitre_persistence]
@@ -2693,7 +2693,7 @@
     and not user_known_set_setuid_or_setgid_bit_conditions
   output: >
     Setuid or setgid bit is set via chmod (fd=%evt.arg.fd filename=%evt.arg.filename mode=%evt.arg.mode user=%user.name user_loginuid=%user.loginuid process=%proc.name
-    command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
+    command=%proc.cmdline %container.info container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority:
     NOTICE
   tags: [process, mitre_persistence]
@@ -2718,7 +2718,7 @@
     not user_known_create_hidden_file_activities
   output: >
     Hidden file or directory created (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline
-    file=%fd.name newpath=%evt.arg.newpath container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
+    file=%fd.name newpath=%evt.arg.newpath %container.info container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority:
     NOTICE
   tags: [file, mitre_persistence]
@@ -2743,7 +2743,7 @@
     and not user_known_remote_file_copy_activities
   output: >
     Remote file copy tool launched in container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline parent_process=%proc.pname
-    container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
+    %container.info container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority: NOTICE
   tags: [network, process, mitre_lateral_movement, mitre_exfiltration]
 
@@ -2849,14 +2849,14 @@
   desc: Miners typically connect to miner pools on common ports.
   condition: net_miner_pool and not trusted_images_query_miner_domain_dns
   enabled: false
-  output: Outbound connection to IP/Port flagged by cryptoioc.ch (command=%proc.cmdline port=%fd.rport ip=%fd.rip container=%container.info image=%container.image.repository)
+  output: Outbound connection to IP/Port flagged by cryptoioc.ch (command=%proc.cmdline port=%fd.rport ip=%fd.rip %container.info image=%container.image.repository)
   priority: CRITICAL
   tags: [network, mitre_execution]
 
 - rule: Detect crypto miners using the Stratum protocol
   desc: Miners typically specify the mining pool to connect to with a URI that begins with 'stratum+tcp'
   condition: spawned_process and proc.cmdline contains "stratum+tcp"
-  output: Possible miner running (command=%proc.cmdline container=%container.info image=%container.image.repository)
+  output: Possible miner running (command=%proc.cmdline %container.info image=%container.image.repository)
   priority: CRITICAL
   tags: [process, mitre_execution]
 
@@ -2892,7 +2892,7 @@
 - rule: Packet socket created in container
   desc: Detect new packet socket at the device driver (OSI Layer 2) level in a container. Packet socket could be used for ARP Spoofing and privilege escalation(CVE-2020-14386) by attacker.
   condition: evt.type=socket and evt.arg[0]=AF_PACKET and consider_packet_socket_communication and container and not proc.name in (user_known_packet_socket_binaries)
-  output: Packet socket was created in a container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline socket_info=%evt.args container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
+  output: Packet socket was created in a container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline socket_info=%evt.args %container.info container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority: NOTICE
   tags: [network, mitre_discovery]
 
@@ -2931,7 +2931,7 @@
     k8s.ns.name in (namespace_scope_network_only_subnet)
   output: >
     Network connection outside local subnet
-    (command=%proc.cmdline connection=%fd.name user=%user.name user_loginuid=%user.loginuid container_id=%container.id
+    (command=%proc.cmdline connection=%fd.name user=%user.name user_loginuid=%user.loginuid %container.info
      image=%container.image.repository namespace=%k8s.ns.name
      fd.rip.name=%fd.rip.name fd.lip.name=%fd.lip.name fd.cip.name=%fd.cip.name fd.sip.name=%fd.sip.name)
   priority: WARNING
@@ -2971,7 +2971,7 @@
     not fd.sport in (authorized_server_port)
   output: >
     Network connection outside authorized port and binary
-    (command=%proc.cmdline connection=%fd.name user=%user.name user_loginuid=%user.loginuid container_id=%container.id
+    (command=%proc.cmdline connection=%fd.name user=%user.name user_loginuid=%user.loginuid %container.info
     image=%container.image.repository)
   priority: WARNING
   tags: [network]
@@ -2983,7 +2983,7 @@
   desc: Detect redirecting stdout/stdin to network connection in container (potential reverse shell).
   condition: evt.type=dup and evt.dir=> and container and fd.num in (0, 1, 2) and fd.type in ("ipv4", "ipv6") and not user_known_stand_streams_redirect_activities
   output: >
-    Redirect stdout/stdin to network connection (user=%user.name user_loginuid=%user.loginuid %container.info process=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository fd.name=%fd.name fd.num=%fd.num fd.type=%fd.type fd.sip=%fd.sip)
+    Redirect stdout/stdin to network connection (user=%user.name user_loginuid=%user.loginuid %container.info process=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty %container.info image=%container.image.repository fd.name=%fd.name fd.num=%fd.num fd.type=%fd.type fd.sip=%fd.sip)
   priority: WARNING
 
 # The two Container Drift rules below will fire when a new executable is created in a container.


### PR DESCRIPTION

**What type of PR is this?**

/kind rule-update

/area rules


**What this PR does / why we need it**:

In my case, I log to ES, I want all informations about running pods available within the alert/audit record. Output field of rule, frequently miss important informations (ie, namespace). container.info macro instead can provide bunch of usefull details if k8s is configured (otherwise it has fallback). 

It is then better, to log all details and have them either available on alerts.  

(Here I miss some clarification, havent found it documented, but it seems to me, that only details about an event, that are part of falcosidekick Outputfields (https://github.com/falcosecurity/falcosidekick/blob/master/outputs/alertmanager.go#L25) are the ones key=value between "()" of the output field of rule. Sorry I am lazy to find it again in src code - it might be bit different, but the truth is that alert does not have all event details.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
racionale here is as I cant get more details in alert, I do have need use flexible %container.info macro to give me all important (namespace, podname, ...)

**Does this PR introduce a user-facing change?**:

```release-note
rule(Disallowed SSH Connection): use container.info in output fields
rule(Unexpected outbound connection destination): use container.info in output fields
rule(Unexpected inbound connection source): use container.info in output fields
rule(Modify Shell Configuration File): use container.info in output fields
rule(Read Shell Configuration File): use container.info in output fields
rule(Schedule Cron Jobs): use container.info in output fields
rule(Update Package Repository): use container.info in output fields
rule(Read ssh information): use container.info in output fields
rule(Write below etc): use container.info in output fields
rule(Read sensitive file trusted after startup): use container.info in output fields
rule(Write below rpm database): use container.info in output fields
rule(Modify binary dirs): use container.info in output fields
rule(Mkdir binary dirs): use container.info in output fields
rule(System user interactive): use container.info in output fields
rule(Terminal shell in container): use container.info in output fields
rule(System procs network activity): use container.info in output fields
rule(Program run with disallowed http proxy env): use container.info in output fields
rule(Interpreted procs inbound network activity): use container.info in output fields
rule(Interpreted procs outbound network activity): use container.info in output fields
rule(Unexpected UDP Traffic): use container.info in output fields
rule(User mgmt binaries): use container.info in output fields
rule(Create files below dev): use container.info in output fields
rule(Unexpected K8s NodePort Connection): use container.info in output fields
rule(Netcat Remote Code Execution in Container): use container.info in output fields
rule(Launch Suspicious Network Tool in Container): use container.info in output fields
rule(Launch Suspicious Network Tool on Host): use container.info in output fields
rule(Search Private Keys or Passwords): use container.info in output fields
rule(Clear Log Activities): use container.info in output fields
rule(Remove Bulk Data from Disk): use container.info in output fields
rule(Create Hidden Files or Directories): use container.info in output fields
rule(Launch Remote File Copy Tools in Container): use container.info in output fields
rule(Create Symlink Over Sensitive Files): use container.info in output fields
rule(Detect outbound connections to common miner pool ports): use container.info in output fields
rule(Detect crypto miners using the Stratum protocol): use container.info in output fields
rule(Packet socket created in container): use container.info in output fields
rule(Network Connection outside Local Subnet): use container.info in output fields
rule(Redirect STDOUT/STDIN to Network Connection in Container): use container.info in output fields
```
