### PR TITLE
fix(userspace): handle exceptions for process_k8s_audit_event

### DIFF
--- a/userspace/engine/json_evt.cpp
+++ b/userspace/engine/json_evt.cpp
@@ -281,7 +281,11 @@ bool json_event_value::parse_as_int64(int64_t &intval, const std::string &val)
 			return false;
 		}
 	}
-	catch (std::invalid_argument &e)
+	catch(std::out_of_range &)
+	{
+		return false;
+	}
+	catch (std::invalid_argument &)
 	{
 		return false;
 	}

--- a/userspace/falco/webserver.cpp
+++ b/userspace/falco/webserver.cpp
@@ -84,7 +84,17 @@ bool k8s_audit_handler::accept_data(falco_engine *engine,
 	for(auto &jev : jevts)
 	{
 		std::unique_ptr<falco_engine::rule_result> res;
-		res = engine->process_k8s_audit_event(&jev);
+
+		try
+		{
+			res = engine->process_k8s_audit_event(&jev);
+		}
+		catch(...)
+		{
+			errstr = string("unkown error processing audit event");
+			fprintf(stderr, "%s\n", errstr.c_str());
+			return false;
+		}
 
 		if(res)
 		{


### PR DESCRIPTION
This fix has two major points in it:

- when `std::stoll` is used in parse_as_int64 handle all the exceptions it
can throw (https://en.cppreference.com/w/cpp/string/basic_string/stol)
- when `process_k8s_audit_event` an eventual exception in it does not
stop the webserver process. This is done by doing a catch all handle
outside it and by logging an error message to the caller as well as in
stderr

Signed-off-by: Lorenzo Fontana <lo@linux.com>


**What type of PR is this?**

/kind bug


**Any specific area of the project related to this PR?**


/area engine


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:


Fixes #1575

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix: do not stop the webserver for k8s audit logs when invalid data is coming in the event to be processed
```
