### PR TITLE
new DRIVERS_REPO default URL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ include(GetFalcoVersion)
 set(PACKAGE_NAME "falco")
 set(PROBE_NAME "falco")
 set(PROBE_DEVICE_NAME "falco")
-set(DRIVERS_REPO "https://dl.bintray.com/falcosecurity/driver")
+set(DRIVERS_REPO "https://download.falco.org/driver")
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX
       /usr

--- a/proposals/20201025-drivers-storage-s3.md
+++ b/proposals/20201025-drivers-storage-s3.md
@@ -1,5 +1,9 @@
 # Falco Drivers Storage S3
 
+Supersedes: [20200818-artifacts-storage.md#drivers](20200818-artifacts-storage.md#drivers)
+
+Supersedes: [20200901-artifacts-cleanup.md#drivers](20200901-artifacts-cleanup.md#drivers)
+
 ## Introduction
 
 In the past days, as many people probably noticed, Bintray started rate-limiting our users, effectively preventing them from downloading any kernel module, rpm/deb package or any pre-built dependency we host there.
@@ -41,7 +45,7 @@ Before today, we had many issues with storage even without the spike in users we
 
 ## Context on AWS
 
-Amazon AWS, recently gave credits to the Falco project to operate some parts of the infrastructure on AWS. The CNCF is providing a sub-account we are already using for the migration of the other pieces (like Prow). 
+Amazon AWS, recently gave credits to the Falco project to operate some parts of the infrastructure on AWS. The CNCF is providing a sub-account we are already using for the migration of the other pieces (like Prow).
 
 ## Interactions with other teams and the CNCF
 
@@ -55,7 +59,7 @@ We want to propose to move the drivers and the container dependencies to S3.
 
 #### Moving means:
 
-* We create a public S3 bucket with[ stats enabled](https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html)
+* We create a public S3 bucket with [stats enabled](https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html)
 
 * We attach the bucket to a cloudfront distribution behind the download.falco.org subdomain
 
@@ -113,7 +117,7 @@ export DRIVERS_REPO=https://your-url-here
 
 Pass it as environment variable using the docker run flag -e - for example:
 
-docker run -e DRIVERS_REPO=[https://your-url-here](https://your-url-here) 
+docker run -e DRIVERS_REPO=[https://your-url-here](https://your-url-here)
 
 **Kubernetes**
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**



/kind feature



**Any specific area of the project related to this PR?**



/area build


/area proposals


**What this PR does / why we need it**:

It replaces the default value of `DRIVERS_REPO` variable with the new drivers storage on AWS S3 (as per @fntlnz's [proposal](https://github.com/falcosecurity/falco/blob/master/proposals/20201025-drivers-storage-s3.md)).

The new storage is at https://download.falco.org

**Which issue(s) this PR fixes**:



Fixes #1458 
Fixes #1455

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
update: DRIVERS_REPO now defaults to https://download.falco.org/driver
```
