### PR TITLE
fix(.circleci): tar must be present in the image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,15 +371,17 @@ jobs:
   # Publish the dev packages
   "publish/packages-dev":
     docker:
-      - image: docker.io/amazon/aws-cli:latest
+      - image: docker.io/centos:7
     steps:
       - attach_workspace:
           at: /
       - run:
           name: Setup
           command: |
+            yum install epel-release -y
             yum update -y
-            yum install createrepo gpg tar -y
+            yum install createrepo gpg python python-pip -y
+            pip install awscli
             echo $GPG_KEY | base64 -d | gpg --import
       - run:
           name: Publish rpm-dev
@@ -507,15 +509,17 @@ jobs:
   # Publish the packages
   "publish/packages":
     docker:
-      - image: docker.io/amazon/aws-cli:latest
+      - image: docker.io/centos:7
     steps:
       - attach_workspace:
           at: /
       - run:
           name: Setup
           command: |
+            yum install epel-release -y
             yum update -y
-            yum install createrepo gpg tar -y
+            yum install createrepo gpg python python-pip -y
+            pip install awscli
             echo $GPG_KEY | base64 -d | gpg --import
       - run:
           name: Publish rpm


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Since `amazon/aws-cli` does not include the tar util (which must be present in the image, as per CircleCI requirement) we are switching from `amazon/aws-cli` to `centos`.

That should fix the broken CI job (see
https://app.circleci.com/pipelines/github/falcosecurity/falco/1391/workflows/c1e1bc39-f008-4644-b8bf-45d1105e1978/jobs/11263)
and complete #1577 (I hope :smile_cat: ).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.28.0
/cc @leodido 
/cc @fntlnz 

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
