### PR TITLE
Use url-safe characters in falco version

### DIFF
--- a/cmake/modules/GetFalcoVersion.cmake
+++ b/cmake/modules/GetFalcoVersion.cmake
@@ -27,7 +27,7 @@ if(NOT FALCO_VERSION)
       set(FALCO_VERSION "0.0.0")
     endif()
     # Format FALCO_VERSION to be semver with prerelease and build part
-    string(REPLACE "-g" "+" FALCO_VERSION "${FALCO_VERSION}")
+    string(REPLACE "-g" "~" FALCO_VERSION "${FALCO_VERSION}")
   else()
     # A tag has been found: use it as the Falco version
     set(FALCO_VERSION "${FALCO_TAG}")


### PR DESCRIPTION
In some cases, you might want to host falco packages in a way where
they're directly accessible via http. The '+' character that separates
the version and the git hash ends up breaking naive solutions that don't
properly url-escape the package name before doing the http fetch.

Of course, clients can properly url-escape, but switching to a tilde is
url safe and I think still preserves the idea of separating the version
and hash.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Make the falco version a bit more url-friendly by using tilde as the version/hash separator instead of plus.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Make the falco version a bit more url-friendly by using tilde as the version/hash separator instead of plus.
```
