### PR TITLE
upgrade macro keepalived_writing_conf

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1100,7 +1100,7 @@
   condition: (proc.name=oc and fd.name startswith /etc/origin/node)
 
 - macro: keepalived_writing_conf
-  condition: (proc.name=keepalived and fd.name=/etc/keepalived/keepalived.conf)
+  condition: (proc.name in (keepalived, kube-keepalive) and fd.name=/etc/keepalived/keepalived.conf)
 
 - macro: etcd_manager_updating_dns
   condition: (container and proc.name=etcd-manager and fd.name=/etc/hosts)


### PR DESCRIPTION
me and @pmusa found that some k8s clusters are using `kube-keepalive` instead of `keepalive`. This macro is affecting our katacoda lab for k8s environments. It is not going to break anything, as it just extends the `proc.name` included in the rule condition. More info about it here: https://github.com/aledbf/kube-keepalived-vip

Example of the logs:

```
10:37:16.732178071: Error File below /etc opened for writing (user=root user_loginuid=-1 command=kube-keepalived --services-configmap=kube-system/vip-configmap parent=containerd-shim pcmdline=containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/8d542604c0f88c7e6756ba3a95e6cb59da06100c57be29490adedc2b2a9069e2 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc -systemd-cgroup file=/etc/keepalived/keepalived.conf program=kube-keepalived gparent=containerd ggparent=systemd gggparent=<NA> container_id=8d542604c0f8 image=gcr.io/google_containers/kube-keepalived-vip) k8s.ns=kube-system k8s.pod=kube-keepalived-vip-h542z container=8d542604c0f8 k8s.ns=kube-system k8s.pod=kube-keepalived-vip-h542z container=8d542604c0f8
```
@pmusa tested in our environment, and it fix the error.

Signed-off-by: Pablo Lopez <pablo.lopezzaldivar@falco.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

/kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note

```
