### PR TITLE
Systemd unit: Do not send falco alerts to /var/log/messages by default

### DIFF
--- a/scripts/rpm/falco.service
+++ b/scripts/rpm/falco.service
@@ -19,6 +19,7 @@ ProtectSystem=full
 ProtectKernelTunables=true
 RestrictRealtime=true
 RestrictAddressFamilies=~AF_PACKET
+StandardOutput=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Signed-off-by: Domenico Chirabino <chirabino@protonmail.com>

**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area engine

**What this PR does**:
This PR set `StandardOutput` to `null` in the systemd unit configuration `falco.service`.

**Why we need it**
After the migration from initd to systemd (#1448), when falco is installed via systemd it writes to `/var/log/messages` by default.

The problem is not present when manually running Falco (without using systemd).

This is due to the default value in the systemd configuration: `DefaultStandardOutput=journal` (which falco inherits), so that Falco standard output is redirected to `/var/log/messages` (see https://manpages.debian.org/wheezy/systemd/systemd.conf.5.en.html).

At the time of writing a workaround is to disable `stdout_output`:
```yaml
stdout_output:
  enabled: false
```

I think that falco should not write to system logs by default. Moreover, asking users to disable `stdout_output` (enabled by default) may be misleading and confusing (ie. I want `stdout_output` enabled so I can start falco manually for debugging or for testing rules)

**Which issue(s) this PR fixes**:
Fixes #1673

**Special notes for your reviewer**:
Thanks for your time :)
/cc @leogr 

**Does this PR introduce a user-facing change?**:

```release-note
fix(scripts): correct standard output redirection in systemd config
```

