### PR TITLE
Generate doxygen documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <hr>
 
-[![Build Status](https://img.shields.io/circleci/build/github/falcosecurity/falco/master?style=for-the-badge)](https://circleci.com/gh/falcosecurity/falco) [![CII Best Practices Summary](https://img.shields.io/cii/summary/2317?label=CCI%20Best%20Practices&style=for-the-badge)](https://bestpractices.coreinfrastructure.org/projects/2317) [![GitHub](https://img.shields.io/github/license/falcosecurity/falco?style=for-the-badge)](COPYING)
+[![Build Status](https://img.shields.io/circleci/build/github/falcosecurity/falco/master?style=for-the-badge)](https://circleci.com/gh/falcosecurity/falco) [![CII Best Practices Summary](https://img.shields.io/cii/summary/2317?label=CCI%20Best%20Practices&style=for-the-badge)](https://bestpractices.coreinfrastructure.org/projects/2317) [![GitHub](https://img.shields.io/github/license/falcosecurity/falco?style=for-the-badge)](./COPYING)
 
 Want to talk? Join us on the [#falco](https://kubernetes.slack.com/archives/CMWH3EH32) channel in the [Kubernetes Slack](https://slack.k8s.io).
 

--- a/cmake/modules/CPM.cmake
+++ b/cmake/modules/CPM.cmake
@@ -1,0 +1,19 @@
+set(CPM_DOWNLOAD_VERSION 0.27.2)
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+  message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+  file(DOWNLOAD
+       https://github.com/TheLartians/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+       ${CPM_DOWNLOAD_LOCATION}
+  )
+endif()
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+project(FalcoDocs)
+
+# Dependencies
+
+include(../cmake/modules/CPM.cmake)
+
+CPMAddPackage(NAME Falco SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
+
+CPMAddPackage(
+  NAME MCSS
+  DOWNLOAD_ONLY YES
+  GITHUB_REPOSITORY mosra/m.css
+  GIT_TAG 42d4a9a48f31f5df6e246c948403b54b50574a2a
+)
+
+# Doxygen variables
+
+set(DOXYGEN_PROJECT_NAME Falco)
+set(DOXYGEN_PROJECT_VERSION ${FALCO_VERSION})
+set(DOXYGEN_PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}/..")
+set(DOXYGEN_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/doxygen")
+
+configure_file(${CMAKE_CURRENT_LIST_DIR}/Doxyfile ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+
+configure_file(${CMAKE_CURRENT_LIST_DIR}/conf.py ${CMAKE_CURRENT_BINARY_DIR}/conf.py)
+
+add_custom_target(
+  GenerateDocs
+  ${CMAKE_COMMAND} -E make_directory "${DOXYGEN_OUTPUT_DIRECTORY}"
+  COMMAND "${MCSS_SOURCE_DIR}/documentation/doxygen.py" "${CMAKE_CURRENT_BINARY_DIR}/conf.py"
+  COMMAND echo "Docs written to: ${DOXYGEN_OUTPUT_DIRECTORY}"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)

--- a/documentation/Doxyfile
+++ b/documentation/Doxyfile
@@ -1,0 +1,31 @@
+# Configuration for Doxygen for use with CMake
+# Only options that deviate from the default are included
+# To create a new Doxyfile containing all available options, call `doxygen -g`
+
+# Get Project name and version from CMake
+PROJECT_NAME = @DOXYGEN_PROJECT_NAME@
+PROJECT_NUMBER = @DOXYGEN_PROJECT_VERSION@
+
+# Add sources
+INPUT = @DOXYGEN_PROJECT_ROOT@/README.md @DOXYGEN_PROJECT_ROOT@/userspace @DOXYGEN_PROJECT_ROOT@/documentation/pages
+EXTRACT_ALL = YES
+RECURSIVE = YES
+OUTPUT_DIRECTORY = @DOXYGEN_OUTPUT_DIRECTORY@
+
+# Use the README as a main page
+USE_MDFILE_AS_MAINPAGE = @DOXYGEN_PROJECT_ROOT@/README.md
+
+# Set relative include paths
+FULL_PATH_NAMES = YES
+STRIP_FROM_PATH = @DOXYGEN_PROJECT_ROOT@/userspace @DOXYGEN_PROJECT_ROOT@
+
+# We only need XML output because use m.css to generate the html documentation
+GENERATE_XML = YES
+GENERATE_HTML = NO
+GENERATE_LATEX = NO
+XML_PROGRAMLISTING = NO
+CREATE_SUBDIRS = NO
+
+# Include all directories, files and namespaces in the documentation
+# Disable to include only explicitly documented objects
+M_SHOW_UNDOCUMENTED = YES

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -1,0 +1,19 @@
+DOXYFILE = 'Doxyfile'
+
+LINKS_NAVBAR1 = [
+    (None, 'pages', [(None, 'about')]),
+    (None, 'namespaces', []),
+]
+
+# Add your own navbar links using the code below.
+# To find the valid link names, you can inspect the URL of a generated documentation site.
+
+# LINKS_NAVBAR1 = [
+#     (None, 'pages', [(None, 'about')]),
+#     (None, 'namespaces', [(None, 'namespacexyz')]),
+# ]
+#
+# LINKS_NAVBAR2 = [
+#     (None, 'annotated', [(None, 'classxyz_1_1_xyz')]),
+#     (None, 'files', [(None, 'xyz_8h')]),
+# ]

--- a/documentation/pages/about.dox
+++ b/documentation/pages/about.dox
@@ -1,0 +1,4 @@
+/** @page about About
+  @section doc Falco Documentation
+  This is the documentation for the Falco project.
+*/


### PR DESCRIPTION
**What type of PR is this?**



/kind documentation

/kind feature

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This PR introduces a way to build the **Falco development docs**. 🎉 

Docs for developers, and people that want to contribute to Falco, are a long-standing feature needed by our community. Thus, I decided to package this gift for our awesome community 🎁 

Namely, this PR:

- introduces a new target - ie., `GenerateDocs` - to generate **Doxygen** documentation
     - to work it requires `doxygen`, `jinja2`, and `pygments` installed on the machine
     - uses mosra/m.css (A no-nonsense, no-JavaScript CSS framework for content-oriented websites)
         - live demo of a possible final result [here](https://doc.magnum.graphics/magnum) 👈 
- introduces [CPM](https://github.com/TheLartians/CPM.cmake) (that I intend to use to simplify the way we handle all our dependencies)
     - it's a CMake module that adds dependency management capabilities to CMake
     - It's built as a thin wrapper around CMake's FetchContent module that adds version control, caching, a simple API
     - read more at the provided link for extensive documentation about it

### How to try it out

```console
cmake -Hdocumentation -Bbuild/docs
cmake --build build/docs --target GenerateDocs
```

Then open the `build/docs/doxygen/html/index.html` file in your browser.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Things to do to consider it 100% done:

- [ ] add doxygen comments to our source code
- [ ] fine-tune the generated docs structure (navbars, etc.)
- [ ] fine-tune the generated docs content
- [ ] publish the HTML using a CI job (to discuss with the community how/where/etc.)
    - [x] community choose to put development docs on a new website (falcosecurity.dev)
    - [x] obtain falcosecurity.dev

/hold

**Does this PR introduce a user-facing change?**:

```release-note
new: Falco development docs at ...
```
