### PR TITLE
move falco_hostnetwork_images list to k8s_audit_rules.yaml to avoid a warning

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1871,19 +1871,6 @@
               container.image.repository in (falco_sensitive_mount_images) or
               container.image.repository startswith quay.io/sysdig/)
 
-# These container images are allowed to run with hostnetwork=true
-- list: falco_hostnetwork_images
-  items: [
-    gcr.io/google-containers/prometheus-to-sd,
-    gcr.io/projectcalico-org/typha,
-    gcr.io/projectcalico-org/node,
-    gke.gcr.io/gke-metadata-server,
-    gke.gcr.io/kube-proxy,
-    gke.gcr.io/netd-amd64,
-    k8s.gcr.io/ip-masq-agent-amd64
-    k8s.gcr.io/prometheus-to-sd,
-    ]
-
 # Add conditions to this macro (probably in a separate file,
 # overwriting this macro) to specify additional containers that are
 # allowed to perform sensitive mounts.

--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -152,6 +152,19 @@
   source: k8s_audit
   tags: [k8s]
 
+# These container images are allowed to run with hostnetwork=true
+- list: falco_hostnetwork_images
+  items: [
+    gcr.io/google-containers/prometheus-to-sd,
+    gcr.io/projectcalico-org/typha,
+    gcr.io/projectcalico-org/node,
+    gke.gcr.io/gke-metadata-server,
+    gke.gcr.io/kube-proxy,
+    gke.gcr.io/netd-amd64,
+    k8s.gcr.io/ip-masq-agent-amd64
+    k8s.gcr.io/prometheus-to-sd,
+    ]
+
 # Corresponds to K8s CIS Benchmark 1.7.4
 - rule: Create HostNetwork Pod
   desc: Detect an attempt to start a pod using the host network.

--- a/test/falco_k8s_audit_tests.yaml
+++ b/test/falco_k8s_audit_tests.yaml
@@ -49,6 +49,7 @@ trace_files: !mux
     detect: False
     rules_file:
       - ../rules/falco_rules.yaml
+      - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/engine_v4_k8s_audit_rules.yaml
       - ./rules/k8s_audit/trust_nginx_container.yaml
     trace_file: trace_files/k8s_audit/create_nginx_pod_privileged.json
@@ -74,6 +75,7 @@ trace_files: !mux
     detect: False
     rules_file:
       - ../rules/falco_rules.yaml
+      - ../rules/k8s_audit_rules.yaml
       - ./rules/k8s_audit/engine_v4_k8s_audit_rules.yaml
       - ./rules/k8s_audit/trust_nginx_container.yaml
     trace_file: trace_files/k8s_audit/create_nginx_pod_hostnetwork.json


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>



**What type of PR is this?**



/kind cleanup



/kind rule-update



**Any specific area of the project related to this PR?**



/area rules



**What this PR does / why we need it**:

The `falco_hostnetwork_images` list is defined in `falco_rules.yaml` but it's unused in it.

This PR moves it to avoid the warning when using only `falco_rules.yaml`. 

```console
When reading rules content: 1 warnings:
list falco_hostnetwork_images not referred to by any rule/macro/list
```

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

The `falco_hostnetwork_images` list is only used in `k8s_audit_rules.yaml`.

**Does this PR introduce a user-facing change?**:


```release-note
rule(list falco_hostnetwork_images): moved to k8s_audit_rules.yaml to avoid a warning when usng falco_rules.yaml only
```
