### PR TITLE
update(proposal): clarify that old drivers are not removed anymore

### DIFF
--- a/proposals/20200901-artifacts-cleanup.md
+++ b/proposals/20200901-artifacts-cleanup.md
@@ -2,6 +2,8 @@
 
 This document reflects when and how we clean up the Falco artifacts from their storage location.
 
+**Superseeded by**: [drivers-storage-s3 proposal](https://github.com/falcosecurity/falco/blob/master/proposals/20201025-drivers-storage-s3.md).
+
 ## Motivation
 
 The [bintray](https://bintray.com/falcosecurity) open-source plan offers 10GB free space for storing artifacts.
@@ -94,9 +96,19 @@ Since the process of building drivers is time and resource consuming, this docum
 
 The candidate is an AWS S3 bucket responsible for holding the deleted driver version files.
 
+#### Notice
+
+The current mechanism the Falco community uses to store the Falco drivers is explained by the [drivers-storage-s3](https://github.com/falcosecurity/falco/blob/master/proposals/20201025-drivers-storage-s3.md) proposal.
+
 ### Implementation
 
 The [test-infra](https://github.com/falcosecurity/test-infra) CI, specifically its part dedicated to run the **Drivers Build Grid** that runs every time it detects changes into the `driverkit` directory of the [test-infra](https://github.com/falcosecurity/test-infra) repository,
 will have a new job - called `drivers/cleanup` - responsible for removing all the Falco driver versions except the last two.
 
 This job will be triggered after the `drivers/publish` completed successfully on the master branch.
+
+#### Notice
+
+At the moment of writing (2021 09 28) the `drivers/cleanup` job is no more in place.
+
+Pragmatically, this means that the older Falco drivers will remain available in their [S3 bucket](https://download.falco.org/?prefix=driver/).


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

**What type of PR is this?**



/kind cleanup



**Any specific area of the project related to this PR?**


/area proposals

**What this PR does / why we need it**:

Clarify that the `drivers/cleanup` job we needed when we were using Bintray to store the Falco drivers is not needed anymore. And that, its related proposal has been superseded by a newer one (already implemented and in place during the last year).

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

/milestone 0.30.0

**Does this PR introduce a user-facing change?**:

```release-note
docs: clarify that previous Falco drivers will remain available at https://download.falco.org and no automated cleanup is run anymore
```
