### PR TITLE
update rules

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1537,7 +1537,6 @@
         - [[rancher-bridge], "rancher/network-manager"]
         - [[calico-node], "calico/node"]
         - [[scope], "weaveworks/scope"]
-        - [[system-probe], "datadog/agent"]
   output: >
     Namespace change (setns) by unexpected program (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline
     parent=%proc.pname %container.info container_id=%container.id image=%container.image.repository:%container.image.tag)
@@ -1799,7 +1798,7 @@
     docker.io/rook/toolbox, docker.io/cloudnativelabs/kube-router, docker.io/consul,
     docker.io/datadog/docker-dd-agent, docker.io/datadog/agent, docker.io/docker/ucp-agent, docker.io/gliderlabs/logspout,
     docker.io/netdata/netdata, docker.io/google/cadvisor, docker.io/prom/node-exporter,
-    amazon/amazon-ecs-agent, prom/node-exporter, gcr.io/datadoghq/agent, amazon/cloudwatch-agent
+    amazon/amazon-ecs-agent, prom/node-exporter, amazon/cloudwatch-agent
     ]
 
 # These container images are allowed to run with hostnetwork=true
@@ -2365,8 +2364,7 @@
      gcr.io/google_containers/kube2sky, docker.io/sysdig/falco,
      docker.io/sysdig/sysdig, docker.io/falcosecurity/falco,
      sysdig/falco, sysdig/sysdig, falcosecurity/falco, fluent/fluentd-kubernetes-daemonset, 
-     newrelic/infrastructure-k8s, prom/prometheus,
-     cloudability/metrics-agent) or (k8s.ns.name = "kube-system"))
+     prom/prometheus) or (k8s.ns.name = "kube-system"))
 
 - macro: k8s_api_server
   condition: (fd.sip.name="kubernetes.default.svc.cluster.local")

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1724,22 +1724,23 @@
        container.image.repository endswith /prometheus-node-exporter or
        container.image.repository endswith /image-inspector))
 
-#602401143452.dkr.ecr is official AWS EKS registry. AWS has different ECR repo per region
-#602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/kube-proxy
-#602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy
-#For this reason we use two macro to match all regions 
+# 602401143452.dkr.ecr is official AWS EKS registry. AWS has different ECR repo per region
+# 602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/kube-proxy
+# 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy
+# For this reason we use two macro to match all regions 
 - macro: allowed_aws_eks_registry_root
-    condition: >
-          (container.image.repository startswith "602401143452.dkr.ecr")
+  condition: >
+        (container.image.repository startswith "602401143452.dkr.ecr")
 
 - macro: aws_eks_image
-    condition: >
-          (allowed_aws_eks_registry_root and
-          (container.image.repository endswith ".amazonaws.com/amazon-k8s-cni" or
-          container.image.repository endswith ".amazonaws.com/eks/kube-proxy"))
+  condition: >
+        (allowed_aws_eks_registry_root and
+        (container.image.repository endswith ".amazonaws.com/amazon-k8s-cni" or
+        container.image.repository endswith ".amazonaws.com/eks/kube-proxy"))
+
 - macro: aws_eks_image_sensitive_mount
-    condition: >
-          (allowed_aws_eks_registry_root and container.image.repository endswith ".amazonaws.com/amazon-k8s-cni")
+  condition: >
+        (allowed_aws_eks_registry_root and container.image.repository endswith ".amazonaws.com/amazon-k8s-cni")
 
 
 # These images are allowed both to run with --privileged and to mount

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1537,6 +1537,7 @@
         - [[rancher-bridge], "rancher/network-manager"]
         - [[calico-node], "calico/node"]
         - [[scope], "weaveworks/scope"]
+        - [[system-probe], "datadog/agent"]
   output: >
     Namespace change (setns) by unexpected program (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline
     parent=%proc.pname %container.info container_id=%container.id image=%container.image.repository:%container.image.tag)
@@ -1724,6 +1725,24 @@
        container.image.repository endswith /prometheus-node-exporter or
        container.image.repository endswith /image-inspector))
 
