### PR TITLE
detect consecutive timeouts without events and alert accordingly to a configurable value

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -110,6 +110,7 @@ syscall_event_drops:
 # Here you can configure the maximum number of consecutive timeouts without an event
 # after which you want Falco to alert.
 # By default this value is set to 1000 consecutive timeouts without an event at all.
+# How this value maps to a time interval depends on the CPU frequency.
 
 syscall_event_timeouts:
   max_consecutives: 1000

--- a/falco.yaml
+++ b/falco.yaml
@@ -97,6 +97,23 @@ syscall_event_drops:
   rate: .03333
   max_burst: 1
 
+# Falco uses a shared buffer between the kernel and userspace to receive
+# the events (eg., system call information) in userspace.
+#
+# Anyways, the underlying libraries can also timeout for various reasons.
+# For example, there could have been issues while reading an event.
+# Or the particular event needs to be skipped.
+# Normally, it's very unlikely that Falco does not receive events consecutively.
+#
+# Falco is able to detect such uncommon situation.
+#
+# Here you can configure the maximum number of consecutive timeouts without an event
+# after which you want Falco to alert.
+# By default this value is set to 1000 consecutive timeouts without an event at all.
+
+syscall_event_timeouts:
+  max_consecutives: 1000
+
 # Falco continuously monitors outputs performance. When an output channel does not allow
 # to deliver an alert within a given deadline, an error is reported indicating
 # which output is blocking notifications.

--- a/userspace/engine/falco_utils.h
+++ b/userspace/engine/falco_utils.h
@@ -17,6 +17,8 @@ limitations under the License.
 
 */
 
+#pragma once
+
 #include <sstream>
 #include <fstream>
 #include <iostream>
@@ -24,7 +26,13 @@ limitations under the License.
 #include <thread>
 #include <nonstd/string_view.hpp>
 
-#pragma once
+#ifdef __GNUC__
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#else
+#define likely(x) (x)
+#define unlikely(x) (x)
+#endif
 
 namespace falco
 {

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -246,6 +246,12 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 	m_syscall_evt_drop_rate = m_config->get_scalar<double>("syscall_event_drops", "rate", .03333);
 	m_syscall_evt_drop_max_burst = m_config->get_scalar<double>("syscall_event_drops", "max_burst", 1);
 	m_syscall_evt_simulate_drops = m_config->get_scalar<bool>("syscall_event_drops", "simulate_drops", false);
+
+	m_syscall_evt_timeout_max_consecutives = m_config->get_scalar<uint32_t>("syscall_event_timeouts", "max_consecutives", 1000);
+	if(m_syscall_evt_timeout_max_consecutives == 0)
+	{
+		throw logic_error("Error reading config file(" + m_config_file + "): the maximum consecutive timeouts without an event must be an unsigned integer > 0");
+	}
 }
 
 void falco_configuration::read_rules_file_directory(const string &path, list<string> &rules_filenames)

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -219,13 +219,15 @@ public:
 	std::string m_webserver_k8s_healthz_endpoint;
 	bool m_webserver_ssl_enabled;
 	std::string m_webserver_ssl_certificate;
+
 	syscall_evt_drop_actions m_syscall_evt_drop_actions;
 	double m_syscall_evt_drop_threshold;
 	double m_syscall_evt_drop_rate;
 	double m_syscall_evt_drop_max_burst;
-
 	// Only used for testing
 	bool m_syscall_evt_simulate_drops;
