### PR TITLE
feature(grpc): Add engine version to version svc

### DIFF
--- a/userspace/falco/grpc_server_impl.cpp
+++ b/userspace/falco/grpc_server_impl.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include "config_falco.h"
+#include "falco_engine_version.h"
 #include "grpc_server_impl.h"
 #include "grpc_queue.h"
 #include "logger.h"
@@ -74,6 +75,9 @@ void falco::grpc::server_impl::version(const context& ctx, const version::reques
 
 	auto& version = *res.mutable_version();
 	version = FALCO_VERSION;
+
+	res.set_engine_version(FALCO_ENGINE_VERSION);
+	res.set_engine_fields_checksum(FALCO_FIELDS_CHECKSUM); 
 
 	res.set_major(FALCO_VERSION_MAJOR);
 	res.set_minor(FALCO_VERSION_MINOR);

--- a/userspace/falco/version.proto
+++ b/userspace/falco/version.proto
@@ -36,10 +36,14 @@ message request
 // its parts as per semver 2.0 specification (https://semver.org).
 message response
 {
+// falco version
   string version = 1;
   uint32 major = 2;
   uint32 minor = 3;
   uint32 patch = 4;
   string prerelease = 5;
   string build = 6;
+// falco engine version
+  uint32 engine_version = 7;
+  string engine_fields_checksum = 8;
 }


### PR DESCRIPTION

Add two new fields in the version service for falco's engine version and
the checksum of all of the fields it understands.

This will require rebuilding/re-releasing all the clients.

Signed-off-by: Spencer Krum <nibz@spencerkrum.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Adds engine version to version endpoint


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1269

**Special notes for your reviewer**:

Tested using the client-go:

```
./version_unix_socket
{"version":"0.26.1-114+6443bb7","minor":26,"patch":1,"prerelease":"114","build":"6443bb7","engineVersion":7,"engineFieldsChecksum":"2f324e2e66d4b423f53600e7e0fcf2f0ff72e4a87755c490f2ae8f310aba9386"}
```

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note

Added falco engine version to grpc version service

```
