### PR TITLE
publish packages to S3 (download.falco.org)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,7 +368,7 @@ jobs:
           root: /
           paths:
             - build/release/*.rpm
-  # Publish the packages
+  # Publish the dev packages
   "publish/packages-dev":
     docker:
       - image: docker.io/amazon/aws-cli:latest
@@ -507,32 +507,44 @@ jobs:
   # Publish the packages
   "publish/packages":
     docker:
-      - image: docker.bintray.io/jfrog/jfrog-cli-go:latest
+      - image: docker.io/amazon/aws-cli:latest
     steps:
       - attach_workspace:
           at: /
       - run:
-          name: Create versions
+          name: Setup
           command: |
-            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            jfrog bt vs falcosecurity/deb/falco/${FALCO_VERSION} --user poiana --key ${BINTRAY_SECRET} || jfrog bt vc falcosecurity/deb/falco/${FALCO_VERSION} --desc="Falco (${CIRCLE_TAG})" --released=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z") --vcs-tag=${CIRCLE_TAG} --user poiana --key ${BINTRAY_SECRET}
-            jfrog bt vs falcosecurity/rpm/falco/${FALCO_VERSION} --user poiana --key ${BINTRAY_SECRET} || jfrog bt vc falcosecurity/rpm/falco/${FALCO_VERSION} --desc="Falco (${CIRCLE_TAG})" --released=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z") --vcs-tag=${CIRCLE_TAG} --user poiana --key ${BINTRAY_SECRET}
-            jfrog bt vs falcosecurity/bin/falco/${FALCO_VERSION} --user poiana --key ${BINTRAY_SECRET} || jfrog bt vc falcosecurity/bin/falco/${FALCO_VERSION} --desc="Falco (${CIRCLE_TAG})" --released=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z") --vcs-tag=${CIRCLE_TAG} --user poiana --key ${BINTRAY_SECRET}
-      - run:
-          name: Publish deb
-          command: |
-            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            jfrog bt u /build/release/falco-${FALCO_VERSION}-x86_64.deb falcosecurity/deb/falco/${FALCO_VERSION} stable/ --deb stable/main/amd64 --user poiana --key ${BINTRAY_SECRET} --publish --override
+            yum update -y
+            yum install createrepo gpg -y
+            echo $GPG_KEY | base64 -d | gpg --import
       - run:
           name: Publish rpm
           command: |
             FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            jfrog bt u /build/release/falco-${FALCO_VERSION}-x86_64.rpm falcosecurity/rpm/falco/${FALCO_VERSION} --user poiana --key ${BINTRAY_SECRET} --publish --override
+            /source/falco/scripts/publish-rpm -f /build/release/falco-${FALCO_VERSION}-x86_64.rpm -r rpm
       - run:
           name: Publish bin
           command: |
             FALCO_VERSION=$(cat /build-static/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            jfrog bt u /build-static/release/falco-${FALCO_VERSION}-x86_64.tar.gz falcosecurity/bin/falco/${FALCO_VERSION} x86_64/ --user poiana --key ${BINTRAY_SECRET} --publish --override
+            /source/falco/scripts/publish-bin -f /build-static/release/falco-${FALCO_VERSION}-x86_64.tar.gz -r bin -a x86_64
+  "publish/packages-deb":
+    docker:
+      - image: docker.io/debian:stable
+    steps:
+      - attach_workspace:
+          at: /
+      - run:
+          name: Setup
+          command: |
+            apt update -y
+            apt-get install apt-utils bzip2 gpg python python-pip -y
+            pip install awscli
+            echo $GPG_KEY | base64 -d | gpg --import
+      - run:
+          name: Publish deb
+          command: |
+            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
+            /source/falco/scripts/publish-deb -f /build/release/falco-${FALCO_VERSION}-x86_64.deb -r deb
   # Publish docker packages
   "publish/docker":
     docker:
@@ -734,10 +746,24 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
+      - "publish/packages-deb":
+          context:
+            - falco
+            - test-infra
+          requires:
+            - "build/centos7"
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
       - "publish/docker":
-          context: falco
+          context:
+            - falco
+            - test-infra
           requires:
             - "publish/packages"
+            - "publish/packages-deb"
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,32 +371,44 @@ jobs:
   # Publish the packages
   "publish/packages-dev":
     docker:
-      - image: docker.bintray.io/jfrog/jfrog-cli-go:latest
+      - image: docker.io/amazon/aws-cli:latest
     steps:
       - attach_workspace:
           at: /
       - run:
-          name: Create versions
+          name: Setup
           command: |
-            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            jfrog bt vs falcosecurity/deb-dev/falco/${FALCO_VERSION} --user poiana --key ${BINTRAY_SECRET} || jfrog bt vc falcosecurity/deb-dev/falco/${FALCO_VERSION} --desc="Falco (master)" --github-rel-notes=CHANGELOG.md --released=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z") --vcs-tag=${CIRCLE_SHA1} --user poiana --key ${BINTRAY_SECRET}
-            jfrog bt vs falcosecurity/rpm-dev/falco/${FALCO_VERSION} --user poiana --key ${BINTRAY_SECRET} || jfrog bt vc falcosecurity/rpm-dev/falco/${FALCO_VERSION} --desc="Falco (master)" --github-rel-notes=CHANGELOG.md --released=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z") --vcs-tag=${CIRCLE_SHA1} --user poiana --key ${BINTRAY_SECRET}
-            jfrog bt vs falcosecurity/bin-dev/falco/${FALCO_VERSION} --user poiana --key ${BINTRAY_SECRET} || jfrog bt vc falcosecurity/bin-dev/falco/${FALCO_VERSION} --desc="Falco (master)" --github-rel-notes=CHANGELOG.md --released=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z") --vcs-tag=${CIRCLE_SHA1} --user poiana --key ${BINTRAY_SECRET}
-      - run:
-          name: Publish deb-dev
-          command: |
-            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            jfrog bt u /build/release/falco-${FALCO_VERSION}-x86_64.deb falcosecurity/deb-dev/falco/${FALCO_VERSION} stable/ --deb stable/main/amd64 --user poiana --key ${BINTRAY_SECRET} --publish --override
+            yum update -y
+            yum install createrepo gpg -y
+            echo $GPG_KEY | base64 -d | gpg --import
       - run:
           name: Publish rpm-dev
           command: |
             FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            jfrog bt u /build/release/falco-${FALCO_VERSION}-x86_64.rpm falcosecurity/rpm-dev/falco/${FALCO_VERSION} --user poiana --key ${BINTRAY_SECRET} --publish --override
+            /source/falco/scripts/publish-rpm -f /build/release/falco-${FALCO_VERSION}-x86_64.rpm -r rpm-dev
       - run:
           name: Publish bin-dev
           command: |
             FALCO_VERSION=$(cat /build-static/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            jfrog bt u /build-static/release/falco-${FALCO_VERSION}-x86_64.tar.gz falcosecurity/bin-dev/falco/${FALCO_VERSION} x86_64/ --user poiana --key ${BINTRAY_SECRET} --publish --override
+            /source/falco/scripts/publish-bin -f /build-static/release/falco-${FALCO_VERSION}-x86_64.tar.gz -r bin-dev -a x86_64
+  "publish/packages-deb-dev":
+    docker:
+      - image: docker.io/debian:stable
+    steps:
+      - attach_workspace:
+          at: /
+      - run:
+          name: Setup
+          command: |
+            apt update -y
+            apt-get install apt-utils bzip2 gpg python python-pip -y
+            pip install awscli
+            echo $GPG_KEY | base64 -d | gpg --import
+      - run:
+          name: Publish deb-dev
+          command: |
+            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
+            /source/falco/scripts/publish-deb -f /build/release/falco-${FALCO_VERSION}-x86_64.deb -r deb-dev
   # Clenup the Falco development release packages
   "cleanup/packages-dev":
     docker:
@@ -635,7 +647,9 @@ workflows:
           requires:
             - "tests/integration"
       - "publish/packages-dev":
-          context: falco
+          context:
+            - falco
+            - test-infra
           filters:
             tags:
               ignore: /.*/
