### PR TITLE
adding other alternate AWS builds to circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,6 +462,18 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
+          name: Build and publish no-driver to AWS
+          command: |
+            apk update
+            apk add --update groff less py-pip
+            pip install awscli
+            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
+            docker build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t "public.ecr.aws/falcosecurity/falco-no-driver:master" docker/no-driver
+            docker tag public.ecr.aws/falcosecurity/falco-no-driver:master public.ecr.aws/falcosecurity/falco:master-slim
+            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
+            docker push "public.ecr.aws/falcosecurity/falco-no-driver:master"
+            docker push "public.ecr.aws/falcosecurity/falco:master-slim"
+      - run:
           name: Build and publish falco to AWS
           command: |
             apk update
@@ -471,6 +483,16 @@ jobs:
             docker build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t "public.ecr.aws/falcosecurity/falco:master" docker/falco
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
             docker push "public.ecr.aws/falcosecurity/falco:master"
+      - run:
+          name: Build and publish driver-loader to AWS
+          command: |
+            apk update
+            apk add --update groff less py-pip
+            pip install awscli
+            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
+            docker build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t "public.ecr.aws/falcosecurity/falco-driver-loader:master" docker/driver-loader
+            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
+            docker push "public.ecr.aws/falcosecurity/falco-driver-loader:master"
   # Publish the packages
   "publish/packages":
     docker:
@@ -547,6 +569,17 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
+          name: Build and publish no-driver to AWS
+          command: |
+            apk update
+            apk add --update groff less py-pip
+            pip install awscli
+            docker build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" docker/no-driver
+            docker tag "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" public.ecr.aws/falcosecurity/falco-no-driver:latest
+            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
+            docker push "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}"
+            docker push "public.ecr.aws/falcosecurity/falco-no-driver:latest"
+      - run:
           name: Build and publish falco to AWS
           command: |
             apk update
@@ -557,6 +590,17 @@ jobs:
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
             docker push "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}"
             docker push "public.ecr.aws/falcosecurity/falco:latest"
+      - run:
+          name: Build and publish driver-loader to AWS
+          command: |
+            apk update
+            apk add --update groff less py-pip
+            pip install awscli
+            docker build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "public.ecr.aws/falcosecurity/falco-driver-loader:${CIRCLE_TAG}" docker/driver-loader
+            docker tag "public.ecr.aws/falcosecurity/falco-driver-loader:${CIRCLE_TAG}" public.ecr.aws/falcosecurity/falco-driver-loader:latest
+            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
+            docker push "public.ecr.aws/falcosecurity/falco-driver-loader:${CIRCLE_TAG}"
+            docker push "public.ecr.aws/falcosecurity/falco-driver-loader:latest"
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,7 +468,7 @@ jobs:
             apk add --update groff less py-pip
             pip install awscli
             FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            docker build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t "public.ecr.aws/falcosecurity/falco-no-driver:master" docker/no-driver
+            docker build --build-arg VERSION_BUCKET=bin-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t "public.ecr.aws/falcosecurity/falco-no-driver:master" docker/no-driver
             docker tag public.ecr.aws/falcosecurity/falco-no-driver:master public.ecr.aws/falcosecurity/falco:master-slim
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
             docker push "public.ecr.aws/falcosecurity/falco-no-driver:master"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,7 +462,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Build and publish no-driver to AWS
+          name: Build and publish no-driver (dev) to AWS
           command: |
             apk update
             apk add --update groff less py-pip
@@ -474,7 +474,7 @@ jobs:
             docker push "public.ecr.aws/falcosecurity/falco-no-driver:master"
             docker push "public.ecr.aws/falcosecurity/falco:master-slim"
       - run:
-          name: Build and publish falco to AWS
+          name: Build and publish falco (dev) to AWS
           command: |
             apk update
             apk add --update groff less py-pip
@@ -484,13 +484,12 @@ jobs:
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
             docker push "public.ecr.aws/falcosecurity/falco:master"
       - run:
-          name: Build and publish driver-loader to AWS
+          name: Build and publish driver-loader (dev) to AWS
           command: |
             apk update
             apk add --update groff less py-pip
             pip install awscli
-            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            docker build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t "public.ecr.aws/falcosecurity/falco-driver-loader:master" docker/driver-loader
+            docker build --build-arg FALCO_IMAGE_TAG=master -t "public.ecr.aws/falcosecurity/falco-driver-loader:master" docker/driver-loader
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
             docker push "public.ecr.aws/falcosecurity/falco-driver-loader:master"
   # Publish the packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -576,9 +576,13 @@ jobs:
             pip install awscli
             docker build --build-arg VERSION_BUCKET=bin --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" docker/no-driver
             docker tag "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" public.ecr.aws/falcosecurity/falco-no-driver:latest
+            docker tag "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}-slim"
+            docker tag "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" "public.ecr.aws/falcosecurity/falco:latest-slim"
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
             docker push "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}"
             docker push "public.ecr.aws/falcosecurity/falco-no-driver:latest"
+            docker push "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}-slim"
+            docker push "public.ecr.aws/falcosecurity/falco:latest-slim"
       - run:
           name: Build and publish falco to AWS
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -578,10 +578,10 @@ jobs:
             docker tag "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}-slim"
             docker tag "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" "public.ecr.aws/falcosecurity/falco:latest-slim"
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
-            docker push "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}"
-            docker push "public.ecr.aws/falcosecurity/falco-no-driver:latest"
             docker push "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}-slim"
             docker push "public.ecr.aws/falcosecurity/falco:latest-slim"
+            docker push "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}"
+            docker push "public.ecr.aws/falcosecurity/falco-no-driver:latest"
       - run:
           name: Build and publish falco to AWS
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,7 +574,7 @@ jobs:
             apk update
             apk add --update groff less py-pip
             pip install awscli
-            docker build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" docker/no-driver
+            docker build --build-arg VERSION_BUCKET=bin --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" docker/no-driver
             docker tag "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" public.ecr.aws/falcosecurity/falco-no-driver:latest
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
             docker push "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -595,12 +595,12 @@ jobs:
             docker push "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}"
             docker push "public.ecr.aws/falcosecurity/falco:latest"
       - run:
-          name: Build and publish driver-loader to AWS
+          name: Build and publish falco-driver-loader to AWS
           command: |
             apk update
             apk add --update groff less py-pip
             pip install awscli
-            docker build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "public.ecr.aws/falcosecurity/falco-driver-loader:${CIRCLE_TAG}" docker/driver-loader
+            docker build --build-arg FALCO_IMAGE_TAG=${CIRCLE_TAG} -t "public.ecr.aws/falcosecurity/falco-driver-loader:${CIRCLE_TAG}" docker/driver-loader
             docker tag "public.ecr.aws/falcosecurity/falco-driver-loader:${CIRCLE_TAG}" public.ecr.aws/falcosecurity/falco-driver-loader:latest
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
             docker push "public.ecr.aws/falcosecurity/falco-driver-loader:${CIRCLE_TAG}"


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

 /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Uploads other Falco images `no-driver` and `driver-loader` to AWS public gallery.

**Does this PR introduce a user-facing change?**:

No

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new: falco-no-driver container images on AWS ECR gallery
new: falco-driver-loader container images on AWS ECR gallery
```
