### PR TITLE
enable "Packet socket created in container" by default.

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2859,17 +2859,16 @@
   tags: [container, mitre_execution]
 
 
-# This rule is not enabled by default, as there are legitimate use
-# cases for raw packet. If you want to enable it, modify the
-# following macro.
+# This rule is enabled by default. 
+# If you want to disable it, modify the following macro.
 - macro: consider_packet_socket_communication
-  condition: (never_true)
+  condition: (always_true)
 
 - list: user_known_packet_socket_binaries
   items: []
 
 - rule: Packet socket created in container
-  desc: Detect new packet socket at the device driver (OSI Layer 2) level in a container. Packet socket could be used to do ARP Spoofing by attacker.
+  desc: Detect new packet socket at the device driver (OSI Layer 2) level in a container. Packet socket could be used for ARP Spoofing and privilege escalation(CVE-2020-14386) by attacker.
   condition: evt.type=socket and evt.arg[0]=AF_PACKET and consider_packet_socket_communication and container and not proc.name in (user_known_packet_socket_binaries)
   output: Packet socket was created in a container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline socket_info=%evt.args container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
   priority: NOTICE


### PR DESCRIPTION
Signed-off-by: Hiroki Suezawa <suezawa@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind rule-update

**Any specific area of the project related to this PR?**
/area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
- I want to enable "Packet socket created in container" rule by default.

- "Packet socket created in container" rule was created at the end of last year. I think we can say the rule is stable.
  - https://github.com/falcosecurity/falco/pull/945
- The rule can detect ARP spoofing attacks on Kubernetes.
  - Ref: https://blog.aquasec.com/dns-spoofing-kubernetes-clusters
- and new kernel vulnerability(CVE-2020-14386, allow privilege escalation to node) was disclosed recently. 
  - The bug is in `net/packet/af_packet.c`, so we could detect an attack to the vuln by this rule as far as I read [reporter's message and patch](https://www.openwall.com/lists/oss-security/2020/09/03/3).
    - fyi: the rule can detect `socket(AF_PACKET, ...` syscall.
  - This is High severity bug, It's great if Falco can detect it by default!
  - Ref: https://cloud.google.com/kubernetes-engine/docs/security-bulletins?hl=en#gcp-2020-012


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rule(macro consider_packet_socket_communication): enable "Packet socket created in container" rule by default.
```
