### PR TITLE
build(test): upgrade urllib3 to 1.26.5

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -9,5 +9,5 @@ PyYAML==5.4
 requests==2.23.0
 six==1.14.0
 stevedore==1.32.0
-urllib3==1.25.9
+urllib3==1.26.5
 watchdog==0.10.2


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area rules

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

`urllib3` is a dependency used in our test suite. Version v1.25.9 is affected by a security vulnerability (CVE-2021-33503) which has been fixed in v1.26.5.

See:
 - https://github.com/urllib3/urllib3/security/advisories/GHSA-q2q7-5pp4-w6pg
 - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33503
 - https://github.com/urllib3/urllib3/releases/tag/1.26.5

Note that the above dependency is not directly used by Falco. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.29.0

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
