### PR TITLE
Publish Falco container image to AWS ECR Public registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,11 +467,10 @@ jobs:
             apk update
             apk add --update groff less py-pip
             pip install awscli
-            FALCO_VERSION="0.26.1-115+574e7f4"
-            # FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            docker build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t "public.ecr.aws/b4t6c0y6/falco:master" docker/falco
-            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/b4t6c0y6
-            docker push "public.ecr.aws/b4t6c0y6/falco:master"
+            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
+            docker build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t "public.ecr.aws/falcosecurity/falco:master" docker/falco
+            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
+            docker push "public.ecr.aws/falcosecurity/falco:master"
   # Publish the packages
   "publish/packages":
     docker:
@@ -553,10 +552,10 @@ jobs:
             apk update
             apk add --update groff less py-pip
             pip install awscli
-            docker build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "public.ecr.aws/b4t6c0y6/falco:${CIRCLE_TAG}" docker/falco
-            docker tag "public.ecr.aws/b4t6c0y6/falco:${CIRCLE_TAG}" public.ecr.aws/b4t6c0y6/falco:latest
-            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/b4t6c0y6
-            docker push "public.ecr.aws/b4t6c0y6/falco:${CIRCLE_TAG}"
+            docker build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}" docker/falco
+            docker tag "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}" public.ecr.aws/falcosecurity/falco:latest
+            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
+            docker push "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}"
             docker push "public.ecr.aws/b4t6c0y6/falco:latest"
 workflows:
   version: 2
@@ -623,9 +622,9 @@ workflows:
             tags:
               ignore: /.*/
             branches:
-              only: jonah-ci-aws-ecr-registry # todo > revert to master before to merge
+              only: master
           requires:
-            - build/centos7 # Switch with "publish/docker-dev" once passes
+            - publish/docker-dev
       - "quality/static-analysis"
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,8 +467,9 @@ jobs:
             apk update
             apk add --update groff less py-pip
             pip install awscli
-            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            docker build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${FALCO_VERSION} -t "public.ecr.aws/b4t6c0y6/falco:master" docker/falco
+            FALCO_VERSION="0.26.1-115+574e7f4"
+            # FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
+            docker build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t "public.ecr.aws/b4t6c0y6/falco:master" docker/falco
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/b4t6c0y6
             docker push "public.ecr.aws/b4t6c0y6/falco:master"
   # Publish the packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,6 +518,26 @@ jobs:
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
             docker push "falcosecurity/falco-driver-loader:${CIRCLE_TAG}"
             docker push "falcosecurity/falco-driver-loader:latest"
+  # Publish docker packages to AWS Public
+  "publish/packages-aws":
+    docker:
+      - image: docker:stable
+    steps:
+      - attach_workspace:
+          at: /
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build and publish falco to AWS
+          command: |
+            apk update
+            apk add --update groff less py-pip
+            pip install awscli
+            docker build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "public.ecr.aws/b4t6c0y6/falco:${CIRCLE_TAG}" docker/falco
+            docker tag "public.ecr.aws/b4t6c0y6/falco:${CIRCLE_TAG}" public.ecr.aws/b4t6c0y6/falco:latest
+            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/b4t6c0y6
+            docker push "public.ecr.aws/b4t6c0y6/falco:${CIRCLE_TAG}"
+            docker push "public.ecr.aws/b4t6c0y6/falco:latest"
 workflows:
   version: 2
   build_and_test:
@@ -620,3 +640,13 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
+      - "publish/packages-aws":
+          context: test-infra
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: new/ecr-public-push #Name of PR branch to test
+          # Add this once tests pass
+          # requires:
+          #   - "publish/docker"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -556,7 +556,7 @@ jobs:
             docker tag "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}" public.ecr.aws/falcosecurity/falco:latest
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
             docker push "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}"
