### PR TITLE
build: always populate partial version variables

### DIFF
--- a/cmake/modules/GetFalcoVersion.cmake
+++ b/cmake/modules/GetFalcoVersion.cmake
@@ -31,29 +31,33 @@ if(NOT FALCO_VERSION)
   else()
     # A tag has been found: use it as the Falco version
     set(FALCO_VERSION "${FALCO_TAG}")
-    # Remove the starting "v" in case there is one
-    string(REGEX REPLACE "^v(.*)" "\\1" FALCO_VERSION "${FALCO_TAG}")
-  endif()
-  # TODO(leodido) > ensure Falco version is semver before extracting parts Populate partial version variables
-  string(REGEX MATCH "^(0|[1-9][0-9]*)" FALCO_VERSION_MAJOR "${FALCO_VERSION}")
-  string(REGEX REPLACE "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\..*" "\\2" FALCO_VERSION_MINOR "${FALCO_VERSION}")
-  string(REGEX REPLACE "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*).*" "\\3" FALCO_VERSION_PATCH
-                       "${FALCO_VERSION}")
-  string(
-    REGEX
-    REPLACE
-      "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*).*"
-      "\\5"
-      FALCO_VERSION_PRERELEASE
-      "${FALCO_VERSION}")
-  if(FALCO_VERSION_PRERELEASE STREQUAL "${FALCO_VERSION}")
-    set(FALCO_VERSION_PRERELEASE "")
-  endif()
-  if(NOT FALCO_VERSION_BUILD)
-    string(REGEX REPLACE ".*\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)" "\\1" FALCO_VERSION_BUILD "${FALCO_VERSION}")
-  endif()
-  if(FALCO_VERSION_BUILD STREQUAL "${FALCO_VERSION}")
-    set(FALCO_VERSION_BUILD "")
   endif()
 endif()
+
+# Remove the starting "v" in case there is one
+string(REGEX REPLACE "^v(.*)" "\\1" FALCO_VERSION "${FALCO_VERSION}")
+
+# TODO(leodido) > ensure Falco version is semver before extracting parts Populate partial version variables
+string(REGEX MATCH "^(0|[1-9][0-9]*)" FALCO_VERSION_MAJOR "${FALCO_VERSION}")
+string(REGEX REPLACE "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\..*" "\\2" FALCO_VERSION_MINOR "${FALCO_VERSION}")
+string(REGEX REPLACE "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*).*" "\\3" FALCO_VERSION_PATCH
+                     "${FALCO_VERSION}")
+string(
+  REGEX
+  REPLACE
+    "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*).*"
+    "\\5"
+    FALCO_VERSION_PRERELEASE
+    "${FALCO_VERSION}")
+
+if(FALCO_VERSION_PRERELEASE STREQUAL "${FALCO_VERSION}")
+  set(FALCO_VERSION_PRERELEASE "")
+endif()
+if(NOT FALCO_VERSION_BUILD)
+  string(REGEX REPLACE ".*\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)" "\\1" FALCO_VERSION_BUILD "${FALCO_VERSION}")
+endif()
+if(FALCO_VERSION_BUILD STREQUAL "${FALCO_VERSION}")
+  set(FALCO_VERSION_BUILD "")
+endif()
+
 message(STATUS "Falco version: ${FALCO_VERSION}")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

When FALCO_VERSION was provided via a CMake variable, the build would
eventually fail because the partial version variables hadn't been
populated. Move the creation of those outside the check of FALCO_VERSION
being set so they also happen when that is provided too.

**Which issue(s) this PR fixes**:

Fixes: #1654

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```