### PR TITLE
fix(falco/test): bump pyyaml from 5.3.1 to 5.4

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -5,7 +5,7 @@ chardet==3.0.4
 idna==2.9
 pathtools==0.1.2
 pbr==5.4.5
-PyYAML==5.3.1
+PyYAML==5.4
 requests==2.23.0
 six==1.14.0
 stevedore==1.32.0


### PR DESCRIPTION


Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>



**What type of PR is this?**

/kind cleanup


**Any specific area of the project related to this PR?**


/area tests

> /area proposals

**What this PR does / why we need it**:

CVE-2020-14343 affects one of the dependencies the Falco (integration) test suite uses.

**Which issue(s) this PR fixes**:

NONE.

**Special notes for your reviewer**:

This **does not affect** Falco itself.

I'll build and publish a new `falco-tester` container image as soon as possible.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
