### PR TITLE
rule to detect successful unprivileged userfaultfd events

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3056,6 +3056,16 @@
   priority: WARNING
   tags: [container, cis, mitre_lateral_movement]
 
+- rule: Unprivileged Delegation of Page Faults Handling to a Userspace Process
+  desc: Detect a successful unprivileged userfaultfd syscall which might act as an attack primitive to exploit other bugs
+  condition: >
+    evt.type = userfaultfd and
+    user.uid != 0 and
+    (evt.rawres >= 0 or evt.res != -1)
+  output: An userfaultfd syscall was successfully executed by an unprivileged user (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)
+  priority: CRITICAL
+  tags: [process, mitre_defense_evasion]
+
 # Application rules have moved to application_rules.yaml. Please look
 # there if you want to enable them by adding to
 # falco_rules.local.yaml.

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3059,13 +3059,17 @@
 - macro: consider_userfaultfd_activities
   condition: (always_true)
 
+- list: user_known_userfaultfd_activities
+  items: []
+
 - rule: Unprivileged Delegation of Page Faults Handling to a Userspace Process
   desc: Detect a successful unprivileged userfaultfd syscall which might act as an attack primitive to exploit other bugs
   condition: >
     consider_userfaultfd_activities and evt.type = userfaultfd and
     user.uid != 0 and
-    (evt.rawres >= 0 or evt.res != -1)
-  output: An userfaultfd syscall was successfully executed by an unprivileged user (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)
+    (evt.rawres >= 0 or evt.res != -1) and
+    not proc.name in (user_known_userfaultfd_activities)
+  output: An userfaultfd syscall was successfully executed by an unprivileged user (user=%user.name user_loginuid=%user.loginuid process=%proc.name command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)
   priority: CRITICAL
   tags: [syscall, mitre_defense_evasion]
 

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-# The latest Falco Engine version is 8 if you want to
-# use exceptions. However the default rules file does not
-# use them so we stick with 7 for compatibility.
-- required_engine_version: 7
+# The latest Falco Engine version is 9.
+# Starting with version 8, the Falco engine supports exceptions.
+# However the Falco rules file does not use them by default.
+- required_engine_version: 9
 
 # Currently disabled as read/write are ignored syscalls. The nearly
 # similar open_write/open_read check for files being opened for

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3065,7 +3065,8 @@
 - rule: Unprivileged Delegation of Page Faults Handling to a Userspace Process
   desc: Detect a successful unprivileged userfaultfd syscall which might act as an attack primitive to exploit other bugs
   condition: >
-    consider_userfaultfd_activities and evt.type = userfaultfd and
+    consider_userfaultfd_activities and
+    evt.type = userfaultfd and
     user.uid != 0 and
     (evt.rawres >= 0 or evt.res != -1) and
     not proc.name in (user_known_userfaultfd_activities)

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1753,13 +1753,13 @@
 - macro: allowed_aws_ecr_registry_root_for_eks
   condition: >
     (container.image.repository startswith "602401143452.dkr.ecr" or
-     container.image.repository startswith "877085696533.dkr.ecr" or 
-     container.image.repository startswith "800184023465.dkr.ecr" or 
-     container.image.repository startswith "602401143452.dkr.ecr" or 
+     container.image.repository startswith "877085696533.dkr.ecr" or
+     container.image.repository startswith "800184023465.dkr.ecr" or
+     container.image.repository startswith "602401143452.dkr.ecr" or
      container.image.repository startswith "918309763551.dkr.ecr" or
-     container.image.repository startswith "961992271922.dkr.ecr" or 
+     container.image.repository startswith "961992271922.dkr.ecr" or
      container.image.repository startswith "590381155156.dkr.ecr" or
-     container.image.repository startswith "558608220178.dkr.ecr" or 
+     container.image.repository startswith "558608220178.dkr.ecr" or
      container.image.repository startswith "151742754352.dkr.ecr" or
      container.image.repository startswith "013241004608.dkr.ecr")
 
@@ -3003,7 +3003,7 @@
 - rule: Linux Kernel Module Injection Detected
   desc: Detect kernel module was injected (from container).
   condition: spawned_process and container and proc.name=insmod and not proc.args in (white_listed_modules)
-  output: Linux Kernel Module injection using insmod detected (user=%user.name user_loginuid=%user.loginuid parent_process=%proc.pname module=%proc.args)
+  output: Linux Kernel Module injection using insmod detected (user=%user.name user_loginuid=%user.loginuid parent_process=%proc.pname module=%proc.args %container.info image=%container.image.repository:%container.image.tag)
   priority: WARNING
   tags: [process]
 