@@ -644,15 +658,28 @@ workflows:
           requires:
             - "rpm/sign"
             - "tests/integration-static"
-      - "cleanup/packages-dev":
-          context: falco
+      - "publish/packages-deb-dev":
+          context:
+            - falco
+            - test-infra
           filters:
             tags:
               ignore: /.*/
             branches:
               only: master
           requires:
-            - "publish/packages-dev"
+            - "tests/integration-static"
+      # todo(leogr): the cleanup job is intende to work with bintray, now deprecated,
+      #              do we still need it?
+      # - "cleanup/packages-dev":
+      #     context: falco
+      #     filters:
+      #       tags:
+      #         ignore: /.*/
+      #       branches:
+      #         only: master
+      #     requires:
+      #       - "publish/packages-dev"
       - "publish/docker-dev":
           context: falco
           filters:
@@ -662,6 +689,7 @@ workflows:
               only: master
           requires:
             - "publish/packages-dev"
+            - "publish/packages-deb-dev"
             - "tests/driver-loader/integration"
       - "publish/container-images-aws-dev":
           context: test-infra # contains Falco AWS credentials

--- a/README.md
+++ b/README.md
@@ -11,11 +11,54 @@ Want to talk? Join us on the [#falco](https://kubernetes.slack.com/archives/CMWH
 
 Read the [change log](CHANGELOG.md).
 
+<!-- 
+Badges in the following table are constructed by using the
+https://img.shields.io/badge/dynamic/xml endpoint.
+
+Parameters are configured for fetching packages from S3 before 
+(filtered by prefix, sorted in ascending order) and for picking 
+the latest package by using an XPath selector after.
+
+
+- Common query parameters:
+
+color=#300aec7
+style=flat-square
+label=Falco
+
+
+- DEB packages parameters:
+
+url=https://falco-distribution.s3-eu-west-1.amazonaws.com/?prefix=packages/deb/stable/falco-
+query=substring-before(substring-after((/*[name()='ListBucketResult']/*[name()='Contents'])[last()]/*[name()='Key'],"falco-"),".asc")
+
+
+- RPM packages parameters:
+
+url=https://falco-distribution.s3-eu-west-1.amazonaws.com/?prefix=packages/rpm/falco-
+query=substring-before(substring-after((/*[name()='ListBucketResult']/*[name()='Contents'])[last()]/*[name()='Key'],"falco-"),".asc")
+
+
+BIN packages parameters:
+
+url=https://falco-distribution.s3-eu-west-1.amazonaws.com/?prefix=packages/bin/x86_64/falco-
+query=substring-after((/*[name()='ListBucketResult']/*[name()='Contents'])[last()]/*[name()='Key'], "falco-")
+
+
+Notes:
+ - if more than 1000 items are present under as S3 prefix, 
+   the actual latest package will be not picked;
+   see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
+ - for `-dev` packages, the S3 prefix is modified accordingly
+ - finally, all parameters are URL encoded and appended to the badge endpoint
+
+-->
+
 |        | development                                                                                                                 | stable                                                                                                              |
 |--------|-----------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| rpm    | [![rpm-dev](https://img.shields.io/bintray/v/falcosecurity/rpm-dev/falco?label=Falco&color=%2300aec7&style=flat-square)][1] | [![rpm](https://img.shields.io/bintray/v/falcosecurity/rpm/falco?label=Falco&color=%23005763&style=flat-square)][2] |
-| deb    | [![deb-dev](https://img.shields.io/bintray/v/falcosecurity/deb-dev/falco?label=Falco&color=%2300aec7&style=flat-square)][3] | [![deb](https://img.shields.io/bintray/v/falcosecurity/deb/falco?label=Falco&color=%23005763&style=flat-square)][4] |
-| binary | [![bin-dev](https://img.shields.io/bintray/v/falcosecurity/bin-dev/falco?label=Falco&color=%2300aec7&style=flat-square)][5] | [![bin](https://img.shields.io/bintray/v/falcosecurity/bin/falco?label=Falco&color=%23005763&style=flat-square)][6] |
+| rpm    | [![rpm-dev](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Frpm-dev%2Ffalco-)][1] | [![rpm](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Frpm%2Ffalco-)][2] |
+| deb    | [![deb-dev](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fdeb-dev%2Fstable%2Ffalco-)][3] | [![deb](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-before%28substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%22falco-%22%29%2C%22.asc%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fdeb%2Fstable%2Ffalco-)][4] |
+| binary | [![bin-dev](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%20%22falco-%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fbin-dev%2Fx86_64%2Ffalco-)][5] | [![bin](https://img.shields.io/badge/dynamic/xml?color=%2300aec7&style=flat-square&label=Falco&query=substring-after%28%28%2F%2A%5Bname%28%29%3D%27ListBucketResult%27%5D%2F%2A%5Bname%28%29%3D%27Contents%27%5D%29%5Blast%28%29%5D%2F%2A%5Bname%28%29%3D%27Key%27%5D%2C%20%22falco-%22%29&url=https%3A%2F%2Ffalco-distribution.s3-eu-west-1.amazonaws.com%2F%3Fprefix%3Dpackages%2Fbin%2Fx86_64%2Ffalco-)][6] |
 
 ---
 
@@ -99,9 +142,9 @@ Please report security vulnerabilities following the community process documente
 Falco is licensed to you under the [Apache 2.0](./COPYING) open source license.
 
 
-[1]: https://dl.bintray.com/falcosecurity/rpm-dev
-[2]: https://dl.bintray.com/falcosecurity/rpm
-[3]: https://dl.bintray.com/falcosecurity/deb-dev/stable
-[4]: https://dl.bintray.com/falcosecurity/deb/stable
-[5]: https://dl.bintray.com/falcosecurity/bin-dev/x86_64
-[6]: https://dl.bintray.com/falcosecurity/bin/x86_64
+[1]: https://download.falco.org/?prefix=packages/rpm-dev/
+[2]: https://download.falco.org/?prefix=packages/rpm/
+[3]: https://download.falco.org/?prefix=packages/deb-dev/stable/
+[4]: https://download.falco.org/?prefix=packages/deb/stable/
+[5]: https://download.falco.org/?prefix=packages/bin-dev/x86_64/
+[6]: https://download.falco.org/?prefix=packages/bin/x86_64/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -65,9 +65,9 @@ Now assume `x.y.z` is the new version.
 
     | Packages | Download                                                                                                                                               |
     | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-    | rpm      | [![rpm](https://img.shields.io/badge/Falco-x.y.z-%2300aec7?style=flat-square)](https://dl.bintray.com/falcosecurity/rpm/falco-x.y.z-x86_64.rpm)        |
-    | deb      | [![deb](https://img.shields.io/badge/Falco-x.y.z-%2300aec7?style=flat-square)](https://dl.bintray.com/falcosecurity/deb/stable/falco-x.y.z-x86_64.deb) |
-    | tgz      | [![tgz](https://img.shields.io/badge/Falco-x.y.z-%2300aec7?style=flat-square)](https://dl.bintray.com/falcosecurity/bin/x86_64/falco-x.y.z-x86_64.deb) |
+    | rpm      | [![rpm](https://img.shields.io/badge/Falco-x.y.z-%2300aec7?style=flat-square)](https://download.falco.org/packages/rpm/falco-x.y.z-x86_64.rpm)        |
+    | deb      | [![deb](https://img.shields.io/badge/Falco-x.y.z-%2300aec7?style=flat-square)](https://download.falco.org/packages/deb/stable/falco-x.y.z-x86_64.deb) |
+    | tgz      | [![tgz](https://img.shields.io/badge/Falco-x.y.z-%2300aec7?style=flat-square)](https://download.falco.org/packages/bin/x86_64/falco-x.y.z-x86_64.tar.gz) |
 
     | Images                                                                      |
     | --------------------------------------------------------------------------- |

--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -78,7 +78,7 @@ RUN rm -rf /usr/bin/clang \
 	&& ln -s /usr/bin/llc-7 /usr/bin/llc
 
 RUN curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | apt-key add - \
-	&& echo "deb https://dl.bintray.com/falcosecurity/${VERSION_BUCKET} stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list \
+	&& echo "deb https://download.falco.org/packages/${VERSION_BUCKET} stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list \
 	&& apt-get update -y \
 	&& if [ "$FALCO_VERSION" = "latest" ]; then apt-get install -y --no-install-recommends falco; else apt-get install -y --no-install-recommends falco=${FALCO_VERSION}; fi \
 	&& apt-get clean \

--- a/docker/no-driver/Dockerfile
+++ b/docker/no-driver/Dockerfile
@@ -6,14 +6,16 @@ ARG VERSION_BUCKET=bin
 ENV FALCO_VERSION=${FALCO_VERSION}
 ENV VERSION_BUCKET=${VERSION_BUCKET}
 
+RUN apt-get -y update && apt-get -y install gridsite-clients curl
+
 WORKDIR /
 
-ADD https://download.falco.org/packages/${VERSION_BUCKET}/x86_64/falco-${FALCO_VERSION}-x86_64.tar.gz /
-
-RUN tar -xvf falco-${FALCO_VERSION}-x86_64.tar.gz && \
-    rm -f falco-${FALCO_VERSION}-x86_64.tar.gz && \
+RUN curl -L -o falco.tar.gz \
+    https://download.falco.org/packages/${VERSION_BUCKET}/x86_64/falco-$(urlencode ${FALCO_VERSION})-x86_64.tar.gz && \
+    tar -xvf falco.tar.gz && \
+    rm -f falco.tar.gz && \
     mv falco-${FALCO_VERSION}-x86_64 falco && \
-    rm -rf falco/usr/src/falco-* falco/usr/bin/falco-driver-loader
+    rm -rf /falco/usr/src/falco-* /falco/usr/bin/falco-driver-loader
 
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /falco/etc/falco/falco.yaml > /falco/etc/falco/falco.yaml.new \
     && mv /falco/etc/falco/falco.yaml.new /falco/etc/falco/falco.yaml

--- a/docker/no-driver/Dockerfile
+++ b/docker/no-driver/Dockerfile
@@ -8,7 +8,7 @@ ENV VERSION_BUCKET=${VERSION_BUCKET}
 
 WORKDIR /
 
-ADD https://bintray.com/api/ui/download/falcosecurity/${VERSION_BUCKET}/x86_64/falco-${FALCO_VERSION}-x86_64.tar.gz /
+ADD https://download.falco.org/packages/${VERSION_BUCKET}/x86_64/falco-${FALCO_VERSION}-x86_64.tar.gz /
 
 RUN tar -xvf falco-${FALCO_VERSION}-x86_64.tar.gz && \
     rm -f falco-${FALCO_VERSION}-x86_64.tar.gz && \

--- a/scripts/publish-bin
+++ b/scripts/publish-bin
@@ -35,9 +35,13 @@ if [ -z "${file}" ] || [ -z "${repo}" ] || [ -z "${arch}" ]; then
     usage
 fi
 
+# settings
 s3_bucket_repo="s3://falco-distribution/packages/${repo}/${arch}"
+cloudfront_path="/packages/${repo}/${arch}"
 
 # publish
 package=$(basename -- ${file})
 echo "Publishing ${package} to ${s3_bucket_repo}..."
 aws s3 cp ${file} ${s3_bucket_repo}/${package} --acl public-read
+
+aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}

--- a/scripts/publish-bin
+++ b/scripts/publish-bin
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -e
+
+usage() {
+    echo "usage: $0 -f <package.tar.gz> -r <bin|bin-dev> -a <arch>"
+    exit 1
+}
+
+# parse options
+while getopts ":f::r::a:" opt; do
+    case "${opt}" in
+        f )
+          file=${OPTARG}
+          ;;
+        r )
+          repo="${OPTARG}"
+          [[ "${repo}" == "bin" || "${repo}" == "bin-dev" ]] || usage
+          ;;
+        a )
+          arch=${OPTARG}
+          ;;
+        : )
+          echo "invalid option: ${OPTARG} requires an argument" 1>&2
+          exit 1
+          ;;
+        \?)
+          echo "invalid option: ${OPTARG}" 1>&2
+          exit 1
+          ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${file}" ] || [ -z "${repo}" ] || [ -z "${arch}" ]; then
+    usage
+fi
+
+s3_bucket_repo="s3://falco-distribution/packages/${repo}/${arch}"
+
+# publish
+package=$(basename -- ${file})
+echo "Publishing ${package} to ${s3_bucket_repo}..."
+aws s3 cp ${file} ${s3_bucket_repo}/${package} --acl public-read

--- a/scripts/publish-deb
+++ b/scripts/publish-deb
@@ -107,6 +107,7 @@ check_program aws
 # settings
 debSuite=stable
 s3_bucket_repo="s3://falco-distribution/packages/${repo}"
+cloudfront_path="/packages/${repo}"
 tmp_repo_path=/tmp/falco-$repo
 
 # prepere repository local copy
@@ -125,3 +126,7 @@ echo "Publishing ${package} to ${s3_bucket_repo}..."
 aws s3 cp ${tmp_repo_path}/${debSuite}/${package} ${s3_bucket_repo}/${debSuite}/${package} --acl public-read
 aws s3 cp ${tmp_repo_path}/${debSuite}/${package}.asc ${s3_bucket_repo}/${debSuite}/${package}.asc --acl public-read
 aws s3 sync ${tmp_repo_path}/dists ${s3_bucket_repo}/dists --delete --acl public-read
+
+aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}
+aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}.asc
+aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/dists/*

--- a/scripts/publish-deb
+++ b/scripts/publish-deb
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -e
+
+usage() {
+    echo "usage: $0 -f <package.deb> -r <deb|deb-dev>"
+    exit 1
+}
+
+check_program() {
+  if ! command -v $1 &> /dev/null
+  then
+      echo "$1 is required and could not be found"
+      exit
+  fi
+}
+
+# Add a package to the local DEB repository
+#
+# $1: path of the repository.
+# $2: suite (eg. "stable")
+# $3: path of the DEB file.
+add_deb() {
+    cp -f $3 $1/$2
+    pushd $1/$2 > /dev/null
+    rm -f $(basename -- $3).asc
+    gpg --detach-sign --armor $(basename -- $3)
+    popd > /dev/null
+}
+
+# Update the local DEB repository
+#
+# $1: path of the repository
+# $2: suite (eg. "stable")
+update_repo() {
+    # fixme(leogr): we cannot use apt-ftparchive --arch packages ...
+    # since our .deb files ends with "_x86_64" instead of "amd64".
+    # See https://manpages.debian.org/jessie/apt-utils/apt-ftparchive.1.en.html
+    #
+    # As a workaround, we temporarily stick here with "amd64" 
+    # (the only supported arch at the moment)
+    local arch=amd64
+
+    local component=main
+    local debs_dir=$2
+    local release_dir=dists/$2
+    local packages_dir=${release_dir}/${component}/binary-${arch}
+
+    pushd $1 > /dev/null
+
+    # packages metadata
+    apt-ftparchive packages ${debs_dir} > ${packages_dir}/Packages
+    gzip -c ${packages_dir}/Packages > ${packages_dir}/Packages.gz
+    bzip2 -z -c ${packages_dir}/Packages > ${packages_dir}/Packages.bz2
+    
+    # release metadata
+    apt-ftparchive release \
+      -o APT::FTPArchive::Release::Origin=Falco \
+      -o APT::FTPArchive::Release::Label=Falco \
+      -o APT::FTPArchive::Release::Suite=$2 \
+      -o APT::FTPArchive::Release::Codename=$2 \
+      -o APT::FTPArchive::Release::Components=${component} \
+      -o APT::FTPArchive::Release::Architectures=${arch} \
+      ${release_dir} > ${release_dir}/Release
+
+    # release signature
+    gpg --detach-sign --armor ${release_dir}/Release
+    rm -f ${release_dir}/Release.gpg
+    mv ${release_dir}/Release.asc ${release_dir}/Release.gpg
+
+    popd > /dev/null
+}
+
+# parse options
+while getopts ":f::r:" opt; do
+    case "${opt}" in
+        f )
+          file=${OPTARG}
+          ;;
+        r )
+          repo="${OPTARG}"
+          [[ "${repo}" == "deb" || "${repo}" == "deb-dev" ]] || usage
+          ;;
+        : )
+          echo "invalid option: ${OPTARG} requires an argument" 1>&2
+          exit 1
+          ;;
+        \?)
+          echo "invalid option: ${OPTARG}" 1>&2
+          exit 1
+          ;;
+    esac
+done
+shift $((OPTIND-1))
+
+# check options
+if [ -z "${file}" ] || [ -z "${repo}" ]; then
+    usage
+fi
+
+# check prerequisites
+check_program apt-ftparchive
+check_program gzip
+check_program bzip2
+check_program gpg
+check_program aws
+
+# settings
+debSuite=stable
+s3_bucket_repo="s3://falco-distribution/packages/${repo}"
+tmp_repo_path=/tmp/falco-$repo
+
+# prepere repository local copy
+echo "Fetching ${s3_bucket_repo}..."
+mkdir -p ${tmp_repo_path}
+aws s3 cp ${s3_bucket_repo} ${tmp_repo_path} --recursive
+
+# update the repo
+echo "Adding ${file}..."
+add_deb ${tmp_repo_path} ${debSuite} ${file}
+update_repo ${tmp_repo_path} ${debSuite}
+
+# publish
+package=$(basename -- ${file})
+echo "Publishing ${package} to ${s3_bucket_repo}..."
+aws s3 cp ${tmp_repo_path}/${debSuite}/${package} ${s3_bucket_repo}/${debSuite}/${package} --acl public-read
+aws s3 cp ${tmp_repo_path}/${debSuite}/${package}.asc ${s3_bucket_repo}/${debSuite}/${package}.asc --acl public-read
+aws s3 sync ${tmp_repo_path}/dists ${s3_bucket_repo}/dists --delete --acl public-read

--- a/scripts/publish-rpm
+++ b/scripts/publish-rpm
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -e
+
+usage() {
+    echo "usage: $0 -f <package.rpm> -r <rpm|rpm-dev>"
+    exit 1
+}
+
+check_program() {
+  if ! command -v $1 &> /dev/null
+  then
+      echo "$1 is required and could not be found"
+      exit
+  fi
+}
+
+# Add a package to the local RPM repository
+#
+# $1: path of the repository.
+# $2: path of the RPM file.
+add_rpm() {
+    cp -f $2 $1
+    pushd $1 > /dev/null
+    rm -f $(basename -- $2).asc
+    gpg --detach-sign --armor $(basename -- $2)
+    popd > /dev/null
+}
+
+# Update the local RPM repository
+#
+# $1: path of the repository.
+update_repo() {
+    pushd $1 > /dev/null
+    createrepo --update --no-database .
+    rm -f repodata/repomd.xml.asc
+    gpg --detach-sign --armor repodata/repomd.xml
+    popd > /dev/null
+}
+
+
+# parse options
+while getopts ":f::r:" opt; do
+    case "${opt}" in
+        f )
+          file=${OPTARG}
+          ;;
+        r )
+          repo="${OPTARG}"
+          [[ "${repo}" == "rpm" || "${repo}" == "rpm-dev" ]] || usage
+          ;;
+        : )
+          echo "invalid option: ${OPTARG} requires an argument" 1>&2
+          exit 1
+          ;;
+        \?)
+          echo "invalid option: ${OPTARG}" 1>&2
+          exit 1
+          ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${file}" ] || [ -z "${repo}" ]; then
+    usage
+fi
+
+# check prerequisites
+check_program createrepo
+check_program gpg
+check_program aws
+
+# settings
+s3_bucket_repo="s3://falco-distribution/packages/${repo}"
+tmp_repo_path=/tmp/falco-$repo
+
+# prepere repository local copy
+echo "Fetching ${s3_bucket_repo}..."
+mkdir -p ${tmp_repo_path}
+aws s3 cp ${s3_bucket_repo} ${tmp_repo_path} --recursive
+
+# update the repo
+echo "Adding ${file}..."
+add_rpm ${tmp_repo_path} ${file}
+update_repo ${tmp_repo_path}
+
+# publish
+package=$(basename -- ${file})
+echo "Publishing ${package} to ${s3_bucket_repo}..."
+aws s3 cp ${tmp_repo_path}/${package} ${s3_bucket_repo}/${package} --acl public-read
+aws s3 cp ${tmp_repo_path}/${package}.asc ${s3_bucket_repo}/${package}.asc --acl public-read
+aws s3 sync ${tmp_repo_path}/repodata ${s3_bucket_repo}/repodata --delete --acl public-read

--- a/scripts/publish-rpm
+++ b/scripts/publish-rpm
@@ -71,6 +71,7 @@ check_program aws
 
 # settings
 s3_bucket_repo="s3://falco-distribution/packages/${repo}"
+cloudfront_path="/packages/${repo}"
 tmp_repo_path=/tmp/falco-$repo
 
 # prepere repository local copy
@@ -89,3 +90,7 @@ echo "Publishing ${package} to ${s3_bucket_repo}..."
 aws s3 cp ${tmp_repo_path}/${package} ${s3_bucket_repo}/${package} --acl public-read
 aws s3 cp ${tmp_repo_path}/${package}.asc ${s3_bucket_repo}/${package}.asc --acl public-read
 aws s3 sync ${tmp_repo_path}/repodata ${s3_bucket_repo}/repodata --delete --acl public-read
+
+aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}
+aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}.asc
+aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/repodata/*


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build


**What this PR does / why we need it**:

This PR introduces scripts to deal with updates of Debian and RPM repositories and modify CI jobs to publish packages (ie. `bin-dev`, `deb-dev`, `rpm-dev`, `bin`, `deb`, `rpm`) to our S3 bucket which serves those files at https://download.falco.org/


**Which issue(s) this PR fixes**:

Fixes #1567

**Special notes for your reviewer**:

~~If this works as expected, a follow-up PR will update the configuration to publish stable packages too (ie. `bin`, `deb`, `rpm`) in the same way.~~
I'm confident that scripts work as expected, so I decided to include the stable packages too in this PR. A follow-up PR might come in case of unexpected issues.

The artifact cleanup job has been disabled since it is intended to work with Bintray only. If needed, we can refactor or clean up it in a follow-up PR.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
build: now Falco packages are published at download.falco.org
BREAKING CHANGE:  Bintray is deprecated, no new packages will be published at https://dl.bintray.com/falcosecurity/
```
