### PR TITLE
new: bump driver, sinsp and scap to 2aa88dcf6243982697811df4c1b484bcbe9488a2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ if(MINIMAL_BUILD)
 endif()
 
 if(MUSL_OPTIMIZED_BUILD)
-  set(MUSL_FLAGS "-static -Os -D__NEED_struct_timespec -D__NEED_time_t")
+  set(MUSL_FLAGS "-static -Os")
 endif()
 
 set(CMAKE_COMMON_FLAGS "-Wall -ggdb ${DRAIOS_FEATURE_FLAGS} ${MINIMAL_BUILD_FLAGS} ${MUSL_FLAGS}")

--- a/cmake/modules/sysdig.cmake
+++ b/cmake/modules/sysdig.cmake
@@ -29,8 +29,8 @@ file(MAKE_DIRECTORY ${SYSDIG_CMAKE_WORKING_DIR})
 # default below In case you want to test against another sysdig version just pass the variable - ie., `cmake
 # -DSYSDIG_VERSION=dev ..`
 if(NOT SYSDIG_VERSION)
-  set(SYSDIG_VERSION "e0db61604dbe41765d3848a59f80f9dc61d6ffc2")
-  set(SYSDIG_CHECKSUM "SHA256=b6ffd89af2ff77270a24f900cfc40e7869183d1c7dbc289278683144228d4079")
+  set(SYSDIG_VERSION "2aa88dcf6243982697811df4c1b484bcbe9488a2")
+  set(SYSDIG_CHECKSUM "SHA256=a737077543a6f3473ab306b424bcf7385d788149829ed1538252661b0f20d0f6")
 endif()
 set(PROBE_VERSION "${SYSDIG_VERSION}")
 

--- a/cmake/modules/sysdig.cmake
+++ b/cmake/modules/sysdig.cmake
@@ -29,8 +29,8 @@ file(MAKE_DIRECTORY ${SYSDIG_CMAKE_WORKING_DIR})
 # default below In case you want to test against another sysdig version just pass the variable - ie., `cmake
 # -DSYSDIG_VERSION=dev ..`
 if(NOT SYSDIG_VERSION)
-  set(SYSDIG_VERSION "73554b9c48b06612eb50494ee6fa5b779c57edc0") # todo(leogr): set the correct version and checksum before merging
-  set(SYSDIG_CHECKSUM "SHA256=c1c73498a834533dea61c979786a4ac3866743c17829d81aef209ddaa1b31538")
+  set(SYSDIG_VERSION "e0db61604dbe41765d3848a59f80f9dc61d6ffc2")
+  set(SYSDIG_CHECKSUM "SHA256=b6ffd89af2ff77270a24f900cfc40e7869183d1c7dbc289278683144228d4079")
 endif()
 set(PROBE_VERSION "${SYSDIG_VERSION}")
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This PR updates the sysdig version from https://github.com/draios/sysdig/commit/73554b9c48b06612eb50494ee6fa5b779c57edc0 to https://github.com/draios/sysdig/commit/2aa88dcf6243982697811df4c1b484bcbe9488a2 so Falco can benefit from the latest fixes. 

In details:

- https://github.com/draios/sysdig/commit/2aa88dcf6243982697811df4c1b484bcbe9488a2 is needed to fix the segmentation fault described in #1409 
- remove macros that now become unnecessary as done in https://github.com/draios/sysdig/pull/1684



**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1409

**Special notes for your reviewer**:

N.B.
This PR aims to fix the problem that forced us to postpone the release (see https://lists.cncf.io/g/cncf-falco-dev/message/142)

/cc @fntlnz 
/cc @leodido 

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new: driver updated to 2aa88dcf6243982697811df4c1b484bcbe9488a2
```
