### PR TITLE
rule(macro multipath_writing_conf): create and use the macro

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1213,6 +1213,9 @@
        fd.name startswith /etc/ssh/ssh_monitor_config_ or
        fd.name startswith /etc/ssh/ssh_config_))
 
+- macro: multipath_writing_conf
+  condition: (proc.name = multipath and fd.name startswith /etc/multipath/)
+
 # Add conditions to this macro (probably in a separate file,
 # overwriting this macro) to allow for specific combinations of
 # programs writing below specific directories below
@@ -1333,6 +1336,7 @@
     and not automount_using_mtab
     and not mcafee_writing_cma_d
     and not avinetworks_supervisor_writing_ssh
+    and not multipath_writing_conf
 
 - rule: Write below etc
   desc: an attempt to write to any file below /etc


### PR DESCRIPTION
**What type of PR is this?**

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

`multipath`, which is run by `systemd-udevd` (in our environment), writes to `/etc/multipath/wwids`, `/etc/multipath/bindings` and a few other paths under `/etc/multipath` as part of its normal operation. Falco is sending alerts for this, but given that it's expected behaviour for `multipath`, it probably shouldn't!

 For more information about multipath defaults, see https://manpages.debian.org/testing/multipath-tools/multipath.conf.5.en.html

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
rule(macro multipath_writing_conf): create and use the macro
```