### PR TITLE
fix(test): make integration tests properly fail

### DIFF
--- a/docker/tester/root/usr/bin/entrypoint
+++ b/docker/tester/root/usr/bin/entrypoint
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
-set -u -o pipefail
-
 BUILD_DIR=${BUILD_DIR:-/build}
 SOURCE_DIR=${SOURCE_DIR:-/source}
 SKIP_PACKAGES_TESTS=${SKIP_PACKAGES_TESTS:-false}
 
 CMD=${1:-test}
 shift
+
+# Stop the execution if a command in the pipeline has an error, from now on
+set -e -u -o pipefail
 
 # build type can be "debug" or "release", fallbacks to "release" by default
 BUILD_TYPE=$(echo "$BUILD_TYPE" | tr "[:upper:]" "[:lower:]")

--- a/docker/tester/root/usr/bin/entrypoint
+++ b/docker/tester/root/usr/bin/entrypoint
@@ -50,7 +50,8 @@ case "$CMD" in
 "test")
     if [ -z "$FALCO_VERSION" ]; then
         echo "Automatically figuring out Falco version."
-        FALCO_VERSION=$("$BUILD_DIR/$BUILD_TYPE/userspace/falco/falco" --version | head -n 1 | cut -d' ' -f3 | tr -d '\r')
+        FALCO_VERSION_FULL=$("$BUILD_DIR/$BUILD_TYPE/userspace/falco/falco" --version)
+        FALCO_VERSION=$(echo "$FALCO_VERSION_FULL" | head -n 1 | cut -d' ' -f3  | tr -d '\r')
         echo "Falco version: $FALCO_VERSION"
     fi
     if [ -z "$FALCO_VERSION" ]; then


### PR DESCRIPTION
Signed-off-by: Leonardo Grasso <me@leonardograsso.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

/kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area rules

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

I and @leodido noticed that the CI is reporting green tests even though some of the integrations tests are not passing.
That happened because the falco-tester entrypoint's script was not returning the exit code of `run_regression_tests.sh`

Please note that this PR aims just to correct the test suite behavior, not the problems in Falco. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Atm integration tests cannot pass anyways because of the problem explained in #1438 and another problem introduced by https://github.com/falcosecurity/falco/pull/1436. Both problems will be fixed by #1412

Once #1412 gets merged, then we can rebase this PR on top and definitively fix the aforementioned problems.

PS
I needed to push the `falcosecuity/falco-tester:latest` docker image for testing.



**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
