### PR TITLE
docs(.circleci): adding Jonah to Falco CI maintainers

### DIFF
--- a/.circleci/OWNERS
+++ b/.circleci/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - jonahjon
+reviewers:
+  - jonahjon


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

**What type of PR is this?**

/kind documentation

**Any specific area of the project related to this PR?**

NONE

**What this PR does / why we need it**:

@jonahjon is already a top contributor to the [test-infra](https://github.com/falcosecurity/test-infra) repository.

In the past months, he put a lot of effort into helping us to create a better Falco Infrastructure.
Among other things, in December, I and @jonahjon paired also to publish the main Falco container image (`falcosecurity/falco`) on the AWS ECR gallery (see [PR 1512](https://github.com/falcosecurity/falco/pull/1512)).

Now, he wants to do the same for the other Falco container images (eg., `no-driver`, ...).
Also, he wants to help to move some CI jobs Falco needs to ProwJobs, and/or to create new ones (eg., aarch64 Falco build).

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Note that the `OWNERS` file merges hierarchically.
This means that the top-level maintainers do not lose maintainership of the CI adding a OWNERS containing @jonahjon here. 

**Does this PR introduce a user-facing change?**:


```release-note
docs(.circleci): welcome Jonah (Amazon) as a new Falco CI maintainer
```
