### PR TITLE
fix(userspace/falco): in case output_file cannot be opened, throw a falco exception

### DIFF
--- a/userspace/falco/outputs_file.cpp
+++ b/userspace/falco/outputs_file.cpp
@@ -28,6 +28,10 @@ void falco::outputs::output_file::open_file()
 	if(!m_outfile.is_open())
 	{
 		m_outfile.open(m_oc.options["filename"], fstream::app);
+		if (m_outfile.fail())
+		{
+			throw falco_exception("failed to open output file " + m_oc.options["filename"]);
+		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR just throws an error if desired `output_file` failed to be created:

```
Mon Nov  8 11:00:01 2021: Falco version 0.30.0-19+f7893fb (driver version a03ccfda795f2ba711b80f69cb06869f2b63121b)
Mon Nov  8 11:00:01 2021: Falco initialized with configuration file ../falco.yaml
Mon Nov  8 11:00:01 2021: Loading rules from file ../rules/falco_rules.yaml:
Mon Nov  8 11:00:02 2021: Starting internal webserver, listening on port 8765
Mon Nov  8 11:00:10 2021: file: failed to open output file /home/federicoo/events.txt
11:00:10.602534779: Error File below known binary directory renamed/removed (user=root user_loginuid=1000 command=rm -i /usr/bin/topkek pcmdline=sudo rm -i /usr/bin/topkek operation=unlinkat file=<NA> res=0 dirfd=-100(AT_FDCWD) name=/usr/bin/topkek flags=0  container_id=host image=<NA>)
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
