### PR TITLE
Adding libssl-dev, fixing upstream image reference.

### DIFF
--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:buster
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
@@ -30,6 +30,7 @@ RUN apt-get update \
 	libc6-dev \
 	libelf-dev \
 	libmpx2 \
+	libssl-dev \
 	llvm-7 \
 	netcat \
 	xz-utils \


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:
This PR updates base image with libssl-dev package required to compile kernel module.
It also updates upstream container reference, since recently Buster becomes new stable and container refuses to build.

**Which issue(s) this PR fixes**:

Fixes https://github.com/falcosecurity/falco/issues/1718

**Special notes for your reviewer**:

Since Debian Bullseye become new `stable`, it is also required to update base image reference.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
