### PR TITLE
add known k8s service accounts

### DIFF
--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -304,7 +304,7 @@
 - list: known_sa_list
   items: ["pod-garbage-collector","resourcequota-controller","cronjob-controller","generic-garbage-collector",
           "daemon-set-controller","endpointslice-controller","deployment-controller", "replicaset-controller",
-          "endpoint-controller"]
+          "endpoint-controller", "namespace-controller", "statefulset-controller", "disruption-controller"]
 
 - macro: trusted_sa
   condition: (ka.target.name in (known_sa_list, user_known_sa_list))


### PR DESCRIPTION
/kind rule-update
/area rules

**What this PR does / why we need it**:

Add namespace-controller, statefulset-controller, disruption-controller, job-controller, horizontal-pod-autoscaler and persistent-volume-binder as additional default k8s controller service accounts to the `known_sa_list` list. This addition prevents these controllers from triggering a warning as they are created in the kube-system namespace.

These controllers are default k8s controllers according to the docs (https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/)

```
--controllers strings&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "*"
```
> A  list of controllers to enable. '*' enables all on-by-default  controllers, 'foo' enables the controller named 'foo', '-foo' disables  the controller named 'foo'.All controllers: attachdetach,  bootstrapsigner, cloud-node-lifecycle, clusterrole-aggregation, cronjob,  csrapproving, csrcleaner, csrsigning, daemonset, deployment,  **disruption**, endpoint, endpointslice, endpointslicemirroring,  ephemeral-volume, garbagecollector, **horizontalpodautoscaling**, **job**,  **namespace**, nodeipam, nodelifecycle, **persistentvolume-binder**,  persistentvolume-expander, podgc, pv-protection, pvc-protection,  replicaset, replicationcontroller, resourcequota,  root-ca-cert-publisher, route, service, serviceaccount,  serviceaccount-token, **statefulset**, tokencleaner, ttl, ttl-after-finishedDisabled-by-default controllers: bootstrapsigner, tokencleaner

```release-note
rule(list: known_sa_list): add namespace-controller, statefulset-controller, disruption-controller, job-controller, horizontal-pod-autoscaler and persistent-volume-binder as allowed service accounts in the kube-system namespace
```
