### PR TITLE
build(cmake): bump libs version to 3aa7a83

### DIFF
--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -20,8 +20,8 @@ file(MAKE_DIRECTORY ${FALCOSECURITY_LIBS_CMAKE_WORKING_DIR})
 # default below In case you want to test against another falcosecurity/libs version just pass the variable - ie., `cmake
 # -DFALCOSECURITY_LIBS_VERSION=dev ..`
 if(NOT FALCOSECURITY_LIBS_VERSION)
-  set(FALCOSECURITY_LIBS_VERSION "5727c456ce22f3c1da8c3b1d7d6b6937a9b2126b")
-  set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=549d2dd29109d12cc3eb261d86b35c637ac16796f6d88c39dce02f6d1cdf737d")
+  set(FALCOSECURITY_LIBS_VERSION "3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4")
+  set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=1edb535b3778fcfb46bbeeda891f176a1bd591bebd7b89c27f04837e55a52beb")
 endif()
 
 # cd /path/to/build && cmake /path/to/source


### PR DESCRIPTION
Signed-off-by: Michele Zuccala <michele@zuccala.com>

**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:
This is a direct consequence of https://github.com/falcosecurity/libs/pull/90 and it's needed to unlock Falco 0.30.0 release.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
update: bump driver version to 3aa7a83bf7b9e6229a3824e3fd1f4452d1e95cb4
```
