### PR TITLE
fix(userspace/engine): supporting enabled-only overwritten rules

### DIFF
--- a/test/falco_tests.yaml
+++ b/test/falco_tests.yaml
@@ -354,7 +354,7 @@ trace_files: !mux
     exit_status: 1
     stdout_is: |+
       1 errors:
-      Rule must have exceptions or condition property
+      Appended rule must have exceptions or condition property
       ---
       - rule: no condition rule
         append: true

--- a/test/falco_tests.yaml
+++ b/test/falco_tests.yaml
@@ -634,7 +634,13 @@ trace_files: !mux
     rules_file:
       - rules/single_rule_enabled_flag.yaml
     trace_file: trace_files/cat_write.scap
-
+  
+  disabled_rule_using_false_enabled_flag_only:
+    detect: False
+    rules_file:
+      - rules/disabled_rule_using_enabled_flag_only.yaml
+    trace_file: trace_files/cat_write.scap
+  
   disabled_and_enabled_rules_1:
     exit_status: 1
     stderr_contains: "Runtime error: You can not specify both disabled .-D/-T. and enabled .-t. rules. Exiting."

--- a/test/falco_tests.yaml
+++ b/test/falco_tests.yaml
@@ -641,6 +641,14 @@ trace_files: !mux
       - rules/disabled_rule_using_enabled_flag_only.yaml
     trace_file: trace_files/cat_write.scap
   
+  enabled_rule_using_false_enabled_flag_only:
+    detect: True
+    detect_level: WARNING
+    rules_file:
+      - rules/enabled_rule_using_enabled_flag_only.yaml
+    trace_file: trace_files/cat_write.scap
+    stdout_contains: "Warning An open was seen"
+
   disabled_and_enabled_rules_1:
     exit_status: 1
     stderr_contains: "Runtime error: You can not specify both disabled .-D/-T. and enabled .-t. rules. Exiting."

--- a/test/rules/disabled_rule_using_enabled_flag_only.yaml
+++ b/test/rules/disabled_rule_using_enabled_flag_only.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2021 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+- rule: open_from_cat
+  desc: A process named cat does an open
+  condition: evt.type=open and proc.name=cat
+  output: "An open was seen"
+  priority: WARNING
+
+- rule: open_from_cat
+  enabled: false

--- a/test/rules/enabled_rule_using_enabled_flag_only.yaml
+++ b/test/rules/enabled_rule_using_enabled_flag_only.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2021 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+- rule: open_from_cat
+  desc: A process named cat does an open
+  condition: evt.type=open and proc.name=cat
+  output: "An open was seen"
+  priority: WARNING
+  enabled: false
+
+- rule: open_from_cat
+  enabled: true

--- a/test/rules/invalid_append_rule_without_condition.yaml
+++ b/test/rules/invalid_append_rule_without_condition.yaml
@@ -1,2 +1,24 @@
+#
+# Copyright (C) 2021 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+- rule: no condition rule
+  desc: simpe rule 
+  condition: evt.type=open
+  output: simple output
+  priority: WARNING
+
 - rule: no condition rule
   append: true


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>
Co-authored-by: Leonardo Grasso <me@leonardograsso.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:
This enables overwriting rules by specifying their name and the `enabled` field only, so that users can easily enable/disable already-defined rules. The expected behavior is to be able to overwrite rules like the following (example from @leogr):
```
- rule: A rule enabled by default
  enabled: false
```

The following issues currently prevent this from being supported:
- Every rule is forced to either specify a `condition` or an `exception` field. However, this conceptually applies only to rules having `append` set as `true`.
- Overwritten rules are entirely substituted to their already-defined counterpart. This is correct, however it does not support changing the `enabled` flag only, which is a feature demanded by the community.

Proof of this ambiguity can be seen in the current version of `falco-website`, which reports a non-working example: https://github.com/falcosecurity/falco-website/blob/4a7b5eb82027da5dadd50dc688c7ebd55c24bd9e/content/en/docs/rules/_index.md?plain=1#L263

**Which issue(s) this PR fixes**:
Fixes #1537 
Fixes #1510

**Special notes for your reviewer**:
See https://github.com/falcosecurity/falco/issues/1537 for additional context.

**Does this PR introduce a user-facing change?**:
```release-note
fix(userspace/engine): supporting enabled-only overwritten rules
```
