### PR TITLE
falco: add healthz endpoint

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -152,11 +152,14 @@ stdout_output:
 # $ openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 365 -out certificate.pem
 # $ cat certificate.pem key.pem > falco.pem
 # $ sudo cp falco.pem /etc/falco/falco.pem
-
+#
+# It also exposes a healthy endpoint that can be used to check if Falco is up and running
+# By default the endpoint is /healthz
 webserver:
   enabled: true
   listen_port: 8765
   k8s_audit_endpoint: /k8s-audit
+  k8s_healthz_endpoint: /healthz
   ssl_enabled: false
   ssl_certificate: /etc/falco/falco.pem
 

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -34,6 +34,7 @@ falco_configuration::falco_configuration():
 	m_webserver_enabled(false),
 	m_webserver_listen_port(8765),
 	m_webserver_k8s_audit_endpoint("/k8s-audit"),
+	m_webserver_k8s_healthz_endpoint("/healthz"),
 	m_webserver_ssl_enabled(false),
 	m_config(NULL)
 {
@@ -193,6 +194,7 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 	m_webserver_enabled = m_config->get_scalar<bool>("webserver", "enabled", false);
 	m_webserver_listen_port = m_config->get_scalar<uint32_t>("webserver", "listen_port", 8765);
 	m_webserver_k8s_audit_endpoint = m_config->get_scalar<string>("webserver", "k8s_audit_endpoint", "/k8s-audit");
+	m_webserver_k8s_healthz_endpoint = m_config->get_scalar<string>("webserver", "k8s_healthz_endpoint", "/healthz");
 	m_webserver_ssl_enabled = m_config->get_scalar<bool>("webserver", "ssl_enabled", false);
 	m_webserver_ssl_certificate = m_config->get_scalar<string>("webserver", "ssl_certificate", "/etc/falco/falco.pem");
 

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -216,6 +216,7 @@ public:
 	bool m_webserver_enabled;
 	uint32_t m_webserver_listen_port;
 	std::string m_webserver_k8s_audit_endpoint;
+	std::string m_webserver_k8s_healthz_endpoint;
 	bool m_webserver_ssl_enabled;
 	std::string m_webserver_ssl_certificate;
 	std::set<syscall_evt_drop_mgr::action> m_syscall_evt_drop_actions;

--- a/userspace/falco/webserver.cpp
+++ b/userspace/falco/webserver.cpp
@@ -34,6 +34,15 @@ k8s_audit_handler::~k8s_audit_handler()
 {
 }
 
+bool k8s_healthz_handler::handleGet(CivetServer *server, struct mg_connection *conn)
+{
+	const std::string status_body = "{\"status\": \"ok\"}";
+	mg_send_http_ok(conn, "application/json", status_body.size());
+	mg_printf(conn, "%s", status_body.c_str());
+
+	return true;
+}
+
 bool k8s_audit_handler::accept_data(falco_engine *engine,
 				    falco_outputs *outputs,
 				    std::string &data,
@@ -148,7 +157,7 @@ bool k8s_audit_handler::handlePost(CivetServer *server, struct mg_connection *co
 		return true;
 	}
 
-	std::string ok_body = "<html><body>Ok</body></html>";
+	const std::string ok_body = "<html><body>Ok</body></html>";
 	mg_send_http_ok(conn, "text/html", ok_body.size());
 	mg_printf(conn, "%s", ok_body.c_str());
 
@@ -233,6 +242,8 @@ void falco_webserver::start()
 
 	m_k8s_audit_handler = make_unique<k8s_audit_handler>(m_engine, m_outputs);
 	m_server->addHandler(m_config->m_webserver_k8s_audit_endpoint, *m_k8s_audit_handler);
+	m_k8s_healthz_handler = make_unique<k8s_healthz_handler>();
+	m_server->addHandler(m_config->m_webserver_k8s_healthz_endpoint, *m_k8s_healthz_handler);
 }
 
 void falco_webserver::stop()
@@ -241,5 +252,6 @@ void falco_webserver::stop()
 	{
 		m_server = NULL;
 		m_k8s_audit_handler = NULL;
+		m_k8s_healthz_handler = NULL;
 	}
 }

--- a/userspace/falco/webserver.h
+++ b/userspace/falco/webserver.h
@@ -41,6 +41,20 @@ private:
 	bool accept_uploaded_data(std::string &post_data, std::string &errstr);
 };
 
+class k8s_healthz_handler : public CivetHandler
+{
+public:
+	k8s_healthz_handler()
+	{
+	}
+
+	virtual ~k8s_healthz_handler()
+	{
+	}
+
+	bool handleGet(CivetServer *server, struct mg_connection *conn);
+};
+
 class falco_webserver
 {
 public:
@@ -60,4 +74,5 @@ private:
 	falco_outputs *m_outputs;
 	unique_ptr<CivetServer> m_server;
 	unique_ptr<k8s_audit_handler> m_k8s_audit_handler;
+	unique_ptr<k8s_healthz_handler> m_k8s_healthz_handler;
 };


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

Add an initial implementation to have a `heatlhz` endpoint, this is useful when running the workload in kubernetes so we can add liveness/read probes to do the checks and fail when is not responding.

In the future, we can have some deep checks if needed.

This PR is the initial to fix this issue: https://github.com/falcosecurity/charts/issues/53

tried my best with c++ 😄 

/assign @fntlnz  @leodido 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
falco: add healthz endpoint
```
