### PR TITLE
update(outputs): add configuration option for tags in json outputs

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -46,6 +46,12 @@ json_output: false
 # (user=root ....") in the json output.
 json_include_output_property: true
 
+# When using json output, whether or not to include the "tags" property
+# itself in the json output. If set to true, outputs caused by rules
+# with no tags will have a "tags" field set to an empty array. If set to
+# false, the "tags" field will not be included in the json output at all.
+json_include_tags_property: true
+
 # Send information logs to stderr and/or syslog Note these are *not* security
 # notification logs! These are just Falco lifecycle (and possibly error) logs.
 log_stderr: true

--- a/test/confs/psp.yaml
+++ b/test/confs/psp.yaml
@@ -43,6 +43,12 @@ json_output: false
 # (user=root ....") in the json output.
 json_include_output_property: true
 
+# When using json output, whether or not to include the "tags" property
+# itself in the json output. If set to true, outputs caused by rules
+# with no tags will have a "tags" field set to an empty array. If set to
+# false, the "tags" field will not be included in the json output at all.
+json_include_tags_property: true
+
 # Send information logs to stderr and/or syslog Note these are *not* security
 # notification logs! These are just Falco lifecycle (and possibly error) logs.
 log_stderr: true

--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -90,6 +90,8 @@ class FalcoTest(Test):
         self.json_output = self.params.get('json_output', '*', default=False)
         self.json_include_output_property = self.params.get(
             'json_include_output_property', '*', default=True)
+        self.json_include_tags_property = self.params.get(
+            'json_include_tags_property', '*', default=True)
         self.all_events = self.params.get('all_events', '*', default=False)
         self.priority = self.params.get('priority', '*', default='debug')
         self.rules_file = self.params.get(
@@ -388,10 +390,11 @@ class FalcoTest(Test):
             for line in res.stdout.decode("utf-8").splitlines():
                 if line.startswith('{'):
                     obj = json.loads(line)
+                    attrs = ['time', 'rule', 'priority']
                     if self.json_include_output_property:
-                        attrs = ['time', 'rule', 'priority', 'output']
-                    else:
-                        attrs = ['time', 'rule', 'priority']
+                        attrs.append('output')
+                    if self.json_include_tags_property:
+                        attrs.append('tags')
                     for attr in attrs:
                         if not attr in obj:
                             self.fail(
@@ -614,8 +617,9 @@ class FalcoTest(Test):
                 self.log.debug("Converted Rules: {}".format(psp_rules))
 
         # Run falco
-        cmd = '{} {} {} -c {} {} -o json_output={} -o json_include_output_property={} -o priority={} -v'.format(
-            self.falco_binary_path, self.rules_args, self.disabled_args, self.conf_file, trace_arg, self.json_output, self.json_include_output_property, self.priority)
+        cmd = '{} {} {} -c {} {} -o json_output={} -o json_include_output_property={} -o json_include_tags_property={} -o priority={} -v'.format(
+            self.falco_binary_path, self.rules_args, self.disabled_args, self.conf_file, trace_arg, self.json_output,
+            self.json_include_output_property, self.json_include_tags_property, self.priority)
 
         for tag in self.disable_tags:
             cmd += ' -T {}'.format(tag)

--- a/test/falco_tests.yaml
+++ b/test/falco_tests.yaml
@@ -1111,6 +1111,25 @@ trace_files: !mux
     trace_file: trace_files/cat_write.scap
     stdout_contains: "^(?!.*Warning An open of /dev/null was seen.*)"
 
+  json_output_no_tags_property:
+    json_output: True
+    json_include_tags_property: False
+    detect: True
+    detect_level: WARNING
+    rules_file:
+      - rules/rule_append.yaml
+    trace_file: trace_files/cat_write.scap
+    stdout_contains: "^(?!.*\"tags\":[ ]*\\[.*\\],.*)"
+
+  json_output_empty_tags_property:
+    json_output: True
+    detect: True
+    detect_level: WARNING
+    rules_file:
+      - rules/rule_append.yaml
+    trace_file: trace_files/cat_write.scap
+    stdout_contains: "^(.*\"tags\":[ ]*\\[\\],.*)"
+
   in_operator_netmasks:
     detect: True
     detect_level: INFO

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -177,7 +177,8 @@ void falco_engine::load_rules(const string &rules_content, bool verbose, bool al
 	// json_output to false.
 	bool json_output = false;
 	bool json_include_output_property = false;
-	falco_formats::init(m_inspector, this, m_ls, json_output, json_include_output_property);
+	bool json_include_tags_property = false;
+	falco_formats::init(m_inspector, this, m_ls, json_output, json_include_output_property, json_include_tags_property);
 
 	m_rules->load_rules(rules_content, verbose, all_events, m_extra, m_replace_container_info, m_min_priority, required_engine_version);
 }

--- a/userspace/engine/formats.h
+++ b/userspace/engine/formats.h
@@ -37,7 +37,8 @@ public:
 			 falco_engine *engine,
 			 lua_State *ls,
 			 bool json_output,
-			 bool json_include_output_property);
+			 bool json_include_output_property,
+			 bool json_include_tags_property);
 
 	// formatter = falco.formatter(format_string)
 	static int lua_formatter(lua_State *ls);
