### PR TITLE
Allow exe_running_docker_save in the "Create Hidden Files or Directories" and "Mkdir binary dirs" rules

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2730,6 +2730,7 @@
      (open_write and evt.arg.flags contains "O_CREAT" and fd.name contains "/." and not fd.name pmatch (exclude_hidden_directories))) and
     consider_hidden_file_creation and
     not user_known_create_hidden_file_activities
+    and not exe_running_docker_save
   output: >
     Hidden file or directory created (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline
     file=%fd.name newpath=%evt.arg.newpath container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1601,7 +1601,12 @@
 
 - rule: Mkdir binary dirs
   desc: an attempt to create a directory below a set of binary directories.
-  condition: mkdir and bin_dir_mkdir and not package_mgmt_procs and not user_known_mkdir_bin_dir_activities
+  condition: >
+    mkdir
+    and bin_dir_mkdir
+    and not package_mgmt_procs
+    and not user_known_mkdir_bin_dir_activities
+    and not exe_running_docker_save
   output: >
     Directory below known binary directory created (user=%user.name user_loginuid=%user.loginuid
     command=%proc.cmdline directory=%evt.arg.path container_id=%container.id image=%container.image.repository)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

Adds exe_running_docker_save as an exception to the "Create Hidden Files or Directories" and "Mkdir binary dirs" rules, as these rules can be triggerred when a container is created. This brings these rules in line with similar rules which already contain this exception.

**Does this PR introduce a user-facing change?**:

Yes.

```release-note
Adds exe_running_docker_save as an exception to the "Create Hidden Files or Directories" and "Mkdir binary dirs" rules, as these rules can be triggerred when a container is created.
```
