### PR TITLE
Use new Debian 11 package names for python-pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,7 +403,7 @@ jobs:
           name: Setup
           command: |
             apt update -y
-            apt-get install apt-utils bzip2 gpg python python-pip -y
+            apt-get install apt-utils bzip2 gpg python python3-pip -y
             pip install awscli
             echo $GPG_KEY | base64 -d | gpg --import
       - run:
@@ -517,7 +517,7 @@ jobs:
           name: Setup
           command: |
             apt update -y
-            apt-get install apt-utils bzip2 gpg python python-pip -y
+            apt-get install apt-utils bzip2 gpg python python3-pip -y
             pip install awscli
             echo $GPG_KEY | base64 -d | gpg --import
       - run:


### PR DESCRIPTION
Signed-off-by: Michele Zuccala <michele@zuccala.com>

**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:
As per [this](https://packages.debian.org/search?keywords=python3-pip&searchon=names&suite=stable&section=all), new package name for `pip` in Debian Bullseye is `python3-pip`.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
