### PR TITLE
re-use `spawned_process` macro inside `container_started` macro

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -522,7 +522,7 @@
 - macro: container_started
   condition: >
     ((evt.type = container or
-     (evt.type=execve and evt.dir=< and proc.vpid=1)) and
+     (spawned_process and proc.vpid=1)) and
      container.image.repository != incomplete)
 
 - macro: interactive


### PR DESCRIPTION


Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>



**What type of PR is this?**

/kind rule-update




**Any specific area of the project related to this PR?**


/area rules


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Just a bit of re-use. ♻️ 

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
