### PR TITLE
update(build): bump FakeIt version

### DIFF
--- a/cmake/modules/DownloadFakeIt.cmake
+++ b/cmake/modules/DownloadFakeIt.cmake
@@ -14,8 +14,8 @@ include(ExternalProject)
 
 set(FAKEIT_INCLUDE ${CMAKE_BINARY_DIR}/fakeit-prefix/include)
 
-set(FAKEIT_EXTERNAL_URL URL https://github.com/eranpeer/fakeit/archive/2.0.5.tar.gz URL_HASH
-                        SHA256=298539c773baca6ecbc28914306bba19d1008e098f8adc3ad3bb00e993ecdf15)
+set(FAKEIT_EXTERNAL_URL URL https://github.com/eranpeer/fakeit/archive/2.0.9.tar.gz URL_HASH
+                        SHA256=dc4ee7b17a84c959019b92c20fce6dc9426e9e170b6edf84db6cb2e188520cd7)
 
 ExternalProject_Add(
   fakeit-external


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

/area tests

**What this PR does / why we need it**:

While working on the unit tests for https://github.com/falcosecurity/falco/pull/1792, I discovered that our `FakeIt` mocking lib is currently broken due to an incompatibility with the version of `Catch2` our cmake setup depends on. 

Even though FakeIt is not used by our unit tests yet, I still believe this is a blocker for the future improvements of our testing suite.

The issue was caused by a macro renaming happened in `Catch2`. After doing some research, this PR seems to fix it: https://github.com/eranpeer/FakeIt/pull/195

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
build: bump FakeIt version to 2.0.9
```
