### PR TITLE
Add flex to docker for building bpf module on recent amazon linux2

### DIFF
--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -18,10 +18,12 @@ RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 	bash-completion \
 	bc \
+	bison \
 	clang-7 \
 	ca-certificates \
 	curl \
 	dkms \
+	flex \
 	gnupg2 \
 	gcc \
 	jq \


### PR DESCRIPTION
Flex is needed for building bpf module on recent amazon linux images.

https://github.com/falcosecurity/falco/issues/1558



**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:
/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:
/area build

> /area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
The bpf module fails to build on recent amazon linux2 versions with docker (k8s) deploys.

**Which issue(s) this PR fixes**:
https://github.com/falcosecurity/falco/issues/1558

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1558

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
