### PR TITLE
Remove duplicate allowed ecr registry rule

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1755,7 +1755,6 @@
     (container.image.repository startswith "602401143452.dkr.ecr" or
      container.image.repository startswith "877085696533.dkr.ecr" or
      container.image.repository startswith "800184023465.dkr.ecr" or
-     container.image.repository startswith "602401143452.dkr.ecr" or
      container.image.repository startswith "918309763551.dkr.ecr" or
      container.image.repository startswith "961992271922.dkr.ecr" or
      container.image.repository startswith "590381155156.dkr.ecr" or


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind rule-update

**Any specific area of the project related to this PR?**

/area rules


**What this PR does / why we need it**:
Removes a duplicate ECR repo starts_with rule in the allowed_aws_ecr_registry_root_for_eks macro

**Which issue(s) this PR fixes**:


```release-note
NONE
```
