### PR TITLE
[WIP] Make output rate limiting optional

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -129,6 +129,7 @@ output_timeout: 2000
 outputs:
   rate: 1
   max_burst: 1000
+  rate_limit_enabled: true
 
 # Where security notifications should go.
 # Multiple outputs can be enabled.

--- a/tests/engine/test_token_bucket.cpp
+++ b/tests/engine/test_token_bucket.cpp
@@ -23,7 +23,7 @@ using namespace Catch::literals;
 
 TEST_CASE("token bucket default ctor", "[token_bucket]")
 {
-	auto tb = std::make_shared<token_bucket>();
+	auto tb = std::make_shared<raw_token_bucket>();
 
 	REQUIRE(tb->get_tokens() == 1);
 
@@ -37,10 +37,16 @@ TEST_CASE("token bucket default ctor", "[token_bucket]")
 	}
 }
 
+TEST_CASE("token bucket default initialization", "[token_bucket]")
+{
+	raw_token_bucket tb;
+	REQUIRE(tb.get_tokens() == 1);
+}
+
 TEST_CASE("token bucket ctor with custom timer", "[token_bucket]")
 {
 	auto t = []() -> uint64_t { return 22; };
-	auto tb = std::make_shared<token_bucket>(t);
+	auto tb = std::make_shared<token_bucket>(1, 1, t);
 
 	REQUIRE(tb->get_tokens() == 1);
 	REQUIRE(tb->get_last_seen() == 22);
@@ -48,36 +54,34 @@ TEST_CASE("token bucket ctor with custom timer", "[token_bucket]")
 
 TEST_CASE("token bucket with 2 tokens/sec rate, max 10 tokens", "[token_bucket]")
 {
-	auto tb = std::make_shared<token_bucket>();
-	tb->init(2.0, 10, 1);
+	uint64_t time_seq[] = {1, 1000000001, 2000000001, 3000000001};
+	size_t idx{0};
+	std::function<uint64_t()> mock_get_time_ns = [&idx, time_seq] {
+		return time_seq[(idx++) % sizeof(time_seq)];
+	};
+	auto tb = std::make_shared<token_bucket>(2.0, 10, mock_get_time_ns);
 
 	SECTION("claiming 5 tokens")
 	{
-		bool claimed = tb->claim(5, 1000000001);
+		bool claimed = tb->claim(5);
 		REQUIRE(tb->get_last_seen() == 1000000001);
 		REQUIRE(tb->get_tokens() == 5.0_a);
 		REQUIRE(claimed);
 
 		SECTION("claiming all the 7 remaining tokens")
 		{
-			bool claimed = tb->claim(7, 2000000001);
+			bool claimed = tb->claim(7);
 			REQUIRE(tb->get_last_seen() == 2000000001);
 			REQUIRE(tb->get_tokens() == 0.0_a);
 			REQUIRE(claimed);
 
 			SECTION("claiming 1 token more than the 2 available fails")
 			{
-				bool claimed = tb->claim(3, 3000000001);
+				bool claimed = tb->claim(3);
 				REQUIRE(tb->get_last_seen() == 3000000001);
 				REQUIRE(tb->get_tokens() == 2.0_a);
 				REQUIRE_FALSE(claimed);
 			}
 		}
 	}
-}
-
-TEST_CASE("token bucket default initialization", "[token_bucket]")
-{
-	token_bucket tb;
-	REQUIRE(tb.get_tokens() == 1);
 }

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -169,6 +169,7 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 
 	m_output_timeout = m_config->get_scalar<uint32_t>("output_timeout", 2000);
 
+	m_notifications_rate_limit_enabled = m_config->get_scalar<bool>("outputs", "rate_limit_enabled", true);
 	m_notifications_rate = m_config->get_scalar<uint32_t>("outputs", "rate", 1);
 	m_notifications_max_burst = m_config->get_scalar<uint32_t>("outputs", "max_burst", 1000);
 

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -197,6 +197,7 @@ public:
 	bool m_json_include_output_property;
 	std::string m_log_level;
 	std::vector<falco::outputs::config> m_outputs;
+	uint32_t m_notifications_rate_limit_enabled;
 	uint32_t m_notifications_rate;
 	uint32_t m_notifications_max_burst;
 

--- a/userspace/falco/event_drops.cpp
+++ b/userspace/falco/event_drops.cpp
@@ -43,8 +43,8 @@ void syscall_evt_drop_mgr::init(sinsp *inspector,
 	m_inspector = inspector;
 	m_outputs = outputs;
 	m_actions = actions;
-	m_bucket.init(rate, max_tokens);
 	m_threshold = threshold;
+	m_bucket.init(rate, max_tokens, sinsp_utils::get_current_time_ns());
 
 	m_inspector->get_capture_stats(&m_last_stats);
 

--- a/userspace/falco/event_drops.h
+++ b/userspace/falco/event_drops.h
@@ -67,7 +67,7 @@ protected:
 	sinsp *m_inspector;
 	falco_outputs *m_outputs;
 	syscall_evt_drop_actions m_actions;
-	token_bucket m_bucket;
+	raw_token_bucket m_bucket;
 	uint64_t m_next_check_ts;
 	scap_stats m_last_stats;
 	bool m_simulate_drops;

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -972,6 +972,7 @@ int falco_init(int argc, char **argv)
 			hostname = c_hostname;
 		}
 
+
 		if(!all_events)
 		{
 			inspector->set_drop_event_flags(EF_DROP_SIMPLE_CONS);
@@ -1081,6 +1082,7 @@ int falco_init(int argc, char **argv)
 		outputs->init(config.m_json_output,
 			config.m_json_include_output_property,
 			config.m_output_timeout,
+			config.m_notifications_rate_limit_enabled,
 			config.m_notifications_rate, config.m_notifications_max_burst,
 			config.m_buffered_outputs,
 			config.m_time_format_iso_8601,

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -85,8 +85,7 @@ void falco_outputs::init(bool json_output,
 
 	if(rate_limit_enabled)
 	{
-		m_notifications_tb.reset(new token_bucket());
-		m_notifications_tb->init(rate, max_burst);
+		m_notifications_tb.reset(new token_bucket(rate, max_burst));
 	}
 
 	m_buffered = buffered;

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -41,6 +41,7 @@ public:
 	void init(bool json_output,
 		  bool json_include_output_property,
 		  uint32_t timeout,
+		  bool rate_limit_enabled,
 		  uint32_t rate, uint32_t max_burst, bool buffered,
 		  bool time_format_iso_8601, std::string hostname);
 
@@ -67,7 +68,7 @@ private:
 	std::vector<falco::outputs::abstract_output *> m_outputs;
 
 	// Rate limits notifications
-	token_bucket m_notifications_tb;
+	std::unique_ptr<token_bucket> m_notifications_tb;
 
 	bool m_buffered;
 	bool m_json_output;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR partially address #1333, in particular it allows to disable output throttling.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
I profited to refactor a bit the token bucket to:

- Use monotonic clock instead of wall time.
- Having a raw interface where timestamps are provided explicitly and a facade that generates the timestamps automatically, mixing the two does not seem to be a good idea, especially if different types of clocks can be used.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
