### PR TITLE
Update falco_rules : Remove apt-config utility from debian_packages monitoring list

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -211,7 +211,7 @@
 - list: deb_binaries
   items: [dpkg, dpkg-preconfigu, dpkg-reconfigur, dpkg-divert, apt, apt-get, aptitude,
     frontend, preinst, add-apt-reposit, apt-auto-remova, apt-key,
-    apt-listchanges, unattended-upgr, apt-add-reposit, apt-config, apt-cache, apt.systemd.dai
+    apt-listchanges, unattended-upgr, apt-add-reposit, apt-cache, apt.systemd.dai
     ]
 
 # The truncated dpkg-preconfigu is intentional, process names are


### PR DESCRIPTION
apt-config is a read-only utility and cannot mutate the container. Hence it is suggested to remove it from monitoring list to reduce false positive alerts. For more details refer to slack : https://kubernetes.slack.com/archives/CMWH3EH32/p1615341172249000

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind rule-update

**Any specific area of the project related to this PR?**

 /area rules

**What this PR does / why we need it**: Removed apt-config utility from debian packages monitoring list

**Which issue(s) this PR fixes**: Reduces false positive alerts reported for applications using apt-config within containers


**Special notes for your reviewer**: Please refer to slack https://kubernetes.slack.com/archives/CMWH3EH32/p1615341172249000 for more details

**Does this PR introduce a user-facing change?**: 

```release-note
rule(list deb_binaries): remove `apt-config`
```
