### PR TITLE
Sign Packages and Linux Repositories with SHA256.

### DIFF
--- a/scripts/publish-deb
+++ b/scripts/publish-deb
@@ -23,7 +23,7 @@ add_deb() {
     cp -f $3 $1/$2
     pushd $1/$2 > /dev/null
     rm -f $(basename -- $3).asc
-    gpg --detach-sign --armor $(basename -- $3)
+    gpg --detach-sign --digest-algo SHA256 --armor $(basename -- $3)
     popd > /dev/null
 }
 
@@ -63,7 +63,7 @@ update_repo() {
       ${release_dir} > ${release_dir}/Release
 
     # release signature
-    gpg --detach-sign --armor ${release_dir}/Release
+    gpg --detach-sign --digest-algo SHA256 --armor ${release_dir}/Release
     rm -f ${release_dir}/Release.gpg
     mv ${release_dir}/Release.asc ${release_dir}/Release.gpg
 

--- a/scripts/publish-rpm
+++ b/scripts/publish-rpm
@@ -22,7 +22,7 @@ add_rpm() {
     cp -f $2 $1
     pushd $1 > /dev/null
     rm -f $(basename -- $2).asc
-    gpg --detach-sign --armor $(basename -- $2)
+    gpg --detach-sign --digest-algo SHA256 --armor $(basename -- $2)
     popd > /dev/null
 }
 
@@ -33,7 +33,7 @@ update_repo() {
     pushd $1 > /dev/null
     createrepo --update --no-database .
     rm -f repodata/repomd.xml.asc
-    gpg --detach-sign --armor repodata/repomd.xml
+    gpg --detach-sign --digest-algo SHA256 --armor repodata/repomd.xml
     popd > /dev/null
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Currently, Falco Linux packages are signed with SHA1. This prevents the installation of Falco on high-assurance systems that do not allow for the installation of packages without signatures made using SHA256.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1751

**Special notes for your reviewer**:
The SHA256 algorithms should be well supported by Linux distributions in use today. I do not believe this this will break installs for anyone.

**Does this PR introduce a user-facing change?**:
Linux packages and repositories that are created with the modified build scripts will have newer signature algorithms. 

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
update: Linux packages are now signed with SHA256
```
