### PR TITLE
build: bump b64 to v2.0.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,8 +123,8 @@ set(B64_INCLUDE "${B64_SRC}/include")
 set(B64_LIB "${B64_SRC}/src/libb64.a")
 ExternalProject_Add(
   b64
-  URL "https://github.com/libb64/libb64/archive/v2.0.0.1.tar.gz"
-  URL_HASH "SHA256=ce8e578a953a591bd4a6f157eec310b9a4c2e6f10ade2fdda6ae6bafaf798b98"
+  URL "https://github.com/libb64/libb64/archive/ce864b17ea0e24a91e77c7dd3eb2d1ac4175b3f0.tar.gz"
+  URL_HASH "SHA256=d07173e66f435e5c77dbf81bd9313f8d0e4a3b4edd4105a62f4f8132ba932811"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ${CMD_MAKE}
   BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,8 +123,8 @@ set(B64_INCLUDE "${B64_SRC}/include")
 set(B64_LIB "${B64_SRC}/src/libb64.a")
 ExternalProject_Add(
   b64
-  URL "https://github.com/libb64/libb64/archive/v1.2.1.zip"
-  URL_HASH "SHA256=665134c2b600098a7ebd3d00b6a866cb34909a6d48e0e37a0eda226a4ad2638a"
+  URL "https://github.com/libb64/libb64/archive/v2.0.0.1.tar.gz"
+  URL_HASH "SHA256=ce8e578a953a591bd4a6f157eec310b9a4c2e6f10ade2fdda6ae6bafaf798b98"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ${CMD_MAKE}
   BUILD_IN_SOURCE 1


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>


**What type of PR is this?**



/kind cleanup



<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->


/area build




**What this PR does / why we need it**:

libb64, a dependency that we use for base64 encoding/decoding was having an issue on armv7.

Reported by: @alexellis

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
