### PR TITLE
fix(userspace/falco): use given priority in falco_outputs::handle_msg()

### DIFF
--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -203,7 +203,7 @@ void falco_outputs::handle_msg(uint64_t now,
 		iso8601evttime += time_ns;
 
 		jmsg["output"] = msg;
-		jmsg["priority"] = "Critical";
+		jmsg["priority"] = falco_common::priority_names[priority];
 		jmsg["rule"] = rule;
 		jmsg["time"] = iso8601evttime;
 		jmsg["output_fields"] = output_fields;
@@ -216,7 +216,7 @@ void falco_outputs::handle_msg(uint64_t now,
 		bool first = true;
 
 		sinsp_utils::ts_to_string(now, &timestr, false, true);
-		full_msg = timestr + ": " + falco_common::priority_names[LOG_CRIT] + " " + msg + " (";
+		full_msg = timestr + ": " + falco_common::priority_names[priority] + " " + msg + " (";
 		for(auto &pair : output_fields)
 		{
 			if(first)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup


**Any specific area of the project related to this PR?**

/area engine


**What this PR does / why we need it**:

Hardcoded values (`Critical`) for message's priority were present in `falco_outputs::handle_msg()`:
https://github.com/falcosecurity/falco/blob/47fa7d53c43455540ae7ccbe4a1445a93511f723/userspace/falco/falco_outputs.cpp#L206
https://github.com/falcosecurity/falco/blob/47fa7d53c43455540ae7ccbe4a1445a93511f723/userspace/falco/falco_outputs.cpp#L219

Although that was no problem because `handle_msg()` is being used only for drop alerts that are always emitted with `Critical` priority level, it can lead to errors in the future.

Moreover, `handle_msg()` has a `priority` field already in its signature and `syscall_evt_drop_mgr` is already passing the expected value:
https://github.com/falcosecurity/falco/blob/47fa7d53c43455540ae7ccbe4a1445a93511f723/userspace/falco/event_drops.cpp#L138-L144

So, this PR corrects the `handle_msg()` implementation to use the given priority.


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Since `handle_msg()` is only called within `syscall_evt_drop_mgr` and the outputted priority value is not changed, this PR does not introduce any user-facing change.

Somehow related to #1417 

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