+#602401143452.dkr.ecr is official AWS EKS registry. AWS has different ECR repo per region
+#602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/kube-proxy
+#602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy
+#For this reason we use two macro to match all regions 
+- macro: allowed_aws_eks_registry_root
+    condition: >
+          (container.image.repository startswith "602401143452.dkr.ecr")
+
+- macro: aws_eks_image
+    condition: >
+          (allowed_aws_eks_registry_root and
+          (container.image.repository endswith ".amazonaws.com/amazon-k8s-cni" or
+          container.image.repository endswith ".amazonaws.com/eks/kube-proxy"))
+- macro: aws_eks_image_sensitive_mount
+    condition: >
+          (allowed_aws_eks_registry_root and container.image.repository endswith ".amazonaws.com/amazon-k8s-cni")
+
+
 # These images are allowed both to run with --privileged and to mount
 # sensitive paths from the host filesystem.
 #
@@ -1780,7 +1799,7 @@
     docker.io/rook/toolbox, docker.io/cloudnativelabs/kube-router, docker.io/consul,
     docker.io/datadog/docker-dd-agent, docker.io/datadog/agent, docker.io/docker/ucp-agent, docker.io/gliderlabs/logspout,
     docker.io/netdata/netdata, docker.io/google/cadvisor, docker.io/prom/node-exporter,
-    amazon/amazon-ecs-agent
+    amazon/amazon-ecs-agent, prom/node-exporter, gcr.io/datadoghq/agent, amazon/cloudwatch-agent
     ]
 
 # These container images are allowed to run with hostnetwork=true
@@ -1811,6 +1830,7 @@
     container_started and container
     and container.privileged=true
     and not openshift_image
+    and not aws_eks_image
   exceptions:
     - name: image_repo
       fields: container.image.repository
@@ -1865,6 +1885,7 @@
     container_started and container
     and sensitive_mount
     and not user_sensitive_mount_containers
+    and not aws_eks_image_sensitive_mount
   exceptions:
     - name: image_repo
       fields: container.image.repository
@@ -2343,7 +2364,9 @@
     (container.image.repository in (gcr.io/google_containers/hyperkube-amd64,
      gcr.io/google_containers/kube2sky, docker.io/sysdig/falco,
      docker.io/sysdig/sysdig, docker.io/falcosecurity/falco,
-     sysdig/falco, sysdig/sysdig, falcosecurity/falco) or (k8s.ns.name = "kube-system"))
+     sysdig/falco, sysdig/sysdig, falcosecurity/falco, fluent/fluentd-kubernetes-daemonset, 
+     newrelic/infrastructure-k8s, prom/prometheus,
+     cloudability/metrics-agent) or (k8s.ns.name = "kube-system"))
 
 - macro: k8s_api_server
   condition: (fd.sip.name="kubernetes.default.svc.cluster.local")

--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -51,7 +51,8 @@
     cluster-autoscaler,
     "system:addon-manager",
     "cloud-controller-manager",
-    "eks:node-manager"
+    "eks:node-manager",
+    "system:kube-controller-manager"
     ]
 
 - rule: Disallowed K8s User
@@ -346,7 +347,7 @@
   tags: [k8s]
 
 - list: user_known_sa_list
-  items: []
+  items: ["pod-garbage-collector","resourcequota-controller","cronjob-controller","generic-garbage-collector", "daemon-set-controller","endpointslice-controller","deployment-controller", "replicaset-controller"]
 
 - macro: trusted_sa
   condition: (ka.target.name in (user_known_sa_list))

--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -347,7 +347,9 @@
   tags: [k8s]
 
 - list: user_known_sa_list
-  items: ["pod-garbage-collector","resourcequota-controller","cronjob-controller","generic-garbage-collector", "daemon-set-controller","endpointslice-controller","deployment-controller", "replicaset-controller"]
+  items: ["pod-garbage-collector","resourcequota-controller","cronjob-controller","generic-garbage-collector", 
+          "daemon-set-controller","endpointslice-controller","deployment-controller", "replicaset-controller",
+          "endpoint-controller"]
 
 - macro: trusted_sa
   condition: (ka.target.name in (user_known_sa_list))


### PR DESCRIPTION
Signed-off-by: ismail yenigul <ismailyenigul@gmail.com>


**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

 /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

 /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

```release-note
Update rules for commonly used images and internal AWS EKS/Kubernetes pods.
```

**What this PR does / why we need it**:
update falco rules for commonly used containers and internal AWS EKS/k8s pods 
for the following event logs

