### PR TITLE
Static code analysis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,8 +319,8 @@ jobs:
             yum update -y
             yum install epel-release -y
             yum install cppcheck cppcheck-htmlreport -y
-      - attach_workspace:
-          at: /
+      - checkout:
+          path: /source/falco
       - run:
           name: Prepare project
           command: /usr/bin/entrypoint cmake
@@ -573,10 +573,7 @@ workflows:
           requires:
             - "publish/packages-dev"
             - "tests/driver-loader/integration"
-      - "quality/static-analysis":
-          context: falco
-          requires:
-            - "build/centos7"
+      - "quality/static-analysis"
   release:
     jobs:
       - "build/musl":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,24 +309,29 @@ jobs:
   # Code quality
   "quality/static-analysis":
     docker:
-      - image: ubuntu:focal
+      - image: falcosecurity/falco-builder:latest
+        environment:
+          BUILD_TYPE: "release"
     steps:
+      - run:
+          name: Install cppcheck
+          command: |
+            yum update -y
+            yum install epel-release -y
+            yum install cppcheck cppcheck-htmlreport -y
       - attach_workspace:
           at: /
       - run:
-          name: Update base image
-          command: apt update -y
-      - run:
-          name: Install dependencies
-          command: DEBIAN_FRONTEND=noninteractive apt install cppcheck cmake build-essential git -y
+          name: Prepare project
+          command: /usr/bin/entrypoint cmake
       - run:
           name: cppcheck
-          command: |
-            cd /build
-            make cppcheck
-            make cppcheck_htmlreport
+          command: /usr/bin/entrypoint cppcheck
+      - run:
+          name: cppcheck html report
+          command: /usr/bin/entrypoint cppcheck_htmlreport
       - store_artifacts:
-          path: /build/static-analysis-reports
+          path: /build/release/static-analysis-reports
           destination: /static-analysis-reports
   # Sign rpm packages
   "rpm/sign":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,6 +306,28 @@ jobs:
       - run:
           name: Execute driver-loader integration tests
           command: /tmp/ws/source/falco/test/driver-loader/run_test.sh /tmp/ws/build/release/
+  # Code quality
+  "quality/static-analysis":
+    docker:
+      - image: ubuntu:focal
+    steps:
+      - attach_workspace:
+          at: /
+      - run:
+          name: Update base image
+          command: apt update -y
+      - run:
+          name: Install dependencies
+          command: DEBIAN_FRONTEND=noninteractive apt install cppcheck cmake build-essential git -y
+      - run:
+          name: cppcheck
+          command: |
+            cd /build
+            make cppcheck
+            make cppcheck_htmlreport
+      - store_artifacts:
+          path: /build/static-analysis-reports
+          destination: /static-analysis-reports
   # Sign rpm packages
   "rpm/sign":
     docker:
@@ -546,6 +568,10 @@ workflows:
           requires:
             - "publish/packages-dev"
             - "tests/driver-loader/integration"
+      - "quality/static-analysis":
+          context: falco
+          requires:
+            - "build/centos7"
   release:
     jobs:
       - "build/musl":

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,9 @@ add_subdirectory(docker)
 # Clang format
 # add_custom_target(format COMMAND clang-format --style=file -i $<TARGET_PROPERTY:falco,SOURCES> COMMENT "Formatting ..." VERBATIM)
 
+# Static analysis
+include(static-analysis)
+
 # Shared build variables
 set(FALCO_SINSP_LIBRARY sinsp)
 set(FALCO_SHARE_DIR share/falco)

--- a/cmake/modules/static-analysis.cmake
+++ b/cmake/modules/static-analysis.cmake
@@ -1,0 +1,42 @@
+# create the reports folder
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/static-analysis-reports)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/static-analysis-reports/cppcheck)
+
+# cppcheck
+find_program(CPPCHECK cppcheck)
+find_program(CPPCHECK_HTMLREPORT cppcheck-htmlreport)
+
+if(NOT CPPCHECK)
+  message(STATUS "cppcheck command not found, static code analysis using cppcheck will not be available.")
+else()
+  message(STATUS "cppcheck found at: ${CPPCHECK}")
+  # we are aware that cppcheck can be run
+  # along with the software compilation in a single step
+  # using the CMAKE_CXX_CPPCHECK variables.
+  # However, for practical needs we want to keep the
+  # two things separated and have a specific target for it.
+  # Our cppcheck target reads the compilation database produced by CMake
+  set(CMAKE_EXPORT_COMPILE_COMMANDS On)
+  add_custom_target(
+      cppcheck
+      COMMAND ${CPPCHECK}
+      "--enable=all"
+      "--force"
+      "--inconclusive"
+      "--inline-suppr" # allows to specify suppressions directly in source code
+      "--project=${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json" # use the compilation database as source
+      "--quiet"
+      "--xml" # we want to generate a report
+      "--output-file=${CMAKE_CURRENT_BINARY_DIR}/static-analysis-reports/cppcheck/cppcheck.xml" # generate the report under the reports folder in the build folder
+      "-i${CMAKE_CURRENT_BINARY_DIR}"# exclude the build folder
+  )
+endif() # CPPCHECK
+
+if(NOT CPPCHECK_HTMLREPORT)
+  message(STATUS "cppcheck-htmlreport command not found, will not be able to produce html reports for cppcheck results")
+else()
+  message(STATUS "cppcheck-htmlreport found at: ${CPPCHECK_HTMLREPORT}")
+  add_custom_target(
+    cppcheck_htmlreport
+    COMMAND ${CPPCHECK_HTMLREPORT} --title=${CMAKE_PROJECT_NAME} --report-dir=${CMAKE_CURRENT_BINARY_DIR}/static-analysis-reports/cppcheck --file=static-analysis-reports/cppcheck/cppcheck.xml)
+endif() # CPPCHECK_HTMLREPORT


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**Any specific area of the project related to this PR?**


/area build


**What this PR does / why we need it**:


This PR adds a static code analysis job to our CI pipeline.
The only implemented tool for now is cppcheck but in the way the structure is, we can add more steps.


By doing this we can also improve our scores in the CII best practices program. See #428 


The report will be generated on every PR under the `ci/circleci: static-analysis` CI pipeline.
Clicking on the pipeline and then on Artifacts > index.hml shows the report.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
