### PR TITLE
rule(list falco_privileged_images): add calico/node without registry …

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1866,6 +1866,7 @@
 - list: falco_privileged_images
   items: [
     docker.io/calico/node,
+    calico/node,
     docker.io/cloudnativelabs/kube-router,
     docker.io/docker/ucp-agent,
     docker.io/falcosecurity/falco,


### PR DESCRIPTION
…prefix

Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>

**What type of PR is this?**

/kind bug
/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

 add calico/node without registry prefix to prevent false positive alerts

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
rule(list falco_privileged_images): add calico/node without registry prefix to prevent false positive alerts
```