```
{
    "output": "12:58:59.026407000: Notice Container with sensitive mount started (user=root user_loginuid=0 command=container:ba304927fed0 k8s.ns=<NA> k8s.pod=<NA> container=ba304927fed0 image=amazon/cloudwatch-agent:1.247345.36b249270 mounts=/var/run/docker.sock:/var/run/docker.sock:ro:false:rprivate,/dev/disk:/dev/disk:ro:false:rprivate,/var/lib/kubelet/pods/9e9aee05-7aaf-4870-82ca-149e191dba51/etc-hosts:/etc/hosts::true:rprivate,/var/lib/kubelet/pods/9e9aee05-7aaf-4870-82ca-149e191dba51/containers/cloudwatch-agent/aaf62131:/dev/termination-log::true:rprivate,/var/lib/kubelet/pods/9e9aee05-7aaf-4870-82ca-149e191dba51/volumes/kubernetes.io~configmap/cwagentconfig:/etc/cwagentconfig:ro:false:rprivate,/:/rootfs:ro:false:rslave,/var/lib/docker:/var/lib/docker:ro:false:rslave,/sys:/sys:ro:false:rprivate,/var/lib/kubelet/pods/9e9aee05-7aaf-4870-82ca-149e191dba51/volumes/kubernetes.io~secret/cloudwatch-agent-token-pn76c:/var/run/secrets/kubernetes.io/serviceaccount:ro:false:rprivate) k8s.ns=<NA> k8s.pod=<NA> container=ba304927fed0 k8s.ns=<NA> k8s.pod=<NA> container=ba304927fed0 k8s.ns=<NA> k8s.pod=<NA> container=ba304927fed0",
    "priority": "Notice",
    "rule": "Launch Sensitive Mount Container",
    "time": "2021-02-10T12:58:59.026407000Z",
    "output_fields": {
        "container.id": "ba304927fed0",
        "container.image.repository": "amazon/cloudwatch-agent",
        "container.image.tag": "1.247345.36b249270",
        "container.mounts": "/var/run/docker.sock:/var/run/docker.sock:ro:false:rprivate,/dev/disk:/dev/disk:ro:false:rprivate,/var/lib/kubelet/pods/9e9aee05-7aaf-4870-82ca-149e191dba51/etc-hosts:/etc/hosts::true:rprivate,/var/lib/kubelet/pods/9e9aee05-7aaf-4870-82ca-149e191dba51/containers/cloudwatch-agent/aaf62131:/dev/termination-log::true:rprivate,/var/lib/kubelet/pods/9e9aee05-7aaf-4870-82ca-149e191dba51/volumes/kubernetes.io~configmap/cwagentconfig:/etc/cwagentconfig:ro:false:rprivate,/:/rootfs:ro:false:rslave,/var/lib/docker:/var/lib/docker:ro:false:rslave,/sys:/sys:ro:false:rprivate,/var/lib/kubelet/pods/9e9aee05-7aaf-4870-82ca-149e191dba51/volumes/kubernetes.io~secret/cloudwatch-agent-token-pn76c:/var/run/secrets/kubernetes.io/serviceaccount:ro:false:rprivate",
        "evt.time": 1612961939026407000,
        "k8s.ns.name": null,
        "k8s.pod.name": null,
        "proc.cmdline": "container:ba304927fed0",
        "user.loginuid": 0,
        "user.name": "root"
    }
}

{
    "output": "12:58:59.529718000: Notice Container with sensitive mount started (user=<NA> user_loginuid=0 command=container:d77575518d8e k8s.ns=prometheus k8s.pod=prometheus-node-exporter-qw9xq container=d77575518d8e image=prom/node-exporter:v1.0.1 mounts=/proc:/host/proc:ro:false:rprivate,/sys:/host/sys:ro:false:rprivate,/var/lib/kubelet/pods/5310dae2-16ff-4a21-a038-7f38ecd235b5/volumes/kubernetes.io~secret/prometheus-node-exporter-token-wg7d2:/var/run/secrets/kubernetes.io/serviceaccount:ro:false:rprivate,/var/lib/kubelet/pods/5310dae2-16ff-4a21-a038-7f38ecd235b5/etc-hosts:/etc/hosts::true:rprivate,/var/lib/kubelet/pods/5310dae2-16ff-4a21-a038-7f38ecd235b5/containers/prometheus-node-exporter/39c19854:/dev/termination-log::true:rprivate) k8s.ns=prometheus k8s.pod=prometheus-node-exporter-qw9xq container=d77575518d8e k8s.ns=prometheus k8s.pod=prometheus-node-exporter-qw9xq container=d77575518d8e k8s.ns=prometheus k8s.pod=prometheus-node-exporter-qw9xq container=d77575518d8e",
    "priority": "Notice",
    "rule": "Launch Sensitive Mount Container",
    "time": "2021-02-10T12:58:59.529718000Z",
    "output_fields": {
        "container.id": "d77575518d8e",
        "container.image.repository": "prom/node-exporter",
        "container.image.tag": "v1.0.1",
        "container.mounts": "/proc:/host/proc:ro:false:rprivate,/sys:/host/sys:ro:false:rprivate,/var/lib/kubelet/pods/5310dae2-16ff-4a21-a038-7f38ecd235b5/volumes/kubernetes.io~secret/prometheus-node-exporter-token-wg7d2:/var/run/secrets/kubernetes.io/serviceaccount:ro:false:rprivate,/var/lib/kubelet/pods/5310dae2-16ff-4a21-a038-7f38ecd235b5/etc-hosts:/etc/hosts::true:rprivate,/var/lib/kubelet/pods/5310dae2-16ff-4a21-a038-7f38ecd235b5/containers/prometheus-node-exporter/39c19854:/dev/termination-log::true:rprivate",
        "evt.time": 1612961939529718000,
        "k8s.ns.name": "prometheus",
        "k8s.pod.name": "prometheus-node-exporter-qw9xq",
        "proc.cmdline": "container:d77575518d8e",
        "user.loginuid": 0,
        "user.name": null
    }
}
{
    "output": "01:20:58.560320000: Warning Service account created in kube namespace (user=system:kube-controller-manager serviceaccount=cronjob-controller ns=kube-system)",
    "priority": "Warning",
    "rule": "Service Account Created in Kube Namespace",
    "time": "2021-02-10T01:20:58.560320000Z",
    "output_fields": {
        "jevt.time": "01:20:58.560320000",
        "ka.target.name": "cronjob-controller",
        "ka.target.namespace": "kube-system",
        "ka.user.name": "system:kube-controller-manager"
    }
}
{
    "output": "01:29:27.514302976: Warning Service account created in kube namespace (user=system:kube-controller-manager serviceaccount=pod-garbage-collector ns=kube-system)",
    "priority": "Warning",
    "rule": "Service Account Created in Kube Namespace",
    "time": "2021-02-10T01:29:27.514302976Z",
    "output_fields": {
        "jevt.time": "01:29:27.514302976",
        "ka.target.name": "pod-garbage-collector",
        "ka.target.namespace": "kube-system",
        "ka.user.name": "system:kube-controller-manager"
    }
}


{
    "output": "12:58:59.529718000: Notice Container with sensitive mount started (user=<NA> user_loginuid=0 command=container:d77575518d8e k8s.ns=prometheus k8s.pod=prometheus-node-exporter-qw9xq container=d77575518d8e image=prom/node-exporter:v1.0.1 mounts=/proc:/host/proc:ro:false:rprivate,/sys:/host/sys:ro:false:rprivate,/var/lib/kubelet/pods/5310dae2-16ff-4a21-a038-7f38ecd235b5/volumes/kubernetes.io~secret/prometheus-node-exporter-token-wg7d2:/var/run/secrets/kubernetes.io/serviceaccount:ro:false:rprivate,/var/lib/kubelet/pods/5310dae2-16ff-4a21-a038-7f38ecd235b5/etc-hosts:/etc/hosts::true:rprivate,/var/lib/kubelet/pods/5310dae2-16ff-4a21-a038-7f38ecd235b5/containers/prometheus-node-exporter/39c19854:/dev/termination-log::true:rprivate) k8s.ns=prometheus k8s.pod=prometheus-node-exporter-qw9xq container=d77575518d8e k8s.ns=prometheus k8s.pod=prometheus-node-exporter-qw9xq container=d77575518d8e k8s.ns=prometheus k8s.pod=prometheus-node-exporter-qw9xq container=d77575518d8e",
    "priority": "Notice",
    "rule": "Launch Sensitive Mount Container",
    "time": "2021-02-10T12:58:59.529718000Z",
    "output_fields": {
        "container.id": "d77575518d8e",
        "container.image.repository": "prom/node-exporter",
        "container.image.tag": "v1.0.1",
        "container.mounts": "/proc:/host/proc:ro:false:rprivate,/sys:/host/sys:ro:false:rprivate,/var/lib/kubelet/pods/5310dae2-16ff-4a21-a038-7f38ecd235b5/volumes/kubernetes.io~secret/prometheus-node-exporter-token-wg7d2:/var/run/secrets/kubernetes.io/serviceaccount:ro:false:rprivate,/var/lib/kubelet/pods/5310dae2-16ff-4a21-a038-7f38ecd235b5/etc-hosts:/etc/hosts::true:rprivate,/var/lib/kubelet/pods/5310dae2-16ff-4a21-a038-7f38ecd235b5/containers/prometheus-node-exporter/39c19854:/dev/termination-log::true:rprivate",
        "evt.time": 1612961939529718000,
        "k8s.ns.name": "prometheus",
        "k8s.pod.name": "prometheus-node-exporter-qw9xq",
        "proc.cmdline": "container:d77575518d8e",
        "user.loginuid": 0,
        "user.name": null
    }
}
{
    "output": "01:20:58.560320000: Warning Service account created in kube namespace (user=system:kube-controller-manager serviceaccount=cronjob-controller ns=kube-system)",
    "priority": "Warning",
    "rule": "Service Account Created in Kube Namespace",
    "time": "2021-02-10T01:20:58.560320000Z",
    "output_fields": {
        "jevt.time": "01:20:58.560320000",
        "ka.target.name": "cronjob-controller",
        "ka.target.namespace": "kube-system",
        "ka.user.name": "system:kube-controller-manager"
    }
}
{
    "output": "01:29:27.514302976: Warning Service account created in kube namespace (user=system:kube-controller-manager serviceaccount=pod-garbage-collector ns=kube-system)",
    "priority": "Warning",
    "rule": "Service Account Created in Kube Namespace",
    "time": "2021-02-10T01:29:27.514302976Z",
    "output_fields": {
        "jevt.time": "01:29:27.514302976",
        "ka.target.name": "pod-garbage-collector",
        "ka.target.namespace": "kube-system",
        "ka.user.name": "system:kube-controller-manager"
    }
}
# These images are allowed both to run with --privileged and to mount
# sensitive paths from the host filesystem.
#
# NOTE: This list is only provided for backwards compatibility with
# older local falco rules files that may have been appending to
# trusted_images. To make customizations, it's better to add images to
# either privileged_images or falco_sensitive_mount_images.
- list: trusted_images
  items: []


{
    "output": "13:23:41.871927287: Notice Unexpected connection to K8s API Server from container (command=event_loop -Eascii-8bit:ascii-8bit /fluentd/vendor/bundle/ruby/2.6.0/bin/fluentd -c /fluentd/etc/fluent.conf -p /fluentd/plugins --gemfile /fluentd/Gemfile --under-supervisor k8s.ns=amazon-cloudwatch k8s.pod=fluentd-cloudwatch-8tcwl container=c0b3f46e3738 image=fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0 connection=192.168.104.140:41098->10.100.0.1:443) k8s.ns=amazon-cloudwatch k8s.pod=fluentd-cloudwatch-8tcwl container=c0b3f46e3738 k8s.ns=amazon-cloudwatch k8s.pod=fluentd-cloudwatch-8tcwl container=c0b3f46e3738 k8s.ns=amazon-cloudwatch k8s.pod=fluentd-cloudwatch-8tcwl container=c0b3f46e3738",
    "priority": "Notice",
    "rule": "Contact K8S API Server From Container",
    "time": "2021-02-10T13:23:41.871927287Z",
    "output_fields": {
        "container.id": "c0b3f46e3738",
        "container.image.repository": "fluent/fluentd-kubernetes-daemonset",
        "container.image.tag": "v1.7.3-debian-cloudwatch-1.0",
        "evt.time": 1612963421871927287,
        "fd.name": "192.168.104.140:41098->10.100.0.1:443",
        "k8s.ns.name": "amazon-cloudwatch",
        "k8s.pod.name": "fluentd-cloudwatch-8tcwl",
        "proc.cmdline": "event_loop -Eascii-8bit:ascii-8bit /fluentd/vendor/bundle/ruby/2.6.0/bin/fluentd -c /fluentd/etc/fluent.conf -p /fluentd/plugins --gemfile /fluentd/Gemfile --under-supervisor"
    }
}
{
    "output": "01:20:58.560320000: Warning Service account created in kube namespace (user=system:kube-controller-manager serviceaccount=cronjob-controller ns=kube-system)",
    "priority": "Warning",
    "rule": "Service Account Created in Kube Namespace",
    "time": "2021-02-10T01:20:58.560320000Z",
    "output_fields": {
        "jevt.time": "01:20:58.560320000",
        "ka.target.name": "cronjob-controller",
        "ka.target.namespace": "kube-system",
        "ka.user.name": "system:kube-controller-manager"
    }
}
{
    "output": "01:29:27.514302976: Warning Service account created in kube namespace (user=system:kube-controller-manager serviceaccount=pod-garbage-collector ns=kube-system)",
    "priority": "Warning",
    "rule": "Service Account Created in Kube Namespace",
    "time": "2021-02-10T01:29:27.514302976Z",
    "output_fields": {
        "jevt.time": "01:29:27.514302976",
        "ka.target.name": "pod-garbage-collector",
        "ka.target.namespace": "kube-system",
        "ka.user.name": "system:kube-controller-manager"
    }
}
{
    "output": "01:40:38.605422080: Warning Service account created in kube namespace (user=system:kube-controller-manager serviceaccount=resourcequota-controller ns=kube-system)",
    "priority": "Warning",
    "rule": "Service Account Created in Kube Namespace",
    "time": "2021-02-10T01:40:38.605422080Z",
    "output_fields": {
        "jevt.time": "01:40:38.605422080",
        "ka.target.name": "resourcequota-controller",
        "ka.target.namespace": "kube-system",
        "ka.user.name": "system:kube-controller-manager"
    }
}


{
    "output": "14:06:48.023231000: Notice Container with sensitive mount started (user=root user_loginuid=0 command=container:8f42f8572285 k8s.ns=prometheus k8s.pod=prometheus-node-exporter-rhxtb container=8f42f8572285 image=prom/node-exporter:v1.0.1 mounts=/proc:/host/proc:ro:false:rprivate,/sys:/host/sys:ro:false:rprivate,/var/lib/kubelet/pods/53b8af2f-896c-4510-8922-26454cd9c0f7/volumes/kubernetes.io~secret/prometheus-node-exporter-token-wg7d2:/var/run/secrets/kubernetes.io/serviceaccount:ro:false:rprivate,/var/lib/kubelet/pods/53b8af2f-896c-4510-8922-26454cd9c0f7/etc-hosts:/etc/hosts::true:rprivate,/var/lib/kubelet/pods/53b8af2f-896c-4510-8922-26454cd9c0f7/containers/prometheus-node-exporter/ac5d0b0a:/dev/termination-log::true:rprivate) k8s.ns=prometheus k8s.pod=prometheus-node-exporter-rhxtb container=8f42f8572285 k8s.ns=prometheus k8s.pod=prometheus-node-exporter-rhxtb container=8f42f8572285 k8s.ns=prometheus k8s.pod=prometheus-node-exporter-rhxtb container=8f42f8572285",
    "priority": "Notice",
    "rule": "Launch Sensitive Mount Container",
    "time": "2021-02-10T14:06:48.023231000Z",
    "output_fields": {
        "container.id": "8f42f8572285",
        "container.image.repository": "prom/node-exporter",
        "container.image.tag": "v1.0.1",
        "container.mounts": "/proc:/host/proc:ro:false:rprivate,/sys:/host/sys:ro:false:rprivate,/var/lib/kubelet/pods/53b8af2f-896c-4510-8922-26454cd9c0f7/volumes/kubernetes.io~secret/prometheus-node-exporter-token-wg7d2:/var/run/secrets/kubernetes.io/serviceaccount:ro:false:rprivate,/var/lib/kubelet/pods/53b8af2f-896c-4510-8922-26454cd9c0f7/etc-hosts:/etc/hosts::true:rprivate,/var/lib/kubelet/pods/53b8af2f-896c-4510-8922-26454cd9c0f7/containers/prometheus-node-exporter/ac5d0b0a:/dev/termination-log::true:rprivate",
        "evt.time": 1612966008023231000,
        "k8s.ns.name": "prometheus",
        "k8s.pod.name": "prometheus-node-exporter-rhxtb",
        "proc.cmdline": "container:8f42f8572285",
        "user.loginuid": 0,
        "user.name": "root"
    }
}


"output": "12:32:30.830213000: Notice Container with sensitive mount started (user=<NA> user_loginuid=0 command=container:cc1cd46a7d61 k8s.ns=default k8s.pod=my-datadog-release-wrrg7 container=cc1cd46a7d61 image=gcr.io/datadoghq/agent:7.23.1 mounts=/sys/fs/cgroup:/host/sys/fs/cgroup:ro:false:rprivate,/var/lib/docker/volumes/38d2a16febc1bce33090fd1639ad0045a5c04238bc7d019994936241388ea243/_data:/var/log/datadog::true:,/var/lib/kubelet/pods/8f52eb5a-219b-4692-885f-c77669c61897/volume-subpaths/installinfo/agent/0:/etc/datadog-agent/install_info:ro:false:rprivate,/var/lib/kubelet/pods/8f52eb5a-219b-4692-885f-c77669c61897/volumes/kubernetes.io~empty-dir/config:/etc/datadog-agent::true:rprivate,/var/lib/kubelet/pods/8f52eb5a-219b-4692-885f-c77669c61897/volumes/kubernetes.io~secret/my-datadog-release-token-hdb6g:/var/run/secrets/kubernetes.io/serviceaccount:ro:false:rprivate,/var/lib/kubelet/pods/8f52eb5a-219b-4692-885f-c77669c61897/etc-hosts:/etc/hosts::true:rprivate,/var/lib/kubelet/pods/8f52eb5a-219b-4692-885f-c77669c61897/containers/agent/b81e41fb:/dev/termination-log::true:rprivate,/var/lib/docker/volumes/f119e7fc92678555a32cae883eeb99dc9c00b63a4938c291864bc3361a743460/_data:/var/run/s6::true:,/var/lib/docker/volumes/4c6ae375c01227ad905c749b41d28f971e15d95fe453193d1fb30f9421fd52f5/_data:/tmp::true:,/var/run:/host/var/run:ro:false:rprivate,/proc:/host/proc:ro:false:rprivate) k8s.ns=default k8s.pod=my-datadog-release-wrrg7 container=cc1cd46a7d61",
"output_fields": {
    "container.id": "cc1cd46a7d61",
    "container.image.repository": "gcr.io/datadoghq/agent",
    "container.image.tag": "7.23.1",
    "container.mounts": "/sys/fs/cgroup:/host/sys/fs/cgroup:ro:false:rprivate,/var/lib/docker/volumes/38d2a16febc1bce33090fd1639ad0045a5c04238bc7d019994936241388ea243/_data:/var/log/datadog::true:,/var/lib/kubelet/pods/8f52eb5a-219b-4692-885f-c77669c61897/volume-subpaths/installinfo/agent/0:/etc/datadog-agent/install_info:ro:false:rprivate,/var/lib/kubelet/pods/8f52eb5a-219b-4692-885f-c77669c61897/volumes/kubernetes.io~empty-dir/config:/etc/datadog-agent::true:rprivate,/var/lib/kubelet/pods/8f52eb5a-219b-4692-885f-c77669c61897/volumes/kubernetes.io~secret/my-datadog-release-token-hdb6g:/var/run/secrets/kubernetes.io/serviceaccount:ro:false:rprivate,/var/lib/kubelet/pods/8f52eb5a-219b-4692-885f-c77669c61897/etc-hosts:/etc/hosts::true:rprivate,/var/lib/kubelet/pods/8f52eb5a-219b-4692-885f-c77669c61897/containers/agent/b81e41fb:/dev/termination-log::true:rprivate,/var/lib/docker/volumes/f119e7fc92678555a32cae883eeb99dc9c00b63a4938c291864bc3361a743460/_data:/var/run/s6::true:,/var/lib/docker/volumes/4c6ae375c01227ad905c749b41d28f971e15d95fe453193d1fb30f9421fd52f5/_data:/tmp::true:,/var/run:/host/var/run:ro:false:rprivate,/proc:/host/proc:ro:false:rprivate",
    "evt.time": 1612960350830213000,
    "k8s.ns.name": "default",
    "k8s.pod.name": "my-datadog-release-wrrg7",
    "proc.cmdline": "container:cc1cd46a7d61",
    "user.loginuid": 0,
    "user.name": null
},
"priority": "Notice",
"rule": "Launch Sensitive Mount Container",
"time": "2021-02-10T12:32:30.830213000Z"
}




