### PR TITLE
upgrade macro(keepalived_writing_conf)

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1100,7 +1100,7 @@
   condition: (proc.name=oc and fd.name startswith /etc/origin/node)
 
 - macro: keepalived_writing_conf
-  condition: (proc.name=keepalived and fd.name=/etc/keepalived/keepalived.conf)
+  condition: (proc.name in (keepalived, kube-keepalived) and fd.name=/etc/keepalived/keepalived.conf)
 
 - macro: etcd_manager_updating_dns
   condition: (container and proc.name=etcd-manager and fd.name=/etc/hosts)


### PR DESCRIPTION
Signed-off-by: pablopez <pablo.lopezzaldivar@sysdig.com>

**What type of PR is this?**

/kind rule-update

**Any specific area of the project related to this PR?**

 /area rules

**What this PR does / why we need it**:

me and @pmusa found that some k8s clusters are using `kube-keepalive` instead of `keepalive`. This macro is affecting the katacoda lab for k8s environments. This change is not going to break anything, as it just extends the `proc.name` included in the rule condition. More info about it [here](https://github.com/aledbf/kube-keepalived-vip)

Example of the logs:
```
10:37:16.732178071: Error File below /etc opened for writing (user=root user_loginuid=-1 command=kube-keepalived --services-configmap=kube-system/vip-configmap parent=containerd-shim pcmdline=containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/8d542604c0f88c7e6756ba3a95e6cb59da06100c57be29490adedc2b2a9069e2 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc -systemd-cgroup file=/etc/keepalived/keepalived.conf program=kube-keepalived gparent=containerd ggparent=systemd gggparent=<NA> container_id=8d542604c0f8 image=gcr.io/google_containers/kube-keepalived-vip) k8s.ns=kube-system k8s.pod=kube-keepalived-vip-h542z container=8d542604c0f8 k8s.ns=kube-system k8s.pod=kube-keepalived-vip-h542z container=8d542604c0f8
```

@pmusa tested in our environment, and it fix the error (lots of false positives in the output like the one copied above).



**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:
NO

```release-note
NONE
```
