### PR TITLE
Better handle not having a config file

### DIFF
--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -47,16 +47,6 @@ falco_configuration::~falco_configuration()
 	}
 }
 
-// If we don't have a configuration file, we just use stdout output and all other defaults
-void falco_configuration::init(list<string> &cmdline_options)
-{
-	init_cmdline_options(cmdline_options);
-
-	falco::outputs::config stdout_output;
-	stdout_output.name = "stdout";
-	m_outputs.push_back(stdout_output);
-}
-
 void falco_configuration::init(string conf_filename, list<string> &cmdline_options)
 {
 	string m_config_file = conf_filename;

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -794,7 +794,7 @@ int falco_init(int argc, char **argv)
 				}
 				else
 				{
-					conf_filename = "";
+					throw std::invalid_argument("You must create a config file at " FALCO_SOURCE_CONF_FILE ", " FALCO_INSTALL_CONF_FILE " or by passing -c\n");
 				}
 			}
 		}
@@ -836,12 +836,7 @@ int falco_init(int argc, char **argv)
 		}
 		else
 		{
-			config.init(cmdline_options);
-			falco_logger::set_time_format_iso_8601(config.m_time_format_iso_8601);
-
-			// log after config init because config determines where logs go
-			falco_logger::log(LOG_INFO, "Falco version " + std::string(FALCO_VERSION) + " (driver version " + std::string(DRIVER_VERSION) + ")\n");
-			falco_logger::log(LOG_INFO, "Falco initialized. No configuration file found, proceeding with defaults\n");
+			throw std::runtime_error("Could not find configuration file at " + conf_filename);
 		}
 
 		if (rules_filenames.size())


### PR DESCRIPTION
Fixes: #1406

Signed-off-by: Spencer Krum <nibz@spencerkrum.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create


**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

When there is a config file that can't be read and a command line config set, that can create a seg fault. Instead of supporting the use case where the user doesn't have a config file, force the user to provide a config file and stop supporting a no-config-file case.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes # 1406

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Users who run falco without a config file will be unable to do that any more
Developers may need to adjust their processes
```
