### PR TITLE
build(cmake/modules): avoid gRCP files to be installed into packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.28.2
 
-Released on 2021-05-27
+Released on 2021-06-01
 
 ### Major Changes
 
@@ -20,6 +20,7 @@ Released on 2021-05-27
 * docs(proposals): fix libs contribution name [[#1641](https://github.com/falcosecurity/falco/pull/1641)] - [@leodido](https://github.com/leodido)
 * add Yahoo!Japan as an adopter [[#1651](https://github.com/falcosecurity/falco/pull/1651)] - [@ukitazume](https://github.com/ukitazume)
 * Add Replicated to adopters [[#1649](https://github.com/falcosecurity/falco/pull/1649)] - [@diamonwiggins](https://github.com/diamonwiggins)
+* build(cmake/modules): avoid gRCP files to be installed into packages [[#1662](https://github.com/falcosecurity/falco/pull/1662)] - [@leogr](https://github.com/leogr)
 
 
 ## v0.28.1

--- a/cmake/modules/falcosecurity-libs-repo/CMakeLists.txt
+++ b/cmake/modules/falcosecurity-libs-repo/CMakeLists.txt
@@ -25,4 +25,4 @@ ExternalProject_Add(
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
   TEST_COMMAND ""
-  PATCH_COMMAND patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/patch/libscap.patch && patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/patch/luajit.patch)
+  PATCH_COMMAND patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/patch/libscap.patch && patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/patch/luajit.patch && patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/patch/grpc.patch)

--- a/cmake/modules/falcosecurity-libs-repo/patch/grpc.patch
+++ b/cmake/modules/falcosecurity-libs-repo/patch/grpc.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/modules/grpc.cmake b/cmake/modules/grpc.cmake
+index ffa4e6c4..346939b9 100644
+--- a/cmake/modules/grpc.cmake
++++ b/cmake/modules/grpc.cmake
+@@ -125,6 +125,7 @@ else()
+ 				-DZLIB_ROOT:STRING=${ZLIB_SRC}
+ 			BUILD_IN_SOURCE 1
+ 			BUILD_BYPRODUCTS ${GRPC_LIB} ${GRPCPP_LIB} ${GPR_LIB} ${GRPC_LIBRARIES}
++			INSTALL_COMMAND DESTDIR=/ make install
+ 		)
+ 	endif()
+ endif()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This patch is to be intended as a temporary workaround.
The root issue needs to be addressed in `falcosecurity/libs`.
A definite solution will be implemented later.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
This is a hotfix to unblock the current release. 
It addresses the issue described in https://github.com/falcosecurity/falco/issues/1653#issuecomment-850438225

/milestone 0.28.2

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
