### PR TITLE
Append Slash to Sensitive Mount Path startswith

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1929,7 +1929,7 @@
   condition: (user_trusted_containers or
               container.image.repository in (trusted_images) or
               container.image.repository in (falco_sensitive_mount_images) or
-              container.image.repository startswith quay.io/sysdig)
+              container.image.repository startswith quay.io/sysdig/)
 
 # These container images are allowed to run with hostnetwork=true
 - list: falco_hostnetwork_images


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug
> /kind rule-update

**Any specific area of the project related to this PR?**
> /area rules

**What this PR does / why we need it**:
Make L#1932 equivalent to L#1898
The sensitive mount path at L#1932:
```
               container.image.repository startswith quay.io/sysdig) 
```
is missing an important trailing slash like in L#1898:
```
               container.image.repository startswith quay.io/sysdig/)
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
rule(macro falco_sensitive_mount_containers): Adds a trailing slash to avoid repo naming issues
```