-            docker push "public.ecr.aws/b4t6c0y6/falco:latest"
+            docker push "public.ecr.aws/falcosecurity/falco:latest"
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,6 +452,25 @@ jobs:
             docker build --build-arg FALCO_IMAGE_TAG=master -t falcosecurity/falco-driver-loader:master docker/driver-loader
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
             docker push falcosecurity/falco-driver-loader:master
+  # Publish container images to AWS ECR Public
+  "publish/container-images-aws-dev":
+    docker:
+      - image: docker:stable
+    steps:
+      - attach_workspace:
+          at: /
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build and publish falco to AWS
+          command: |
+            apk update
+            apk add --update groff less py-pip
+            pip install awscli
+            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
+            docker build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${FALCO_VERSION} -t "public.ecr.aws/b4t6c0y6/falco:master" docker/falco
+            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/b4t6c0y6
+            docker push "public.ecr.aws/b4t6c0y6/falco:master"
   # Publish the packages
   "publish/packages":
     docker:
@@ -597,6 +616,15 @@ workflows:
           requires:
             - "publish/packages-dev"
             - "tests/driver-loader/integration"
+      - "publish/container-images-aws-dev":
+          context: test-infra # contains Falco AWS credentials
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: jonah-ci-aws-ecr-registry # todo > revert to master before to merge
+          requires:
+            - build/centos7 # Switch with "publish/docker-dev" once passes
       - "quality/static-analysis"
   release:
     jobs:
@@ -641,12 +669,11 @@ workflows:
             branches:
               ignore: /.*/
       - "publish/container-images-aws":
-          context: test-infra
+          context: test-infra # contains Falco AWS credentials
+          requires:
+            - "publish/docker"
           filters:
             tags:
               ignore: /.*/
             branches:
-              only: jonah-ci-aws-ecr-registry # todo > revert before to merge
-          # Add this once tests pass
-          # requires:
-          #   - "publish/docker"
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,8 +518,8 @@ jobs:
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
             docker push "falcosecurity/falco-driver-loader:${CIRCLE_TAG}"
             docker push "falcosecurity/falco-driver-loader:latest"
-  # Publish docker packages to AWS Public
-  "publish/packages-aws":
+  # Publish container images to AWS ECR Public
+  "publish/container-images-aws":
     docker:
       - image: docker:stable
     steps:
@@ -640,13 +640,13 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
-      - "publish/packages-aws":
+      - "publish/container-images-aws":
           context: test-infra
           filters:
             tags:
               ignore: /.*/
             branches:
-              only: new/ecr-public-push #Name of PR branch to test
+              only: jonah-ci-aws-ecr-registry # todo > revert before to merge
           # Add this once tests pass
           # requires:
           #   - "publish/docker"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Opening this PR with @jonahjon.

The goal here is to publish the Falco containers images (both the master one and the release one) to the AWS ECR Public registry 📦 

As proposed by @jonahjon during yesterday's community call.

In fact, as discussed, it can be very useful for our community to be able to download Falco container images from different registries, especially since the latest changes to the Docker Hub.

TODOs:

- [x] Publish container image (`falcosecurity/falco:master`) for the `master` branch
- [x] Publish container image (`falcosecurity/falco:<version>`) for the releases (git tags)
- [x] Make these steps depending on those publishing docker images to the Docker Hub
- [x] Obtain `falcosecurity` slug on the AWS ECR Public registry

The following steps could be added in a follow-up PR:

- Publish container image (`falcosecurity:falco-no-driver:master`)
- Publish container image (`falcosecurity:falco-no-driver:<version>`)
- Publish container image (`falcosecurity:falco-driver-loader:master`)
- Publish container image (`falcosecurity:falco-driver-loader:<version>`)

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Note this does not change the status of the container images published to Docker Hub, which remains "official support" as per [docs](https://github.com/falcosecurity/falco/blob/master/proposals/20200506-artifacts-scope-part-1.md#images).

**Does this PR introduce a user-facing change?**:

```release-note
build: falcosecurity/falco:master also available on the AWS ECR Public registry
build: falcosecurity/falco:latest also available on the AWS ECR Public registry
```
