### PR TITLE
fix(userspace/engine): free formatters, if any

### DIFF
--- a/userspace/engine/formats.cpp
+++ b/userspace/engine/formats.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2019 The Falco Authors.
+Copyright (C) 2020 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -44,8 +44,9 @@ void falco_formats::init(sinsp *inspector,
 	s_json_include_output_property = json_include_output_property;
 	if(!s_formatters)
 	{
-		s_formatters = new sinsp_evt_formatter_cache(s_inspector);
+		delete(s_formatters);
 	}
+	s_formatters = new sinsp_evt_formatter_cache(s_inspector);
 
 	luaL_openlib(ls, "formats", ll_falco, 0);
 }

--- a/userspace/engine/formats.cpp
+++ b/userspace/engine/formats.cpp
@@ -24,7 +24,7 @@ sinsp *falco_formats::s_inspector = NULL;
 falco_engine *falco_formats::s_engine = NULL;
 bool falco_formats::s_json_output = false;
 bool falco_formats::s_json_include_output_property = true;
-sinsp_evt_formatter_cache *falco_formats::s_formatters = NULL;
+std::unique_ptr<sinsp_evt_formatter_cache> falco_formats::s_formatters = NULL;
 
 const static struct luaL_reg ll_falco[] =
 	{
@@ -42,11 +42,9 @@ void falco_formats::init(sinsp *inspector,
 	s_engine = engine;
 	s_json_output = json_output;
 	s_json_include_output_property = json_include_output_property;
-	if(!s_formatters)
-	{
-		delete(s_formatters);
-	}
-	s_formatters = new sinsp_evt_formatter_cache(s_inspector);
+
+	// todo(leogr): we should have used std::make_unique, but we cannot since it's not C++14
+	s_formatters = std::unique_ptr<sinsp_evt_formatter_cache>(new sinsp_evt_formatter_cache(s_inspector));
 
 	luaL_openlib(ls, "formats", ll_falco, 0);
 }

--- a/userspace/engine/formats.h
+++ b/userspace/engine/formats.h
@@ -53,7 +53,7 @@ public:
 
 	static sinsp *s_inspector;
 	static falco_engine *s_engine;
-	static sinsp_evt_formatter_cache *s_formatters;
+	static std::unique_ptr<sinsp_evt_formatter_cache> s_formatters;
 	static bool s_json_output;
 	static bool s_json_include_output_property;
 };


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**


/area engine



**What this PR does / why we need it**:

Previously, formatters were freed by LUA code when re-opening outputs.
Since now, outputs are not controlling anymore the falco_formats class (see #1412), we just free formatters only if were already initialized.

That is needed when the engine restarts (see #1446).

By doing so, we also ensure that the correct inspector instance is set to the formatter cache.

**Which issue(s) this PR fixes**:


Fixes #1446

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
