### PR TITLE
feat: asynchronous outputs and slow outputs detection

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -87,17 +87,19 @@ syscall_event_drops:
   rate: .03333
   max_burst: 10
 
-
-# Falco continuously monitors outputs performance. When an output channel does not allow 
-# to deliver an alert within a given deadline, an error is reported to the log indicating 
-# which output is blocking notifications. 
-# An output timeout error may indicate a misconfiguration issue or I/O problems 
-# that should be fixed by the user.
+# Falco continuously monitors outputs performance. When an output channel does not allow
+# to deliver an alert within a given deadline, an error is reported indicating
+# which output is blocking notifications.
+# The timeout error will be reported to the log according to the above log_* settings.
+# Note that the notification will not be discarded from the output queue; thus,
+# output channels may indefinitely remain blocked.
+# An output timeout error indeed indicate a misconfiguration issue or I/O problems
+# that cannot be recovered by Falco and should be fixed by the user.
 #
-# The "output_timeout" value specifies the duration in milliseconds to wait before 
+# The "output_timeout" value specifies the duration in milliseconds to wait before
 # considering the deadline exceed.
 #
-# With a 2000ms default, the notification consumer can block the Falco output 
+# With a 2000ms default, the notification consumer can block the Falco output
 # for up to 2 seconds without reaching the timeout.
 
 output_timeout: 2000

--- a/falco.yaml
+++ b/falco.yaml
@@ -87,6 +87,21 @@ syscall_event_drops:
   rate: .03333
   max_burst: 10
 
+
+# Falco continuously monitors outputs performance. When an output channel does not allow 
+# to deliver an alert within a given deadline, an error is reported to the log indicating 
+# which output is blocking notifications. 
+# An output timeout error may indicate a misconfiguration issue or I/O problems 
+# that should be fixed by the user.
+#
+# The "output_timeout" value specifies the duration in milliseconds to wait before 
+# considering the deadline exceed.
+#
+# With a 2000ms default, the notification consumer can block the Falco output 
+# for up to 2 seconds without reaching the timeout.
+
+output_timeout: 2000
+
 # A throttling mechanism implemented as a token bucket limits the
 # rate of falco notifications. This throttling is controlled by the following configuration
 # options:

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -176,6 +176,8 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 
 	falco_logger::set_level(m_log_level);
 
+	m_output_timeout = m_config->get_scalar<uint32_t>("output_timeout", 2000);
+
 	m_notifications_rate = m_config->get_scalar<uint32_t>("outputs", "rate", 1);
 	m_notifications_max_burst = m_config->get_scalar<uint32_t>("outputs", "max_burst", 1000);
 

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -204,6 +204,7 @@ public:
 
 	bool m_buffered_outputs;
 	bool m_time_format_iso_8601;
