### PR TITLE
fix: set http output contenttype to text/plain when json output is disabled

### DIFF
--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -135,7 +135,7 @@ void falco_outputs::add_output(falco::outputs::config oc)
 		throw falco_exception("Output not supported: " + oc.name);
 	}
 
-	oo->init(oc, m_buffered, m_hostname);
+	oo->init(oc, m_buffered, m_hostname, m_json_output);
 	m_outputs.push_back(oo);
 }
 

--- a/userspace/falco/outputs.h
+++ b/userspace/falco/outputs.h
@@ -63,11 +63,12 @@ class abstract_output
 public:
 	virtual ~abstract_output() {}
 
-	void init(config oc, bool buffered, std::string hostname)
+	void init(config oc, bool buffered, std::string hostname, bool json_output)
 	{
 		m_oc = oc;
 		m_buffered = buffered;
 		m_hostname = hostname;
+		m_json_output = json_output;
 	}
 
 	// Return the output's name as per its configuration.
@@ -89,6 +90,7 @@ protected:
 	config m_oc;
 	bool m_buffered;
 	std::string m_hostname;
+	bool m_json_output;
 };
 
 } // namespace outputs

--- a/userspace/falco/outputs_http.cpp
+++ b/userspace/falco/outputs_http.cpp
@@ -28,7 +28,12 @@ void falco::outputs::output_http::output(const message *msg)
 	curl = curl_easy_init();
 	if(curl)
 	{
-		slist1 = curl_slist_append(slist1, "Content-Type: application/json");
+		if (m_json_output)
+		{
+			slist1 = curl_slist_append(slist1, "Content-Type: application/json");
+		} else {
+			slist1 = curl_slist_append(slist1, "Content-Type: text/plain");
+		}
 		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist1);
 		curl_easy_setopt(curl, CURLOPT_URL, m_oc.options["url"].c_str());
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, msg->msg.c_str());


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:
The PR sets the http output Content-type header to a more meaningful value (text/plain) when json_output is disabled.

**Which issue(s) this PR fixes**:

Fixes #1824 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix: set http output contenttype to text/plain when json output is disabled
```