+
+	uint32_t m_syscall_evt_timeout_max_consecutives;
 
 private:
 	void init_cmdline_options(std::list<std::string>& cmdline_options);

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -309,8 +309,11 @@ uint64_t do_inspect(falco_engine *engine,
 				{
 					std::string rule = "Falco internal: timeouts notification";
 					std::string msg = rule + ". " + std::to_string(config.m_syscall_evt_timeout_max_consecutives) + " consecutive timeouts without event.";
-					std::string last_event_time_str;
-					sinsp_utils::ts_to_string(duration_start, &last_event_time_str, false, true);
+					std::string last_event_time_str = "none";
+					if(duration_start > 0)
+					{
+						sinsp_utils::ts_to_string(duration_start, &last_event_time_str, false, true);
+					}
 					std::map<std::string, std::string> o = {
 						{"last_event_time", last_event_time_str},
 					};

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -37,6 +37,7 @@ limitations under the License.
 #include "utils.h"
 #include "chisel.h"
 #include "fields_info.h"
+#include "falco_utils.h"
 
 #include "event_drops.h"
 #include "configuration.h"
@@ -300,7 +301,7 @@ uint64_t do_inspect(falco_engine *engine,
 		}
 		else if(rc == SCAP_TIMEOUT)
 		{
-			if(ev == nullptr)
+			if(unlikely(ev == nullptr))
 			{
 				timeouts_since_last_success_or_msg++;
 				if(timeouts_since_last_success_or_msg > 100)
@@ -309,6 +310,7 @@ uint64_t do_inspect(falco_engine *engine,
 					std::string msg = rule + ". 100 consecutive timeouts without event.";
 					std::map<std::string, std::string> of;
 					outputs->handle_msg(duration_start, falco_common::PRIORITY_DEBUG, msg, rule, of);
+					// Reset the timeouts counter, Falco alerted
 					timeouts_since_last_success_or_msg = 0;
 				}
 			}
@@ -328,6 +330,7 @@ uint64_t do_inspect(falco_engine *engine,
 			throw sinsp_exception(inspector->getlasterr().c_str());
 		}
 
+		// Reset the timeouts counter, Falco succesfully got an event to process
 		timeouts_since_last_success_or_msg = 0;
 		if(duration_start == 0)
 		{


### PR DESCRIPTION
**What type of PR is this?**


/kind feature


**Any specific area of the project related to this PR?**

NONE

**What this PR does / why we need it**:

This PR makes Falco able to detect a very uncommon situation and alert the user about it.

As everyone probably already knows today, Falco receives events from the drivers through the [libraries](https://github.com/falcosecurity/libs).

Not all the events that the libraries emit are of interest to Falco.
For this reason and other more complex reasons (eg., timeout while reading the event from the ring buffer),
Falco receives timeouts (`SCAP_TIMEOUTS`).

**In the majority of cases**, when Falco receives a timeout it also receives an event that Falco discards.

But, if Falco receives **too many consecutive timeouts without the events** it is likely that something is going wrong at the lower level.

These code changes let the user configure how to detect such an unlikely situation and alert.

Through the `syscall_event_timeouts.max_consecutive` config field the user can instruct Falco after how many consecutive timeouts without an event to emit an alert (with DEBUG priority).

Other than the message, the alert will contain the current time and the time of the last processed (`SCAP_SUCCESS`) event (if available, otherwise "none").


**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

On my CPU a default value of 1000 for `max_consecutives` config value maps to a frequency in the range of 30-40 seconds (depending on the system load too).

In this scenario, Falco alerts if for 30-40 seconds it is not processing events.

Wondering if we're good with such value or if we may need to double it.

#### Reproduce

The only **simple** way to reproduce such an unlikely situation and test out this PR is the following one.

1. Start Falco in userspace mode

```console
sudo ./build/userspace/falco/falco -r rules/falco_rules.yaml -u
```

2.  Send to it some userspace events through [this userspace producer](https://github.com/fntlnz/userspace-example).

```console
sudo ./userspace-example // don't pay attention to the sudo for now, it's an example tool
```

3. Observe Falco receiving a  fake `renameat` event

```console
10:00:44.036991000: Warning Shell history had been deleted or renamed (user=<NA> user_loginuid=-1 type=renameat command=<NA> fd.name=<NA> name=<NA> path=<NA> oldpath=/tmp/bash_history host (id=host))
```

4. Wait for roughly ~40seconds

```console
10:01:22.199076638: Debug Falco internal: timeouts notification. 1000 consecutive timeouts without event. (last_event_time=10:00:44.036991000)
10:02:00.780884781: Debug Falco internal: timeouts notification. 1000 consecutive timeouts without event. (last_event_time=10:00:44.036991000)
```

**Does this PR introduce a user-facing change?**:

```release-note
new: Falco outputs an alert in the unlikely situation it's receiving too many consecutive timeouts without an event
new: configuration field `syscall_event_timeouts.max_consecutive` to configure after how many consecutive timeouts without an event Falco must alert
```
