### PR TITLE
update(.circleci): fix tag definition for ECR image push on releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -674,6 +674,6 @@ workflows:
             - "publish/docker"
           filters:
             tags:
-              ignore: /.*/
+              only: /.*/
             branches:
               ignore: /.*/


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>

**What type of PR is this?**

We released 0.27.0 but we had a small error in the circleci config to release on ECR. This is minor since ECR is just in preview but wanted to have it fixed for the next release.

An image with the same sha had been published by @leodido on ECR manually only for this time.

> Uncomment one (or more) `/kind <>` lines:

/kind bug


**Any specific area of the project related to this PR?**

/area build


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
