### PR TITLE
build: bump civetweb to 1.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,8 +166,8 @@ if(NOT MINIMAL_BUILD)
   message(STATUS "Using bundled civetweb in '${CIVETWEB_SRC}'")
   ExternalProject_Add(
     civetweb
-    URL "https://github.com/civetweb/civetweb/archive/v1.11.tar.gz"
-    URL_HASH "SHA256=de7d5e7a2d9551d325898c71e41d437d5f7b51e754b242af897f7be96e713a42"
+    URL "https://github.com/civetweb/civetweb/archive/v1.13.tar.gz"
+    URL_HASH "SHA256=a7ccc76c2f1b5f4e8d855eb328ed542f8fe3b882a6da868781799a98f4acdedc"
     CONFIGURE_COMMAND ${CMAKE_COMMAND} -E make_directory ${CIVETWEB_SRC}/install/lib
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CIVETWEB_SRC}/install/include
     BUILD_IN_SOURCE 1


### PR DESCRIPTION
Signed-off-by: Angelo Puglisi <angelopuglisi86@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Upgrade civetweb to 1.13
**Which issue(s) this PR fixes**:
I did this mainly because I noticed CivetServer ctor parameter passed by copy (fixed here https://github.com/civetweb/civetweb/commit/f5032dbd241d2516cd33613f5c03c74064c0b590)
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
bump civetweb to 1.13
```