@@ -56,4 +57,5 @@ public:
 	static std::unique_ptr<sinsp_evt_formatter_cache> s_formatters;
 	static bool s_json_output;
 	static bool s_json_include_output_property;
+	static bool s_json_include_tags_property;
 };

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -71,6 +71,7 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 
 	m_json_output = m_config->get_scalar<bool>("json_output", false);
 	m_json_include_output_property = m_config->get_scalar<bool>("json_include_output_property", true);
+	m_json_include_tags_property = m_config->get_scalar<bool>("json_include_tags_property", true);
 
 	falco::outputs::config file_output;
 	file_output.name = "file";

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -195,6 +195,7 @@ public:
 	std::list<std::string> m_rules_filenames;
 	bool m_json_output;
 	bool m_json_include_output_property;
+	bool m_json_include_tags_property;
 	std::string m_log_level;
 	std::vector<falco::outputs::config> m_outputs;
 	uint32_t m_notifications_rate;

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -1122,6 +1122,7 @@ int falco_init(int argc, char **argv)
 
 		outputs->init(config.m_json_output,
 			config.m_json_include_output_property,
+			config.m_json_include_tags_property,
 			config.m_output_timeout,
 			config.m_notifications_rate, config.m_notifications_max_burst,
 			config.m_buffered_outputs,

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -62,6 +62,7 @@ falco_outputs::~falco_outputs()
 
 void falco_outputs::init(bool json_output,
 		  bool json_include_output_property,
+		  bool json_include_tags_property,
 		  uint32_t timeout,
 		  uint32_t rate, uint32_t max_burst, bool buffered,
 		  bool time_format_iso_8601, std::string hostname)
@@ -79,6 +80,7 @@ void falco_outputs::init(bool json_output,
 	// So we can safely update them.
 	falco_formats::s_json_output = json_output;
 	falco_formats::s_json_include_output_property = json_include_output_property;
+	falco_formats::s_json_include_tags_property = json_include_tags_property;
 
 	m_timeout = std::chrono::milliseconds(timeout);
 

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -40,6 +40,7 @@ public:
 
 	void init(bool json_output,
 		  bool json_include_output_property,
+		  bool json_include_tags_property,
 		  uint32_t timeout,
 		  uint32_t rate, uint32_t max_burst, bool buffered,
 		  bool time_format_iso_8601, std::string hostname);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area engine

/area tests

**What this PR does / why we need it**:
Since the recent merge of https://github.com/falcosecurity/falco/pull/1714, `tags` and `source` fields are now part of both the grpc and json outputs. However, the semantic of the json output is not clear in some corner cases, such as when no tags are defined in a rule. Also, users can't configure whether to include `tags` in the json outputs or not, which instead is possible for the `output` field. Moreover, no test cases are yet present for asserting the expected outcome of these corner cases. These issues were reported in https://github.com/falcosecurity/falco/pull/1714#issuecomment-924800821 by @leodido (thank you!!)

As such, this PR contributes with the following:

- Adding the `json_include_tags_property` configuration option, so that users can decide whether to include `tags` in the json outputs or not. By default this is set to `true` to not introduce breaking changes for clients that currently expect the field to be present.
- Clarifying the expected outcome in the corner cases arising when a rule has no defined tags.
- Adding test cases asserting the expected outcomes of the corner cases, and updating the test suite to support the new configuration option.

**Additional Context**:
The table below describes the expected outcomes in the json outputs by using the new configuration option.
|   |  ` json_include_tags_property = true`  |  ` json_include_tags_property = false` |
|---|---|---|
| **Rule with no tags**  |  **(1)** json has a field `tags=[]` |  **(2)** json has no `tags` field  |
| **Rule with tags**  |  **(3)** json has a field `tags=[...]`  |  **(4)** json has no `tags` field  |

These cases are covered by the following tests:

- `json_output_empty_tags_property`: Case **(1)**
- `json_output_no_tags_property`: Cases **(2)** and **(4)**
- `stdout_output_json_strict`: Case **(3)**

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
update(outputs): add configuration option for tags in json outputs
```
