### PR TITLE
correctly clean loaded drivers in `falco-driver-loader`

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -307,9 +307,9 @@ clean_kernel_module() {
 	fi
 	for CURRENT_VER in ${DRIVER_VERSIONS}; do
 		if dkms remove "${CURRENT_VER}" --all 2>/dev/null; then
-			echo "* Removing ${DRIVER_NAME}/${CURRENT_VER} succeeded"
+			echo "* Removing ${CURRENT_VER} succeeded"
 		else
-			echo "* Removing ${DRIVER_NAME}/${CURRENT_VER} failed"
+			echo "* Removing ${CURRENT_VER} failed"
 			exit 1
 		fi
 	done

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -300,13 +300,13 @@ clean_kernel_module() {
 		return
 	fi
 
-	DRIVER_VERSIONS=$(dkms status -m "${DRIVER_NAME}" | cut -d',' -f2 | sed -e 's/^[[:space:]]*//')
+	DRIVER_VERSIONS=$(dkms status -m "${DRIVER_NAME}" | cut -d',' -f1 | sed -e 's/^[[:space:]]*//')
 	if [ -z "${DRIVER_VERSIONS}" ]; then
 		echo "* There is no ${DRIVER_NAME} module in dkms"
 		return
 	fi
 	for CURRENT_VER in ${DRIVER_VERSIONS}; do
-		if dkms remove -m "${DRIVER_NAME}" -v "${CURRENT_VER}" --all 2>/dev/null; then
+		if dkms remove "${CURRENT_VER}" --all 2>/dev/null; then
 			echo "* Removing ${DRIVER_NAME}/${CURRENT_VER} succeeded"
 		else
 			echo "* Removing ${DRIVER_NAME}/${CURRENT_VER} failed"


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>
Co-authored-by: Leonardo Grasso <me@leonardograsso.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:
This fixes the `--clean` option of `falco-driver-loader`, which currently fails to remove the loaded kernel modules. The fail was caused by grabbing the wrong token from the output of `dkms status -m falco`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