+	uint32_t m_output_timeout;
 
 	bool m_grpc_enabled;
 	uint32_t m_grpc_threadiness;

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -972,6 +972,7 @@ int falco_init(int argc, char **argv)
 
 		outputs->init(config.m_json_output,
 			      config.m_json_include_output_property,
+			      config.m_output_timeout,
 			      config.m_notifications_rate, config.m_notifications_max_burst,
 			      config.m_buffered_outputs,
 			      config.m_time_format_iso_8601,

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -196,7 +196,7 @@ void falco_outputs::handle_msg(uint64_t ts,
 	falco_outputs::ctrl_msg cmsg = {};
 	cmsg.ts = ts;
 	cmsg.priority = priority;
-	cmsg.source = "";
+	cmsg.source = "internal";
 	cmsg.rule = rule;
 	cmsg.fields = output_fields;
 

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -293,7 +293,10 @@ inline void falco_outputs::push(ctrl_msg_type cmt)
 	m_queue.push(cmsg);
 }
 
-void falco_outputs::worker()
+// todo(leogr,leodido): this function is not supposed to throw exceptions, and with "noexcept",
+// the program is terminated if that occurs. Although that's the wanted behavior,
+// we still need to improve the error reporting since some inner functions can throw exceptions.
+void falco_outputs::worker() noexcept
 {
 	watchdog<std::string> wd;
 	wd.start([&](std::string payload) -> void {

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -65,6 +65,12 @@ void falco_outputs::init(bool json_output,
 			 uint32_t rate, uint32_t max_burst, bool buffered,
 			 bool time_format_iso_8601, string hostname)
 {
+	// Cannot be initialized more than one time.
+	if(m_initialized)
+	{
+		throw falco_exception("falco_outputs already initialized");
+	}
+
 	m_json_output = json_output;
 
 	// Note that falco_formats is already initialized by the engine,

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -58,6 +58,10 @@ falco_outputs::~falco_outputs()
 		{
 			m_worker_thread.join();
 		}
+		for(auto it = m_outputs.cbegin(); it != m_outputs.cend(); ++it)
+		{
+			delete *it;
+		}
 	}
 }
 
@@ -94,7 +98,10 @@ void falco_outputs::init(bool json_output,
 	m_initialized = true;
 }
 
-// todo(leogr): when the worker has started, adding an outputs is not thread-safe
+// This function has to be called after init() since some configuration settings
+// need to be passed to the output plugins. Then, although the worker has started,
+// the worker is still on hold, waiting for a message.
+// Thus it is still safe to call add_output() before any message has been enqueued.
 void falco_outputs::add_output(falco::outputs::config oc)
 {
 

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -104,6 +104,10 @@ void falco_outputs::init(bool json_output,
 // Thus it is still safe to call add_output() before any message has been enqueued.
 void falco_outputs::add_output(falco::outputs::config oc)
 {
+	if(!m_initialized)
+	{
+		throw falco_exception("cannot add output: falco_outputs not initialized yet");
+	}
 
 	falco::outputs::abstract_output *oo;
 

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -53,9 +53,9 @@ falco_outputs::~falco_outputs()
 	if(m_initialized)
 	{
 		this->stop_worker();
-		for(auto it = m_outputs.cbegin(); it != m_outputs.cend(); ++it)
+		for(auto o : m_outputs)
 		{
-			delete *it;
+			delete o;
 		}
 	}
 }
@@ -308,22 +308,22 @@ void falco_outputs::worker()
 		// Block until a message becomes available.
 		m_queue.pop(cmsg);
 
-		for(auto it = m_outputs.cbegin(); it != m_outputs.cend(); ++it)
+		for(const auto o : m_outputs)
 		{
-			wd.set_timeout(timeout, (*it)->get_name());
+			wd.set_timeout(timeout, o->get_name());
 			try
 			{
 				switch(cmsg.type)
 				{
 					case ctrl_msg_type::CTRL_MSG_OUTPUT:
-						(*it)->output(&cmsg);
+						o->output(&cmsg);
 						break;
 					case ctrl_msg_type::CTRL_MSG_CLEANUP:
 					case ctrl_msg_type::CTRL_MSG_STOP:
-						(*it)->cleanup();
+						o->cleanup();
 						break;
 					case ctrl_msg_type::CTRL_MSG_REOPEN:
-						(*it)->reopen();
+						o->reopen();
 						break;
 					default:
 						falco_logger::log(LOG_DEBUG, "Outputs worker received an unknown message type\n");	
@@ -331,7 +331,7 @@ void falco_outputs::worker()
 			}
 			catch(const exception &e)
 			{
-				falco_logger::log(LOG_ERR, (*it)->get_name() + ": " + string(e.what()) + "\n");
+				falco_logger::log(LOG_ERR, o->get_name() + ": " + string(e.what()) + "\n");
 			}
 		}
 		wd.cancel_timeout();

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -271,7 +271,7 @@ void falco_outputs::reopen_outputs()
 
 void falco_outputs::stop_worker()
 {
-	Watchdog<void *> wd;
+	watchdog<void *> wd;
 	wd.start([&](void *) -> void {
 		falco_logger::log(LOG_NOTICE, "output channels still blocked, discarding all remaining notifications\n");
 		m_queue.clear();
@@ -295,7 +295,7 @@ inline void falco_outputs::push(ctrl_msg_type cmt)
 
 void falco_outputs::worker()
 {
-	Watchdog<std::string> wd;
+	watchdog<std::string> wd;
 	wd.start([&](std::string payload) -> void {
 		falco_logger::log(LOG_CRIT, "\"" + payload + "\" output timeout, all output channels are blocked\n");
 	});

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -278,31 +278,30 @@ void falco_outputs::worker()
 	{
 		// Block until a message becomes available.
 		m_queue.pop(cmsg);
-		switch(cmsg.type)
-		{
-		case ctrl_msg_type::CTRL_MSG_OUTPUT:
-			for(auto it = m_outputs.cbegin(); it != m_outputs.cend(); ++it)
-			{
-				(*it)->output(&cmsg);
-			}
-			break;
-		case ctrl_msg_type::CTRL_MSG_CLEANUP:
-			for(auto it = m_outputs.cbegin(); it != m_outputs.cend(); ++it)
-			{
-				(*it)->cleanup();
-			}
-			break;
-		case ctrl_msg_type::CTRL_MSG_REOPEN:
-			for(auto it = m_outputs.cbegin(); it != m_outputs.cend(); ++it)
-			{
-				(*it)->reopen();
-			}
-			break;
-		case ctrl_msg_type::CTRL_MSG_STOP:
+
+		if (cmsg.type == ctrl_msg_type::CTRL_MSG_STOP)
 			return;
 
-		default:
-			break;
+		for(auto it = m_outputs.cbegin(); it != m_outputs.cend(); ++it)
+		{
+			try {
+				switch(cmsg.type)
+				{
+					case ctrl_msg_type::CTRL_MSG_OUTPUT:
+							(*it)->output(&cmsg);
+						break;
+					case ctrl_msg_type::CTRL_MSG_CLEANUP:
+							(*it)->cleanup();
+						break;
+					case ctrl_msg_type::CTRL_MSG_REOPEN:
+							(*it)->reopen();
+						break;
+					default:
+						falco_logger::log(LOG_DEBUG, "Outputs worker received an unknown message type\n");	
+				}
+			} catch(const exception &e) {
+				falco_logger::log(LOG_ERR, (*it)->get_name() + ": " + string(e.what()) + "\n");
+			}
 		}
 	}
 }

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -94,6 +94,6 @@ private:
 
 	std::thread m_worker_thread;
 	inline void push(ctrl_msg_type cmt);
-	void worker();
+	void worker() noexcept;
 	void stop_worker();
 };

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -40,6 +40,7 @@ public:
 
 	void init(bool json_output,
 		  bool json_include_output_property,
+		  uint32_t timeout,
 		  uint32_t rate, uint32_t max_burst, bool buffered,
 		  bool time_format_iso_8601, std::string hostname);
 
@@ -71,6 +72,7 @@ private:
 	bool m_buffered;
 	bool m_json_output;
 	bool m_time_format_iso_8601;
+	std::chrono::milliseconds m_timeout;
 	std::string m_hostname;
 
 	enum ctrl_msg_type

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "token_bucket.h"
 #include "falco_engine.h"
 #include "outputs.h"
+#include "tbb/concurrent_queue.h"
 
 //
 // This class acts as the primary interface between a program and the
@@ -44,19 +45,18 @@ public:
 
 	void add_output(falco::outputs::config oc);
 
-	//
-	// evt is an event that has matched some rule. Pass the event
-	// to all configured outputs.
-	//
+	// Format then send the event to all configured outputs (`evt` is an event that has matched some rule).
 	void handle_event(gen_event *evt, std::string &rule, std::string &source,
 			  falco_common::priority_type priority, std::string &format);
 
-	// Send a generic message to all outputs. Not necessarily associated with any event.
+	// Format then send a generic message to all outputs. Not necessarily associated with any event.
 	void handle_msg(uint64_t now,
 			falco_common::priority_type priority,
 			std::string &msg,
 			std::string &rule,
 			std::map<std::string, std::string> &output_fields);
+
+	void cleanup_outputs();
 
 	void reopen_outputs();
 
@@ -72,4 +72,26 @@ private:
 	bool m_json_output;
 	bool m_time_format_iso_8601;
 	std::string m_hostname;
+
+	enum ctrl_msg_type
+	{
+		CTRL_MSG_STOP = 0,
+		CTRL_MSG_OUTPUT = 1,
+		CTRL_MSG_CLEANUP = 2,
+		CTRL_MSG_REOPEN = 3,
+	};
+
+	struct ctrl_msg : falco::outputs::message
+	{
+		ctrl_msg_type type;
+	};
+
+	typedef tbb::concurrent_bounded_queue<ctrl_msg> falco_outputs_cbq;
+
+	falco_outputs_cbq m_queue;
+
+	std::thread m_worker_thread;
+	inline void push(ctrl_msg_type cmt);
+	void worker();
+	void stop_worker();
 };

--- a/userspace/falco/outputs.h
+++ b/userspace/falco/outputs.h
@@ -70,7 +70,7 @@ public:
 	}
 
 	// Return the output's name as per its configuration.
-	const std::string get_name()
+	const std::string get_name() const
 	{
 		return m_oc.name;
 	}

--- a/userspace/falco/outputs.h
+++ b/userspace/falco/outputs.h
@@ -67,6 +67,12 @@ public:
 		m_hostname = hostname;
 	}
 
+	// Return the output's name as per its configuration.
+	const std::string get_name()
+	{
+		return m_oc.name;
+	}
+
 	// Output a message.
 	virtual void output(const message *msg) = 0;
 

--- a/userspace/falco/outputs.h
+++ b/userspace/falco/outputs.h
@@ -38,6 +38,21 @@ struct config
 };
 
 //
+// The message to be outputted. It can either refer to:
+//  - an event that has matched some rule,
+//  - or a generic message (e.g., a drop alert).
+//
+struct message
+{
+	uint64_t ts;
+	falco_common::priority_type priority;
+	std::string msg;
+	std::string rule;
+	std::string source;
+	map<std::string, std::string> fields;
+};
+
+//
 // This class acts as the primary interface for implementing
 // a Falco output class.
 //
@@ -52,15 +67,13 @@ public:
 		m_hostname = hostname;
 	}
 
-	// Output an event that has matched some rule.
-	virtual void output_event(gen_event *evt, std::string &rule, std::string &source,
-				  falco_common::priority_type priority, std::string &format, std::string &msg) = 0;
+	// Output a message.
+	virtual void output(const message *msg) = 0;
 
-	// Output a generic message. Not necessarily associated with any event.
-	virtual void output_msg(falco_common::priority_type priority, std::string &msg) = 0;
-
+	// Possibly close the output and open it again.
 	virtual void reopen() {}
 
+	// Possibly flush the output.
 	virtual void cleanup() {}
 
 protected:

--- a/userspace/falco/outputs.h
+++ b/userspace/falco/outputs.h
@@ -60,6 +60,8 @@ struct message
 class abstract_output
 {
 public:
+	virtual ~abstract_output() {}
+
 	void init(config oc, bool buffered, std::string hostname)
 	{
 		m_oc = oc;

--- a/userspace/falco/outputs_file.cpp
+++ b/userspace/falco/outputs_file.cpp
@@ -31,16 +31,10 @@ void falco::outputs::output_file::open_file()
 	}
 }
 
-void falco::outputs::output_file::output_event(gen_event *evt, std::string &rule, std::string &source,
-					       falco_common::priority_type priority, std::string &format, std::string &msg)
-{
-	output_msg(priority, msg);
-}
-
-void falco::outputs::output_file::output_msg(falco_common::priority_type priority, std::string &msg)
+void falco::outputs::output_file::output(const message *msg)
 {
 	open_file();
-	m_outfile << msg + "\n";
+	m_outfile << msg->msg + "\n";
 
 	if(m_oc.options["keep_alive"] != "true")
 	{

--- a/userspace/falco/outputs_file.h
+++ b/userspace/falco/outputs_file.h
@@ -27,10 +27,7 @@ namespace outputs
 
 class output_file : public abstract_output
 {
-	void output_event(gen_event *evt, std::string &rule, std::string &source,
-			  falco_common::priority_type priority, std::string &format, std::string &msg);
-
-	void output_msg(falco_common::priority_type priority, std::string &msg);
+	void output(const message *msg);
 
 	void cleanup();
 

--- a/userspace/falco/outputs_grpc.cpp
+++ b/userspace/falco/outputs_grpc.cpp
@@ -37,7 +37,7 @@ void falco::outputs::output_grpc::output(const message *msg)
 	falco::schema::source s = falco::schema::source::SYSCALL;
 	if(!falco::schema::source_Parse(msg->source, &s))
 	{
-		throw falco_exception("Unknown source passed to output_grpc::output_event()");
+		throw falco_exception("Unknown source passed to output_grpc::output()");
 	}
 	grpc_res.set_source(s);
 
@@ -45,7 +45,7 @@ void falco::outputs::output_grpc::output(const message *msg)
 	falco::schema::priority p = falco::schema::priority::EMERGENCY;
 	if(!falco::schema::priority_Parse(falco_common::priority_names[msg->priority], &p))
 	{
-		throw falco_exception("Unknown priority passed to output_grpc::output_event()");
+		throw falco_exception("Unknown priority passed to output_grpc::output()");
 	}
 	grpc_res.set_priority(p);
 

--- a/userspace/falco/outputs_grpc.h
+++ b/userspace/falco/outputs_grpc.h
@@ -25,10 +25,7 @@ namespace outputs
 
 class output_grpc : public abstract_output
 {
-	void output_event(gen_event *evt, std::string &rule, std::string &source,
-			  falco_common::priority_type priority, std::string &format, std::string &msg);
-
-	void output_msg(falco_common::priority_type priority, std::string &msg);
+	void output(const message *msg);
 };
 
 } // namespace outputs

--- a/userspace/falco/outputs_http.cpp
+++ b/userspace/falco/outputs_http.cpp
@@ -18,13 +18,7 @@ limitations under the License.
 #include "logger.h"
 #include "banned.h" // This raises a compilation error when certain functions are used
 
-void falco::outputs::output_http::output_event(gen_event *evt, std::string &rule, std::string &source,
-					       falco_common::priority_type priority, std::string &format, std::string &msg)
-{
-	output_msg(priority, msg);
-}
-
-void falco::outputs::output_http::output_msg(falco_common::priority_type priority, std::string &msg)
+void falco::outputs::output_http::output(const message *msg)
 {
 	CURL *curl = NULL;
 	CURLcode res = CURLE_FAILED_INIT;
@@ -37,7 +31,7 @@ void falco::outputs::output_http::output_msg(falco_common::priority_type priorit
 		slist1 = curl_slist_append(slist1, "Content-Type: application/json");
 		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist1);
 		curl_easy_setopt(curl, CURLOPT_URL, m_oc.options["url"].c_str());
-		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, msg.c_str());
+		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, msg->msg.c_str());
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, -1L);
 
 		res = curl_easy_perform(curl);

--- a/userspace/falco/outputs_http.h
+++ b/userspace/falco/outputs_http.h
@@ -25,10 +25,7 @@ namespace outputs
 
 class output_http : public abstract_output
 {
-	void output_event(gen_event *evt, std::string &rule, std::string &source,
-			  falco_common::priority_type priority, std::string &format, std::string &msg);
-
-	void output_msg(falco_common::priority_type priority, std::string &msg);
+	void output(const message *msg);
 };
 
 } // namespace outputs

--- a/userspace/falco/outputs_program.cpp
+++ b/userspace/falco/outputs_program.cpp
@@ -31,17 +31,11 @@ void falco::outputs::output_program::open_pfile()
 	}
 }
 
-void falco::outputs::output_program::output_event(gen_event *evt, std::string &rule, std::string &source,
-						  falco_common::priority_type priority, std::string &format, std::string &msg)
-{
-	output_msg(priority, msg);
-}
-
-void falco::outputs::output_program::output_msg(falco_common::priority_type priority, std::string &msg)
+void falco::outputs::output_program::output(const message *msg)
 {
 	open_pfile();
 
-	fprintf(m_pfile, "%s\n", msg.c_str());
+	fprintf(m_pfile, "%s\n", msg->msg.c_str());
 
 	if(m_oc.options["keep_alive"] != "true")
 	{

--- a/userspace/falco/outputs_program.h
+++ b/userspace/falco/outputs_program.h
@@ -25,10 +25,7 @@ namespace outputs
 
 class output_program : public abstract_output
 {
-	void output_event(gen_event *evt, std::string &rule, std::string &source,
-			  falco_common::priority_type priority, std::string &format, std::string &msg);
-
-	void output_msg(falco_common::priority_type priority, std::string &msg);
+	void output(const message *msg);
 
 	void cleanup();
 

--- a/userspace/falco/outputs_stdout.cpp
+++ b/userspace/falco/outputs_stdout.cpp
@@ -18,16 +18,10 @@ limitations under the License.
 #include <iostream>
 #include "banned.h" // This raises a compilation error when certain functions are used
 
-void falco::outputs::output_stdout::output_event(gen_event *evt, std::string &rule, std::string &source,
-						 falco_common::priority_type priority, std::string &format, std::string &msg)
-{
-	output_msg(priority, msg);
-}
-
-void falco::outputs::output_stdout::output_msg(falco_common::priority_type priority, std::string &msg)
+void falco::outputs::output_stdout::output(const message *msg)
 {
 	//
-	// By default, the stdout stream is fully buffered or line buffered 
+	// By default, the stdout stream is fully buffered or line buffered
 	// (if the stream can be determined to refer to an interactive device, e.g. in a TTY).
 	// Just enable automatic flushing when unbuffered output is desired.
 	// Note that it is set every time since other writings to the stdout can disable it.
@@ -36,7 +30,7 @@ void falco::outputs::output_stdout::output_msg(falco_common::priority_type prior
 	{
 		std::cout << std::unitbuf;
 	}
-	std::cout << msg + "\n";
+	std::cout << msg->msg + "\n";
 }
 
 void falco::outputs::output_stdout::cleanup()

--- a/userspace/falco/outputs_stdout.h
+++ b/userspace/falco/outputs_stdout.h
@@ -25,10 +25,7 @@ namespace outputs
 
 class output_stdout : public abstract_output
 {
-	void output_event(gen_event *evt, std::string &rule, std::string &source,
-			  falco_common::priority_type priority, std::string &format, std::string &msg);
-
-	void output_msg(falco_common::priority_type priority, std::string &msg);
+	void output(const message *msg);
 
 	void cleanup();
 };

--- a/userspace/falco/outputs_syslog.cpp
+++ b/userspace/falco/outputs_syslog.cpp
@@ -18,14 +18,8 @@ limitations under the License.
 #include <syslog.h>
 #include "banned.h" // This raises a compilation error when certain functions are used
 
-void falco::outputs::output_syslog::output_event(gen_event *evt, std::string &rule, std::string &source,
-						 falco_common::priority_type priority, std::string &format, std::string &msg)
-{
-	output_msg(priority, msg);
-}
-
-void falco::outputs::output_syslog::output_msg(falco_common::priority_type priority, std::string &msg)
+void falco::outputs::output_syslog::output(const message *msg)
 {
 	// Syslog output should not have any trailing newline
-	::syslog(priority, "%s", msg.c_str());
+	::syslog(msg->priority, "%s", msg->msg.c_str());
 }

--- a/userspace/falco/outputs_syslog.h
+++ b/userspace/falco/outputs_syslog.h
@@ -25,10 +25,7 @@ namespace outputs
 
 class output_syslog : public abstract_output
 {
-	void output_event(gen_event *evt, std::string &rule, std::string &source,
-			  falco_common::priority_type priority, std::string &format, std::string &msg);
-
-	void output_msg(falco_common::priority_type priority, std::string &msg);
+	void output(const message *msg);
 };
 
 } // namespace outputs

--- a/userspace/falco/schema.proto
+++ b/userspace/falco/schema.proto
@@ -57,4 +57,7 @@ enum source {
   k8s_audit = 1;
   K8s_audit = 1;
   K8S_audit = 1;
+  INTERNAL = 2;
+  internal = 2;
+  Internal = 2;
 }

--- a/userspace/falco/watchdog.h
+++ b/userspace/falco/watchdog.h
@@ -20,16 +20,16 @@ limitations under the License.
 #include <atomic>
 
 template<typename _T>
-class Watchdog
+class watchdog
 {
 public:
-	Watchdog():
+	watchdog():
 		m_timeout(nullptr),
 		m_is_running(false)
 	{
 	}
 
-	~Watchdog()
+	~watchdog()
 	{
 		stop();
 	}

--- a/userspace/falco/watchdog.h
+++ b/userspace/falco/watchdog.h
@@ -1,0 +1,96 @@
+/*
+Copyright (C) 2020 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <chrono>
+#include <thread>
+#include <functional>
+#include <atomic>
+
+template<typename _T>
+class Watchdog
+{
+public:
+	Watchdog():
+		m_timeout(nullptr),
+		m_is_running(false)
+	{
+	}
+
+	~Watchdog()
+	{
+		stop();
+	}
+
+	void start(std::function<void(_T)> cb,
+		   std::chrono::milliseconds resolution = std::chrono::milliseconds(100))
+	{
+		stop();
+		m_is_running.store(true, std::memory_order_release);
+		m_thread = std::thread([this, cb, resolution]() {
+			const auto no_deadline = time_point{};
+			timeout_data curr;
+			while(m_is_running.load(std::memory_order_acquire))
+			{
+				auto t = m_timeout.exchange(nullptr, std::memory_order_release);
+				if(t)
+				{
+					curr = *t;
+					delete t;
+				}
+				if(curr.deadline != no_deadline && curr.deadline < std::chrono::steady_clock::now())
+				{
+					cb(curr.payload);
+					curr.deadline = no_deadline;
+				}
+				std::this_thread::sleep_for(resolution);
+			}
+		});
+	}
+
+	void stop()
+	{
+		if(m_is_running.load(std::memory_order_acquire))
+		{
+			m_is_running.store(false, std::memory_order_release);
+			if(m_thread.joinable())
+			{
+				m_thread.join();
+			}
+			delete m_timeout.exchange(nullptr, std::memory_order_release);
+		}
+	}
+
+	inline void set_timeout(std::chrono::milliseconds timeout, _T payload) noexcept
+	{
+		delete m_timeout.exchange(new timeout_data{std::chrono::steady_clock::now() + timeout, payload}, std::memory_order_release);
+	}
+
+	inline void cancel_timeout() noexcept
+	{
+		delete m_timeout.exchange(new timeout_data, std::memory_order_release);
+	}
+
+private:
+	typedef std::chrono::time_point<std::chrono::steady_clock> time_point;
+	struct timeout_data
+	{
+		time_point deadline;
+		_T payload;
+	};
+	std::atomic<timeout_data *> m_timeout;
+	std::atomic<bool> m_is_running;
+	std::thread m_thread;
+};


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR aims to introduce a non-blocking Falco's outputs processing, as per #1417. In details:

- https://github.com/falcosecurity/falco/pull/1451/commits/f449316c2f3f0570c4d9bfd4773a93c1d034af4f simplified (again) the outputs interface by using a single struct as param and melting together the two output methods (i.e., `output_event()` and `output_msg()`);
- https://github.com/falcosecurity/falco/pull/1451/commits/d59d2a4b2a40142c69450d151610d92ff4141994 introduced a bounded concurrent message queue (used for control commands too) that sits between:
  - the handlers for incoming events/messages (i.e., the producers) that run in the main thread, and 
  - the worker (i.e., the consumer) that runs in another thread

Incoming messages are being formatted in the main thread, then send to the worker thru the queue. Finally, the worker receives the formatted messages, then fanouts them to the enabled outputs.

Since the new implementation forwards both the usual messages (i.e., those that happen when a rule is matched) and other kinds of messages (i.e., drop alerts) to the same method (`falco::outputs::abstract_output::output(const message *msg)`), now the gRPC output inherits the ability to subscribe to dropped events.

Finally, https://github.com/falcosecurity/falco/pull/1451/commits/d6f2a3a63a1aa118679a26a7c2b455b26116621f and https://github.com/falcosecurity/falco/pull/1451/commits/4e520fa6d454da0d9c959e94c6906de98e61f77c introduced a watchdog for slow output channels. Basically, when the consumer blocks an output channel for a while, an error is logged (that signals a misconfiguration or a problem that the user should fix).

**Which issue(s) this PR fixes**:

Fixes #531
Fixes #1417 
Fixes #884 (drop alerts for gRPC)

Also, reduce the likelihood of dropped events, see #1403.

**Special notes for your reviewer**:

1. There is no guard to avoid that the message queue grows indefinitely. However, the message queue growth is limited by the embedded notification rate limiter. There is also no guard for the gRPC queue, but it's a different issue (in this case depends on the ability/presence of a client to consume notifications). It's not a goal of this PR solving these issues.

2. I'm assuming 2 seconds is a sane default to detect slow output channel consumers. You can simulate a slow output by configuring the `program_output` as following:
```yaml
program_output:
  enabled: false
  keep_alive: false
  program: "sleep 5"
```

3. Regarding gRPC.
AFAIK one blocker for adding drop alerts was the decision about using the existing API or a newer one (see #884).
Since even with drop alert we will not have any empty field, I believe it's acceptable to re-use the same proto also in case of a drop alert message. 

However, I have added a new source: `internal`. It's needed because Falco internal messages (e.g., drop alerts) did not have their own source, and the proto requires that (we cannot just leave it empty).

Below an example of how a drop alert will look like to a gRPC client:

```
time: <                                                                                                          
  seconds:1603121860 nanos:517807808                                                                             
>                                                                                                                
priority: CRITICAL                                                                                               
source: INTERNAL                                                                                                 
rule: "Falco internal: syscall event drop"                                                                       
output: "17:37:40.517807808: Critical Falco internal: syscall event drop. 1167 system calls dropped in last secon
d. (ebpf_enabled=0 n_drops=1167 n_drops_buffer=1167 n_drops_bug=0 n_drops_pf=0 n_evts=8549)"                     
output_fields: <                                                                                                 
  key: "ebpf_enabled"                                                                                            
  value: "0"                                                                                                     
>                                                                                                                
output_fields: <                                                                                                 
  key: "n_drops"                                                                                                 
  value: "1167"                                                                                                  
>                                                                                                                
output_fields: <                                                                                                 
  key: "n_drops_buffer"                                                                                          
  value: "1167"                                                                                                  
>                                                                                                                
output_fields: <                                                                                                 
  key: "n_drops_bug"                                                                                             
  value: "0"                                                                                                     
>                                                                                                                
output_fields: <                                                                                                 
  key: "n_drops_pf"                                                                                              
  value: "0"                                                                                                     
>                                                                                                                
output_fields: <                                                                                                 
  key: "n_evts"                                                                                                  
  value: "8549"                                                                                                  
>                                                                                                                
hostname: "x1"
```

**Does this PR introduce a user-facing change?**:

```release-note
new: asynchronous outputs implementation, outputs channels will not block event processing anymore
new: slow outputs detection
new: `output_timeout` config option for slow outputs detection
update: gRPC clients can now subscribe to drop alerts via gRCP API
```
