### PR TITLE
chore(cmake): remove unnecessary whitespace patch

### DIFF
--- a/cmake/modules/sysdig-repo/patch/libscap.patch
+++ b/cmake/modules/sysdig-repo/patch/libscap.patch
@@ -38,17 +38,6 @@ index 6f51588e..5f9ea84e 100644
  				}
  				else
  				{
-@@ -579,8 +579,8 @@ scap_t* scap_open_udig_int(char *error, int32_t *rc,
- 	//
- 	// Map the ppm_ring_buffer_info that contains the buffer pointers
- 	//
--	if(udig_alloc_ring_descriptors(&(handle->m_devs[0].m_bufinfo_fd), 
--		&handle->m_devs[0].m_bufinfo, 
-+	if(udig_alloc_ring_descriptors(&(handle->m_devs[0].m_bufinfo_fd),
-+		&handle->m_devs[0].m_bufinfo,
- 		&handle->m_devs[0].m_bufstatus,
- 		error) != SCAP_SUCCESS)
- 	{
 @@ -2175,7 +2175,7 @@ int32_t scap_disable_dynamic_snaplen(scap_t* handle)
  
  const char* scap_get_host_root()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area build


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Very small improvement required to reduce the likelihood that the patching process will fail when the upstream file gets modified.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Not a big issue right now, but may be useful in development since the patching process is already failing if using the latest commit from sysdig. I stumbled upon this problem while experimenting.

/cc @leodido 

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
