### PR TITLE
Fix false-positive of sssd updating /etc/krb5.keytab

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -772,6 +772,9 @@
 - macro: centrify_writing_krb
   condition: (proc.name in (adjoin,addns) and fd.name startswith /etc/krb5)
 
+- macro: sssd_writing_krb
+  condition: (proc.name=adcli and proc.aname[2]=sssd and fd.name startswith /etc/krb5)
+
 - macro: cockpit_writing_conf
   condition: >
     ((proc.pname=cockpit-kube-la or proc.aname[2]=cockpit-kube-la)
@@ -1215,6 +1218,7 @@
     and not nginx_writing_certs
     and not chef_client_writing_conf
     and not centrify_writing_krb
+    and not sssd_writing_krb
     and not cockpit_writing_conf
     and not ipsec_writing_conf
     and not httpd_writing_ssl_conf
@@ -3122,4 +3126,3 @@
 # Application rules have moved to application_rules.yaml. Please look
 # there if you want to enable them by adding to
 # falco_rules.local.yaml.
-


### PR DESCRIPTION
Signed-off-by: Mac Chaffee <me@macchaffee.com>

**What type of PR is this?**
/kind bug
/kind rule-update

**Any specific area of the project related to this PR?**
/area rules

**What this PR does / why we need it**:

SSSD is a popular tool for getting Linux machines to interoperate with ActiveDirectory. Part of that process involves invoking `adcli` to update /etc/krb5.keytab periodically: https://github.com/SSSD/sssd/blob/a664e9ce08ca6c0f9eb2e260b25463eea9c7829b/src/providers/ad/ad_machine_pw_renewal.c#L30

Looks like we already have exceptions for some tools that update this file (`centrify_writing_krb`), but that exception doesn't include `adcli`

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

Here is an example false positive alert:
```
"16:34:45.928110723: Error File below /etc opened for writing (user=root user_loginuid=-1 command=adcli update --domain=ad.renci.org --host-fqdn=k8s-node08.k8s.renci.org --computer-password-lifetime=30 --domain-controller=dc1.ad.renci.org parent=sssd_be pcmdline=sssd_be --domain ad.renci.org --uid 0 --gid 0 --logger=files file=/etc/krb5.keytab program=adcli gparent=sssd ggparent=systemd gggparent=<NA> container_id=host image=<NA>) k8s.ns=<NA> k8s.pod=<NA> container=host k8s.ns=<NA> k8s.pod=<NA> container=host k8s.ns=<NA> k8s.pod=<NA> container=host"
```

**Does this PR introduce a user-facing change?**:
No.


```release-note
Fixed a false-positive alert that was being generated when SSSD updates /etc/krb5.keytab
```
