### PR TITLE
Allow unknown sources

### DIFF
--- a/test/falco_tests.yaml
+++ b/test/falco_tests.yaml
@@ -1277,3 +1277,10 @@ trace_files: !mux
     trace_file: trace_files/cat_write.scap
     stdout_contains: "2016-08-04T16:17:57.882054739\\+0000: Warning An open was seen"
     stderr_contains: "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d\\+0000"
+
+  unknown_source:
+    detect: True
+    detect_level: WARNING
+    rules_file:
+      - rules/unknown_source.yaml
+    trace_file: trace_files/cat_write.scap

--- a/test/rules/unknown_source.yaml
+++ b/test/rules/unknown_source.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2021 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+- macro: Macro with unknown source
+  condition: some other unknown filter
+  source: unknown-source
+
+- rule: Rule with unknown source
+  condition: some unknown filter
+  output: some unknown output
+  priority: INFO
+  source: unknown-source
+
+- rule: open_from_cat
+  desc: A process named cat does an open
+  condition: evt.type=open and proc.name=cat
+  output: "An open was seen (command=%proc.cmdline)"
+  priority: WARNING

--- a/userspace/engine/lua/rule_loader.lua
+++ b/userspace/engine/lua/rule_loader.lua
@@ -436,6 +436,11 @@ function load_rules_doc(rules_mgr, doc, load_state)
 	    v['source'] = "syscall"
 	 end
 
+	 -- Ignore macros with unknown sources
+	 if (v['source'] ~= "syscall" and v['source'] ~= "k8s_audit") then
+	    goto next_object
+	 end
+
 	 if state.macros_by_name[v['macro']] == nil then
 	    state.ordered_macro_names[#state.ordered_macro_names+1] = v['macro']
 	 end
@@ -520,6 +525,11 @@ function load_rules_doc(rules_mgr, doc, load_state)
 
 	 if v['source'] == nil then
 	    v['source'] = "syscall"
+	 end
+
+	 -- Ignore rules with unknown sources
+	 if (v['source'] ~= "syscall" and v['source'] ~= "k8s_audit") then
+	    goto next_object
 	 end
 
 	 -- Add an empty exceptions property to the rule if not
@@ -668,6 +678,8 @@ function load_rules_doc(rules_mgr, doc, load_state)
 	 arr = build_error_with_context(context, "Unknown top level object: "..table.tostring(v))
 	 warnings[#warnings + 1] = arr[1]
       end
+
+      ::next_object::
    end
 
    return true, {}, warnings


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

In #1427 rule processing was already relaxed a bit to allow rules to have new properties without failures. This further relaxes processing to completely ignore rules that have a source other than "syscall" or "k8s_audit"., for example:
```
- rule: Rule with unknown source
  condition: some unknown filteer
  output: some unknown output
  priority: INFO
```

Without this change, falco will try to read rules with unknown sources and match the filtercheck fields against known supported sets for k8s audit/syscall.

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Silently allow and ignore rules where the source is something other than "syscall" or "k8s_audit" (or blank, which defaults to "syscall").
```
