### PR TITLE
style(userspace/engine): avoid creating multiple versions of methods only to assume default ruleset. Use a default argument instead.

### DIFF
--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -40,6 +40,7 @@ extern "C" {
 
 string lua_on_event = "on_event";
 string lua_print_stats = "print_stats";
+const std::string falco_engine::m_default_ruleset = "falco-default-ruleset";
 
 using namespace std;
 
@@ -196,11 +197,6 @@ void falco_engine::enable_rule(const string &substring, bool enabled, const stri
 	}
 }
 
-void falco_engine::enable_rule(const string &substring, bool enabled)
-{
-	enable_rule(substring, enabled, m_default_ruleset);
-}
-
 void falco_engine::enable_rule_exact(const string &rule_name, bool enabled, const string &ruleset)
 {
 	uint16_t ruleset_id = find_ruleset_id(ruleset);
@@ -212,11 +208,6 @@ void falco_engine::enable_rule_exact(const string &rule_name, bool enabled, cons
 	}
 }
 
-void falco_engine::enable_rule_exact(const string &rule_name, bool enabled)
-{
-	enable_rule_exact(rule_name, enabled, m_default_ruleset);
-}
-
 void falco_engine::enable_rule_by_tag(const set<string> &tags, bool enabled, const string &ruleset)
 {
 	uint16_t ruleset_id = find_ruleset_id(ruleset);
@@ -225,11 +216,6 @@ void falco_engine::enable_rule_by_tag(const set<string> &tags, bool enabled, con
 	{
 		it.second->enable_tags(tags, enabled, ruleset_id);
 	}
-}
-
-void falco_engine::enable_rule_by_tag(const set<string> &tags, bool enabled)
-{
-	enable_rule_by_tag(tags, enabled, m_default_ruleset);
 }
 
 void falco_engine::set_min_priority(falco_common::priority_type priority)
@@ -277,11 +263,6 @@ void falco_engine::evttypes_for_ruleset(std::string &source, std::set<uint16_t> 
 
 	it->second->evttypes_for_ruleset(evttypes, ruleset_id);
 
-}
-
-void falco_engine::evttypes_for_ruleset(std::string &source, std::set<uint16_t> &evttypes)
-{
-	evttypes_for_ruleset(source, evttypes, m_default_ruleset);
 }
 
 std::shared_ptr<gen_event_formatter> falco_engine::create_formatter(const std::string &source,

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -40,7 +40,7 @@ extern "C" {
 
 string lua_on_event = "on_event";
 string lua_print_stats = "print_stats";
-const std::string falco_engine::m_default_ruleset = "falco-default-ruleset";
+const std::string falco_engine::s_default_ruleset = "falco-default-ruleset";
 
 using namespace std;
 
@@ -63,7 +63,7 @@ falco_engine::falco_engine(bool seed_rng, const std::string& alternate_lua_dir)
 		srandom((unsigned) getpid());
 	}
 
-	m_default_ruleset_id = find_ruleset_id(m_default_ruleset);
+	m_default_ruleset_id = find_ruleset_id(s_default_ruleset);
 }
 
 falco_engine::~falco_engine()

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -266,7 +266,7 @@ private:
 	double m_sampling_multiplier;
 
 	std::string m_lua_main_filename = "rule_loader.lua";
-	static std::string m_default_ruleset;
+	static const std::string m_default_ruleset;
 	uint32_t m_default_ruleset_id;
 
 	std::string m_extra;

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -78,16 +78,16 @@ public:
 	// be passed as an argument to process_event(). This allows
 	// for different sets of rules being active at once.
 	//
-	void enable_rule(const std::string &substring, bool enabled, const std::string &ruleset = m_default_ruleset);
+	void enable_rule(const std::string &substring, bool enabled, const std::string &ruleset = s_default_ruleset);
 
 
 	// Like enable_rule, but the rule name must be an exact match.
-	void enable_rule_exact(const std::string &rule_name, bool enabled, const std::string &ruleset = m_default_ruleset);
+	void enable_rule_exact(const std::string &rule_name, bool enabled, const std::string &ruleset = s_default_ruleset);
 
 	//
 	// Enable/Disable any rules with any of the provided tags (set, exact matches only)
 	//
-	void enable_rule_by_tag(const std::set<std::string> &tags, bool enabled, const std::string &ruleset = m_default_ruleset);
+	void enable_rule_by_tag(const std::set<std::string> &tags, bool enabled, const std::string &ruleset = s_default_ruleset);
 
 	// Only load rules having this priority or more severe.
 	void set_min_priority(falco_common::priority_type priority);
@@ -197,7 +197,7 @@ public:
 	//
 	void evttypes_for_ruleset(std::string &source,
 				  std::set<uint16_t> &evttypes,
-				  const std::string &ruleset = m_default_ruleset);
+				  const std::string &ruleset = s_default_ruleset);
 
 	//
 	// Given a source and output string, return an
@@ -266,7 +266,7 @@ private:
 	double m_sampling_multiplier;
 
 	std::string m_lua_main_filename = "rule_loader.lua";
-	static const std::string m_default_ruleset;
+	static const std::string s_default_ruleset;
 	uint32_t m_default_ruleset_id;
 
 	std::string m_extra;

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -78,25 +78,16 @@ public:
 	// be passed as an argument to process_event(). This allows
 	// for different sets of rules being active at once.
 	//
-	void enable_rule(const std::string &substring, bool enabled, const std::string &ruleset);
-
-	// Wrapper that assumes the default ruleset
-	void enable_rule(const std::string &substring, bool enabled);
+	void enable_rule(const std::string &substring, bool enabled, const std::string &ruleset = m_default_ruleset);
 
 
 	// Like enable_rule, but the rule name must be an exact match.
-	void enable_rule_exact(const std::string &rule_name, bool enabled, const std::string &ruleset);
-
-	// Wrapper that assumes the default ruleset
-	void enable_rule_exact(const std::string &rule_name, bool enabled);
+	void enable_rule_exact(const std::string &rule_name, bool enabled, const std::string &ruleset = m_default_ruleset);
 
 	//
 	// Enable/Disable any rules with any of the provided tags (set, exact matches only)
 	//
-	void enable_rule_by_tag(const std::set<std::string> &tags, bool enabled, const std::string &ruleset);
-
-	// Wrapper that assumes the default ruleset
-	void enable_rule_by_tag(const std::set<std::string> &tags, bool enabled);
+	void enable_rule_by_tag(const std::set<std::string> &tags, bool enabled, const std::string &ruleset = m_default_ruleset);
 
 	// Only load rules having this priority or more severe.
 	void set_min_priority(falco_common::priority_type priority);
@@ -206,11 +197,7 @@ public:
 	//
 	void evttypes_for_ruleset(std::string &source,
 				  std::set<uint16_t> &evttypes,
-				  const std::string &ruleset);
-
-	// Assuming default ruleset
-	void evttypes_for_ruleset(std::string &source,
-				  std::set<uint16_t> &evttypes);
+				  const std::string &ruleset = m_default_ruleset);
 
 	//
 	// Given a source and output string, return an
@@ -279,7 +266,7 @@ private:
 	double m_sampling_multiplier;
 
 	std::string m_lua_main_filename = "rule_loader.lua";
-	std::string m_default_ruleset = "falco-default-ruleset";
+	static std::string m_default_ruleset;
 	uint32_t m_default_ruleset_id;
 
 	std::string m_extra;


### PR DESCRIPTION
`Signed-off-by: Federico Di Pierro <nierro92@gmail.com>`

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Avoid creating multiple methods to only route that m_default_ruleset to main method; properly use a default argument instead.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
