### PR TITLE
docs(RELEASE.md): link the ecr images in releases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -69,13 +69,12 @@ Now assume `x.y.z` is the new version.
     | deb      | [![deb](https://img.shields.io/badge/Falco-x.y.z-%2300aec7?style=flat-square)](https://dl.bintray.com/falcosecurity/deb/stable/falco-x.y.z-x86_64.deb) |
     | tgz      | [![tgz](https://img.shields.io/badge/Falco-x.y.z-%2300aec7?style=flat-square)](https://dl.bintray.com/falcosecurity/bin/x86_64/falco-x.y.z-x86_64.deb) |
 
-    | Images                                                          |
-    | --------------------------------------------------------------- |
-    | `docker pull docker.io/falcosecurity/falco:_tag_`               |
-    | `docker pull docker.io/falcosecurity/falco-driver-loader:_tag_` |
-    | `docker pull docker.io/falcosecurity/falco-no-driver:_tag_`     |
-
-    <!-- Copy the relevant part of the changelog here -->
+    | Images                                                                      |
+    | --------------------------------------------------------------------------- |
+    | `docker pull docker.io/falcosecurity/falco:x.y.z`                           |
+    | `docker pull public.ecr.aws/falcosecurity/falco:x.y.z`                      |
+    | `docker pull docker.io/falcosecurity/falco-driver-loader:x.y.z`             |
+    | `docker pull docker.io/falcosecurity/falco-no-driver:x.y.z`                 |
 
     ### Statistics
 


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>


**What type of PR is this?**


/kind documentation


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Did this change to the release docs so that we don't forget to link the new ECR images in releases.

See https://github.com/falcosecurity/falco/pull/1512

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
