### PR TITLE
docs(RELEASE.md): switch to 3 releases per year

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,9 @@ Our release process is mostly automated, but we still need some manual steps to 
 
 Changes and new features are grouped in [milestones](https://github.com/falcosecurity/falco/milestones), the milestone with the next version represents what is going to be released.
 
-A release happens every two months ([as per community discussion](https://github.com/falcosecurity/community/blob/master/meeting-notes/2020-09-30.md#agenda)), and we need to assign owners for each (usually we pair a new person with an experienced one). Assignees and the due date are proposed during the [weekly community call](https://github.com/falcosecurity/community). Note that hotfix releases can happen as soon as it is needed.
+Falco releases are due to happen 3 times per year. Our current schedule sees a new release by the end of January, May, and September each year. Hotfix releases can happen whenever it's needed.
+
+Moreover, we need to assign owners for each release (usually we pair a new person with an experienced one). Assignees and the due date are proposed during the [weekly community call](https://github.com/falcosecurity/community).
 
 Finally, on the proposed due date the assignees for the upcoming release proceed with the processes described below.
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation


**Any specific area of the project related to this PR?**


/area build

**What this PR does / why we need it**:

This PR updates the `RELEASE.md` doc reflecting the new release cycle as discussed by Falco's maintainers.
Starting from now, we plan to release 3 times per year.

Thanks to @fntlnz @leodido @kris-nova @mstemm 

/milestone 0.30.0

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
