### PR TITLE
Update k8s rules

### DIFF
--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -303,17 +303,28 @@
 
 - list: known_sa_list
   items: [
+    coredns,
+    coredns-autoscaler,
     cronjob-controller,
     daemon-set-controller,
     deployment-controller,
     disruption-controller,
     endpoint-controller,
     endpointslice-controller,
+    endpointslicemirroring-controller,
     generic-garbage-collector,
+    horizontal-pod-autoscaler,
+    job-controller,
     namespace-controller,
+    node-controller,
+    persistent-volume-binder,
     pod-garbage-collector,
+    pv-protection-controller,
+    pvc-protection-controller,
     replicaset-controller,
     resourcequota-controller,
+    root-ca-cert-publisher,
+    service-account-controller,
     statefulset-controller
     ]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature
/kind rule-update


**Any specific area of the project related to this PR?**

/area rules


**What this PR does / why we need it**:

This PR adds a few more default k8s service accounts to the `known_sa_list` (these service accounts belong to default k8s controllers, see docs https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/).

Not listed in the docs mentioned above are the coredns sa's. As CoreDNS is such an integral part of k8s I opted to list coredns and coredns-autoscaler sa's as well.

To make the sa list easier to view, imo, I formatted it as 1 item per line and ordered all entries alphabetically.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rule(list known_sa_list): add coredns, coredns-autoscaler, endpointslicemirroring-controller, horizontal-pod-autoscaler, job-controller, node-controller (nodelifecycle), persistent-volume-binder, pv-protection-controller, pvc-protection-controller, root-ca-cert-publisher and service-account-controller as allowed service accounts in the kube-system namespace
```
