### PR TITLE
fix(docker): missing HOST_ROOT env in "no-driver" docker image

### DIFF
--- a/docker/driver-loader/Dockerfile
+++ b/docker/driver-loader/Dockerfile
@@ -3,7 +3,7 @@ FROM falcosecurity/falco:${FALCO_IMAGE_TAG}
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
-LABEL usage="docker run -i -t -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --name NAME IMAGE"
+LABEL usage="docker run -i -t --privileged -v /root/.falco:/root/.falco -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc:ro --name NAME IMAGE"
 
 ENV HOST_ROOT /host
 ENV HOME /root

--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stable
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
-LABEL usage="docker run -i -t -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --name NAME IMAGE"
+LABEL usage="docker run -i -t --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc --name NAME IMAGE"
 
 ARG FALCO_VERSION=latest
 ARG VERSION_BUCKET=deb

--- a/docker/no-driver/Dockerfile
+++ b/docker/no-driver/Dockerfile
@@ -22,6 +22,9 @@ RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /falco/
 
 FROM scratch
 
+ENV HOST_ROOT /host
+ENV HOME /root
+
 COPY --from=ubuntu /falco /
 
 CMD ["/usr/bin/falco", "-o", "time_format_iso_8601=true"]

--- a/docker/no-driver/Dockerfile
+++ b/docker/no-driver/Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:18.04 as ubuntu
 
-LABEL maintainer="cncf-falco-dev@lists.cncf.io"
-
 ARG FALCO_VERSION
 ARG VERSION_BUCKET=bin
 
@@ -21,6 +19,11 @@ RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /falco/
     && mv /falco/etc/falco/falco.yaml.new /falco/etc/falco/falco.yaml
 
 FROM scratch
+
+LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+
+LABEL usage="docker run -i -t --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro --name NAME IMAGE"
+# NOTE: for the "least privileged" use case, please refer to the official documentation
 
 ENV HOST_ROOT /host
 ENV HOME /root


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area build


**What this PR does / why we need it**:

This PR solves the problem described in #1491 and makes env vars consistent between the "falco" and the "no-driver" docker images.
It also updates the container labels with the correct docker usage command line.

**Which issue(s) this PR fixes**:

Fixes #1491

**Special notes for your reviewer**:

/milestone 0.27.0

**Does this PR introduce a user-facing change?**:

```release-note
fix: set `HOST_ROOT=/host` environment variable for the `falcosecurity/falco-no-driver` container image by default
```
