### PR TITLE
Added rule to detect LKM module injects using insmod used by rootkits for kernel hooking

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3014,7 +3014,7 @@
 - rule: Linux Kernel Module injection detected
   desc: It is very uncommon for kernel modules to be injected in running production instances, used rookits to obfuscate their behavior via kernel hooking 
   condition: evt.type=execve and proc.name=insmod
-  output: Linux Kernel Module injection using insmod detected (user=%user.name parent_process=%proc.pname module=%proc.args)
+  output: Linux Kernel Module injection using insmod detected (user=%user.name user_loginuid=%user.loginuid parent_process=%proc.pname module=%proc.args)
   priority: WARNING
 
 # Application rules have moved to application_rules.yaml. Please look

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3012,7 +3012,7 @@
 
 # find when a new kernel module is injected
 - rule: Linux Kernel Module injection detected
-  desc: It is very uncommon for kernel modules to be injected on a running server, typically used by rookits implementing kernel hooking obfuscations. 
+  desc: It is very uncommon for kernel modules to be injected in running production instances, used rookits to obfuscate their behavior via kernel hooking 
   condition: evt.type=execve and proc.name=insmod
   output: Linux Kernel Module injection using insmod detected (user=%user.name parent_process=%proc.pname module=%proc.args)
   priority: WARNING

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3010,6 +3010,12 @@
   output: Drift detected (open+create), new executable created in a container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline filename=%evt.arg.filename name=%evt.arg.name mode=%evt.arg.mode event=%evt.type)
   priority: ERROR
 
+# find when a new kernel module is injected
+- rule: Linux Kernel Module injection detected
+  desc: It is very uncommon for kernel modules to be injected on a running server, typically used by rookits implementing kernel hooking obfuscations. 
+  condition: evt.type=execve and proc.name=insmod
+  output: Linux Kernel Module injection using insmod detected (user=%user.name parent_process=%proc.pname module=%proc.args)
+  priority: WARNING
 
 # Application rules have moved to application_rules.yaml. Please look
 # there if you want to enable them by adding to


### PR DESCRIPTION
**What type of PR is this?**

/kind rule-create

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

This PR adds a new falco rule that looks for when insmod is called as part of a execve event. Injecting LKM modules on (post build) running production instances should be rare and is a common way for rootkits that employ kernel hooking to obfuscate themselves. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

This is my first PR please let me know if I missed anything  😇

**Does this PR introduce a user-facing change?**:

Yes new rule in falco_rules.yml

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```
rule(Linux Kernel Module injection detected): adds a new rule that detects when a LKM module is inject using insmod typically used by rookits looking to obfuscate their behavior via kernel hooking. 
```
