### PR TITLE
docs: changelog for 0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v0.26.2
+
+Released on 2020-11-10
+
+### Major Changes
+
+* update: DRIVERS_REPO now defaults to https://download.falco.org/driver [[#1460](https://github.com/falcosecurity/falco/pull/1460)] - [@leodido](https://github.com/leodido)
+
 ## v0.26.1
 
 Released on 2020-10-01


### PR DESCRIPTION
Co-authored-by: Lorenzo Fontana <lo@linux.com>
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>



**What type of PR is this?**

/kind documentation


**Any specific area of the project related to this PR?**

NONE

**What this PR does / why we need it**:

Sync the CHANGELOG with the hotfix 0.26.2 release one.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

This is needed because the 0.26.2 hotfix release is not on the `master` branch, rather it is on the `release/0.26.2` branch because - as discussed in our community calls - we wanted to include only the new prebuilt drivers URL (`DRIVERS_REPO` env variable) in it.

So the CHANGELOG needs to be updated this way.

The alternative would be to wait for 0.27.0 and also add 0.26.2 changes to the CHANGELOG when we release the 0.27.0.

We (me, @fntlnz, and @leogr) chose this path for simplicity.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
