### PR TITLE
fix(scripts): correct lookup order when trying multiple `gcc` versions in the `falco-driver-loader` script

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -154,7 +154,7 @@ load_kernel_module_compile() {
 	fi
 
 	# Try to compile using all the available gcc versions
-	for CURRENT_GCC in $(which gcc) $(ls "$(dirname "$(which gcc)")"/gcc-* | grep 'gcc-[0-9]\+' | sort -r); do
+	for CURRENT_GCC in $(which gcc) $(ls "$(dirname "$(which gcc)")"/gcc-* | grep 'gcc-[0-9]\+' | sort -n -r -k 2 -t -); do
 		echo "* Trying to dkms install ${DRIVER_NAME} module with GCC ${CURRENT_GCC}"
 		echo "#!/usr/bin/env bash" > /tmp/falco-dkms-make
 		echo "make CC=${CURRENT_GCC} \$@" >> /tmp/falco-dkms-make


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

 /kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

 /area build


**Which issue(s) this PR fixes**:

This PR set ```falco-driver-loader ``` ``` ENABLE_DOWNLOAD``` useful.

and try ```gcc``` version from high to low

before

```bash
 $ls ./gcc-* | grep 'gcc-[0-9]\+' | sort -r
./gcc-9
./gcc-8
./gcc-3
./gcc-2
./gcc-11
./gcc-10
./gcc-1
```
now

```bash
$ ls ./gcc-* | grep 'gcc-[0-9]\+' | sort -n -r -k 2 -t - 
./gcc-11
./gcc-10
./gcc-9
./gcc-8
./gcc-3
./gcc-2
./gcc-1
```


Fixes #

```release-note
fix(scripts): correct lookup order when trying multiple `gcc` versions in the `falco-driver-loader` script
```
