### PR TITLE
fix(test): avoid output_strictly_contains failures

### DIFF
--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -409,10 +409,12 @@ class FalcoTest(Test):
             else:
                 actual = open(output['actual']).read()
 
-            if expected not in actual:
-                self.fail("Output '{}' does not strictly contains the expected content '{}'".format(
-                    output['actual'], output['expected']))
-                return False
+            expected_lines = expected.splitlines()
+            for line in expected_lines:
+                if line not in actual:
+                    self.fail("Output '{}' does not strictly contains the expected content '{}'".format(
+                        output['actual'], output['expected']))
+                    return False
 
         return True
 


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind failing-test

**Any specific area of the project related to this PR?**
/area tests

**What this PR does / why we need it**:
This fixes non-deterministic test failures related to the `output_strictly_contains` check.

`output_strictly_contains` now ensures that the actual output contains _every line_ of the expected output. This offers less guarantees than checking that the expected output is perfectly contained in the actual one, but is more fault tolerant and does not alter the semantics of our tests.

**Which issue(s) this PR fixes**:
https://github.com/falcosecurity/falco/issues/1723

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