@@ -3027,7 +3027,7 @@
 # A privilege escalation to root through heap-based buffer overflow
 - rule: Sudo Potential Privilege Escalation
   desc: Privilege escalation vulnerability affecting sudo (<= 1.9.5p2). Executing sudo using sudoedit -s or sudoedit -i command with command-line argument that ends with a single backslash character from an unprivileged user it's possible to elevate the user privileges to root.
-  condition: spawned_process and user.uid!= 0 and proc.name=sudoedit and (proc.args contains -s or proc.args contains -i) and (proc.args contains "\ " or proc.args endswith \)
+  condition: spawned_process and user.uid != 0 and proc.name=sudoedit and (proc.args contains -s or proc.args contains -i) and (proc.args contains "\ " or proc.args endswith \)
   output: "Detect Sudo Privilege Escalation Exploit (CVE-2021-3156) (user=%user.name parent=%proc.pname cmdline=%proc.cmdline %container.info)"
   priority: CRITICAL
   tags: [filesystem, mitre_privilege_escalation]

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3059,7 +3059,7 @@
 - macro: consider_userfaultfd_activities
   condition: (always_true)
 
-- list: user_known_userfaultfd_activities
+- list: user_known_userfaultfd_processes
   items: []
 
 - rule: Unprivileged Delegation of Page Faults Handling to a Userspace Process
@@ -3069,7 +3069,7 @@
     evt.type = userfaultfd and
     user.uid != 0 and
     (evt.rawres >= 0 or evt.res != -1) and
-    not proc.name in (user_known_userfaultfd_activities)
+    not proc.name in (user_known_userfaultfd_processes)
   output: An userfaultfd syscall was successfully executed by an unprivileged user (user=%user.name user_loginuid=%user.loginuid process=%proc.name command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)
   priority: CRITICAL
   tags: [syscall, mitre_defense_evasion]

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3064,7 +3064,7 @@
     (evt.rawres >= 0 or evt.res != -1)
   output: An userfaultfd syscall was successfully executed by an unprivileged user (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)
   priority: CRITICAL
-  tags: [process, mitre_defense_evasion]
+  tags: [syscall, mitre_defense_evasion]
 
 # Application rules have moved to application_rules.yaml. Please look
 # there if you want to enable them by adding to

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3056,10 +3056,13 @@
   priority: WARNING
   tags: [container, cis, mitre_lateral_movement]
 
+- macro: consider_userfaultfd_activities
+  condition: (always_true)
+
 - rule: Unprivileged Delegation of Page Faults Handling to a Userspace Process
   desc: Detect a successful unprivileged userfaultfd syscall which might act as an attack primitive to exploit other bugs
   condition: >
-    evt.type = userfaultfd and
+    consider_userfaultfd_activities and evt.type = userfaultfd and
     user.uid != 0 and
     (evt.rawres >= 0 or evt.res != -1)
   output: An userfaultfd syscall was successfully executed by an unprivileged user (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)

--- a/userspace/engine/falco_engine_version.h
+++ b/userspace/engine/falco_engine_version.h
@@ -16,7 +16,7 @@ limitations under the License.
 
 // The version of rules/filter fields/etc supported by this falco
 // engine.
-#define FALCO_ENGINE_VERSION (8)
+#define FALCO_ENGINE_VERSION (9)
 
 // This is the result of running "falco --list -N | sha256sum" and
 // represents the fields supported by this version of falco. It's used


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

 /kind feature



/kind rule-update

/kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

Adds a rule to alert the Falco users about the delegation of page faults to user-space through an unprivileged successful userfaultfd call.

**Which issue(s) this PR fixes**:

Refs #676 

**Special notes for your reviewer**:

To try it out you need to build Falco against [this branch in libs](https://github.com/falcosecurity/libs/pull/50).

Holding this PR until that branch is merged into libs.

/hold

Also, while doing this PR I took the chance to include a simple addition on the rule detecting kernel module injections from containers: it was missing the container info in the output, I added it.

**Does this PR introduce a user-facing change?**:


```release-note
rule(list user_known_userfaultfd_processes): list to exclude processes known to use userfaultfd syscall
rule(macro consider_userfaultfd_activities): macro to gate the "Unprivileged Delegation of Page Faults Handling to a Userspace Process" rule
rule(Unprivileged Delegation of Page Faults Handling to a Userspace Process): new rule to detect successful unprivileged userfaultfd syscalls
rule(Linux Kernel Module Injection Detected): adding container info to the output of the rule
update: bump the Falco engine version to version 9
```
