### PR TITLE
package manager launched makro - rhsm cert updates, apt

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -201,7 +201,7 @@
 # The explicit quotes are needed to avoid the - characters being
 # interpreted by the filter expression.
 - list: rpm_binaries
-  items: [dnf, rpm, rpmkey, yum, '"75-system-updat"', rhsmcertd-worke, subscription-ma,
+  items: [dnf, rpm, rpmkey, yum, '"75-system-updat"', rhsmcertd-worke, rhsmcertd, subscription-ma,
           repoquery, rpmkeys, rpmq, yum-cron, yum-config-mana, yum-debug-dump,
           abrt-action-sav, rpmdb_stat, microdnf, rhn_check, yumdb]
 
@@ -211,7 +211,7 @@
 - list: deb_binaries
   items: [dpkg, dpkg-preconfigu, dpkg-reconfigur, dpkg-divert, apt, apt-get, aptitude,
     frontend, preinst, add-apt-reposit, apt-auto-remova, apt-key,
-    apt-listchanges, unattended-upgr, apt-add-reposit, apt-config, apt-cache
+    apt-listchanges, unattended-upgr, apt-add-reposit, apt-config, apt-cache, apt.systemd.dai
     ]
 
 # The truncated dpkg-preconfigu is intentional, process names are


### PR DESCRIPTION
Note: the parsed logs on ES shows that `rhsmcertd-worke` is not pname or aname[*] but can be matched by proc.pname= `rhsmcertd`.

![image](https://user-images.githubusercontent.com/1211552/92493017-521a7000-f1f4-11ea-9940-6db13c1f0a8f.png)

What type of PR is this?
/kind rule-update

Any specific area of the project related to this PR?

/area rules




![image](https://user-images.githubusercontent.com/1211552/97845559-01535f00-1ced-11eb-93e5-fd43bf844fc8.png)


```release-note
rule(list rpm_binaries): add rhsmcertd
rule(list deb_binaries): add apt.systemd.daily
```