### PR TITLE
Logrotation

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -198,6 +198,8 @@ file_output:
   enabled: false
   keep_alive: false
   filename: ./events.txt
+  log_maxage: 0
+  log_maxbackup: 0
 
 stdout_output:
   enabled: true

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -89,7 +89,7 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 	file_output.name = "file";
 	if(m_config->get_scalar<bool>("file_output.enabled", false))
 	{
-		string filename, keep_alive;
+		string filename, keep_alive, log_maxage, log_maxbackup;
 		filename = m_config->get_scalar<string>("file_output.filename", "");
 		if(filename == string(""))
 		{
@@ -99,6 +99,12 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 
 		keep_alive = m_config->get_scalar<string>("file_output.keep_alive", "");
 		file_output.options["keep_alive"] = keep_alive;
+
+		log_maxage = m_config->get_scalar<string>("file_output.log_maxage", "0");
+		file_output.options["log_maxage"] = log_maxage;
+
+		log_maxbackup = m_config->get_scalar<string>("file_output.log_maxbackup", "0");
+		file_output.options["log_maxbackup"] = log_maxbackup;
 
 		m_outputs.push_back(file_output);
 	}

--- a/userspace/falco/outputs_file.cpp
+++ b/userspace/falco/outputs_file.cpp
@@ -70,8 +70,11 @@ void falco::outputs::output_file::logrotate()
 
 	if(m_oc.options["log_maxbackup"] == "0")
 	{
-		// Return value of truncate is not meaningful in this case.
-		static_cast<void>(truncate(m_oc.options["filename"].c_str(), 0));
+		// Return value of truncate is not meaningful.
+		if(!truncate(m_oc.options["filename"].c_str(), 0))
+		{
+			//Do nothing.
+		}
 	}
 	else
 	{

--- a/userspace/falco/outputs_file.cpp
+++ b/userspace/falco/outputs_file.cpp
@@ -19,6 +19,11 @@ limitations under the License.
 #include <fstream>
 #include "banned.h" // This raises a compilation error when certain functions are used
 
+falco::outputs::output_file::output_file()
+{
+	m_lastlog = time(nullptr);
+}
+
 void falco::outputs::output_file::open_file()
 {
 	if(!m_buffered)
@@ -56,7 +61,7 @@ void falco::outputs::output_file::logrotate()
 	}
 
 	std::time_t now = time(nullptr);
-	double diff = difftime(now, lastlog);
+	double diff = difftime(now, m_lastlog);
 
 	if(diff/m_secs_day < std::stoi(m_oc.options["log_maxage"]))
 	{
@@ -71,17 +76,17 @@ void falco::outputs::output_file::logrotate()
 	else
 	{
 		cleanup();
-		lastlog = now;
+		m_lastlog = now;
 		struct tm *tn = localtime(&now);
 
 		std::string log_name = m_oc.options["filename"]+"_" + to_string(tn->tm_year) + to_string(tn->tm_mon) + to_string(tn->tm_mday) + to_string(tn->tm_hour) + to_string(tn->tm_min) + to_string(tn->tm_sec) + ".txt";
 
-		rotating_queue.push(log_name);
+		m_rotating_queue.push(log_name);
 		rename(m_oc.options["filename"].c_str(), log_name.c_str());
-		if(rotating_queue.size()> stoi(m_oc.options["log_maxbackup"]))
+		if(m_rotating_queue.size()> stoi(m_oc.options["log_maxbackup"]))
 		{
-			remove(rotating_queue.front().data());
-			rotating_queue.pop();
+			remove(m_rotating_queue.front().data());
+			m_rotating_queue.pop();
 		}
 	}
 

--- a/userspace/falco/outputs_file.cpp
+++ b/userspace/falco/outputs_file.cpp
@@ -65,7 +65,8 @@ void falco::outputs::output_file::logrotate()
 
 	if(m_oc.options["log_maxbackup"] == "0")
 	{
-		truncate(m_oc.options["filename"].c_str(), 0);
+		// Return value of truncate is not meaningful in this case.
+		static_cast<void>(truncate(m_oc.options["filename"].c_str(), 0));
 	}
 	else
 	{

--- a/userspace/falco/outputs_file.h
+++ b/userspace/falco/outputs_file.h
@@ -28,7 +28,6 @@ namespace outputs
 
 class output_file : public abstract_output
 {
-	output_file();
 
 	void output(const message *msg);
 
@@ -38,6 +37,8 @@ class output_file : public abstract_output
 
 	void logrotate();
 
+public:
+	output_file();
 private:
 	void open_file();
 

--- a/userspace/falco/outputs_file.h
+++ b/userspace/falco/outputs_file.h
@@ -28,6 +28,8 @@ namespace outputs
 
 class output_file : public abstract_output
 {
+	output_file();
+
 	void output(const message *msg);
 
 	void cleanup();
@@ -40,8 +42,8 @@ private:
 	void open_file();
 
 	std::ofstream m_outfile;
-	std::queue<string> rotating_queue;
-	std::time_t lastlog = time(nullptr);
+	std::queue<string> m_rotating_queue;
+	std::time_t m_lastlog;
 	const unsigned int m_secs_day = 86400;
 };
 

--- a/userspace/falco/outputs_file.h
+++ b/userspace/falco/outputs_file.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include "outputs.h"
 #include <iostream>
 #include <fstream>
+#include <ctime>
 
 namespace falco
 {
@@ -33,10 +34,15 @@ class output_file : public abstract_output
 
 	void reopen();
 
+	void logrotate();
+
 private:
 	void open_file();
 
 	std::ofstream m_outfile;
+	std::queue<string> rotating_queue;
+	std::time_t lastlog = time(nullptr);
+	const unsigned int m_secs_day = 86400;
 };
 
 } // namespace outputs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The aim of this PR is to implement a simple log rotation mechanism specifically for logs written via `file_output` by Falco.
As stated in issue #1808, the current behavior is to never empty/rotate these files.

Two new config parameters can be applied to `file_output` in the Falco config file:

- `log_maxage: days` represents the number of days worth of output that are kept in the configured `file_output` file, as is written by Falco. The file is emptied after _days_ days, and the old content is "rotated" (moved to a different file). Default is `log_maxage: 0`, which means that the configured `file_output` is never emptied or rotated.
- `log_maxbackup: n` represents the number of old logs (already rotated) to be kept in the same directory as the configured `file_output`. If _n_ logs are already present and a new one needs to be rotated, Falco will remove the oldest log file, following a FIFO policy. Rotated files follow a _filename_timestamp_ naming convention, with _filename_ being the original configuration of `file_output` and _timestamp_ a representation of year/month/day/hour/min/sec when the file was rotated.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1808 implementing the proposed feature.

**Special notes for your reviewer**:

Original proposal in #1808 mentions also a log rotation policy based on the size of the current `file_output` file.
I chose to not implement this third parameter/policy, as in my opinion it is highly unlikely that the size of the file will be a relevant factor for log rotation, considering that the contents of `file_output` should already be considered exceptional events (alerts).

The proposed implementation keeps track of the rotated logs and timestamps internally, with a minimum number of interaction with the host's filesystem. This is to prevent the logrotate feature from introducing too many additional syscalls by itself. A consequence of this choice is that when Falco is started, already present log files from previous executions are not recognized and thus ignored (they will not be part of the set of `log_maxbackup` logs). 

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
