### PR TITLE
feat(falco): Provide a parameter for loading lua files from an alternate path

### DIFF
--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -78,7 +78,8 @@ falco_outputs::~falco_outputs()
 void falco_outputs::init(bool json_output,
 			 bool json_include_output_property,
 			 uint32_t rate, uint32_t max_burst, bool buffered,
-			 bool time_format_iso_8601, string hostname)
+			 bool time_format_iso_8601, string hostname,
+			 const string& alternate_lua_dir)
 {
 	// The engine must have been given an inspector by now.
 	if(!m_inspector)
@@ -88,7 +89,7 @@ void falco_outputs::init(bool json_output,
 
 	m_json_output = json_output;
 
-	falco_common::init(m_lua_main_filename.c_str(), FALCO_SOURCE_LUA_DIR);
+	falco_common::init(m_lua_main_filename.c_str(), alternate_lua_dir.c_str());
 
 	// Note that falco_formats is added to both the lua state used
 	// by the falco engine as well as the separate lua state used

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -54,7 +54,8 @@ public:
 	void init(bool json_output,
 		  bool json_include_output_property,
 		  uint32_t rate, uint32_t max_burst, bool buffered,
-		  bool time_format_iso_8601, std::string hostname);
+		  bool time_format_iso_8601, std::string hostname,
+		  const std::string& alternate_lua_dir);
 
 	void add_output(output_config oc);
 


### PR DESCRIPTION
This will be used by the static build to load lua files from
alternate directories that are not tied to the compile flags

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This allows us to provide tarballs of static builds of falco and use `--alternate-lua-dir $(pwd)/lua` to specify where to look for lua
files.

**Which issue(s) this PR fixes**:
-
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:
This will improve user experience for users of the static build, because currently that path is hardcoded at compile time.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new: CLI flag `--alternate-lua-dir` to load Lua files from arbitrary paths
```
