### PR TITLE
fix(userspace/falco): accept 'Content-Type' header that contains "application/json", but it is not strictly equal to it

### DIFF
--- a/userspace/falco/webserver.cpp
+++ b/userspace/falco/webserver.cpp
@@ -150,7 +150,7 @@ bool k8s_audit_handler::handlePost(CivetServer *server, struct mg_connection *co
 	// Ensure that the content-type is application/json
 	const char *ct = server->getHeader(conn, string("Content-Type"));
 
-	if(ct == NULL || string(ct) != "application/json")
+	if(ct == NULL || strstr(ct, "application/json") == NULL)
 	{
 		mg_send_http_error(conn, 400, "Wrong Content Type");
 

--- a/userspace/falco/webserver.cpp
+++ b/userspace/falco/webserver.cpp
@@ -150,7 +150,8 @@ bool k8s_audit_handler::handlePost(CivetServer *server, struct mg_connection *co
 	// Ensure that the content-type is application/json
 	const char *ct = server->getHeader(conn, string("Content-Type"));
 
-	if(ct == NULL || strstr(ct, "application/json") == NULL)
+	// content type *must* start with application/json
+	if(ct == NULL || strncmp(ct, "application/json", strlen("application/json")) != 0)
 	{
 		mg_send_http_error(conn, 400, "Wrong Content Type");
 


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

**What this PR does / why we need it**:
Do not strictly require "application/json" content-type string in k8s_audit_handler::handlePost(); instead, accept any Content-Type that has "application/json" in it.

**Which issue(s) this PR fixes**:

Fixes #1702 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/falco): accept 'Content-Type' header that contains "application/json", but it is not strictly equal to it
```
