### PR TITLE
rule(list falco_sensitive_mount_images): add images docker.io/falcose…

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1918,6 +1918,7 @@
 - list: falco_sensitive_mount_images
   items: [
     docker.io/sysdig/falco, docker.io/sysdig/sysdig, sysdig/falco, sysdig/sysdig,
+    docker.io/falcosecurity/falco, falcosecurity/falco,
     gcr.io/google_containers/hyperkube,
     gcr.io/google_containers/kube-proxy, docker.io/calico/node,
     docker.io/rook/toolbox, docker.io/cloudnativelabs/kube-router, docker.io/consul,


### PR DESCRIPTION
…curity/falco and falcosecurity/falco

Fixes #1428

Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>

**What type of PR is this?**

/kind bug

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

Add images used by helm charts to exclude list, to prevent false positive alerts.

**Does this PR introduce a user-facing change?**:

```release-note
rule(list falco_sensitive_mount_images): add falco container images to prevent false-positive alerts
```
