### PR TITLE
fix(macro modify_shell_history, truncate_shell_history): avoid false positives from .zsh_history.new and .LOCK files

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2574,15 +2574,15 @@
   condition: >
     (modify and (
       evt.arg.name contains "bash_history" or
-      evt.arg.name contains "zsh_history" or
+      evt.arg.name endswith "zsh_history" or
       evt.arg.name contains "fish_read_history" or
       evt.arg.name endswith "fish_history" or
       evt.arg.oldpath contains "bash_history" or
-      evt.arg.oldpath contains "zsh_history" or
+      evt.arg.oldpath endwith "zsh_history" or
       evt.arg.oldpath contains "fish_read_history" or
       evt.arg.oldpath endswith "fish_history" or
       evt.arg.path contains "bash_history" or
-      evt.arg.path contains "zsh_history" or
+      evt.arg.path endswith "zsh_history" or
       evt.arg.path contains "fish_read_history" or
       evt.arg.path endswith "fish_history"))
 


### PR DESCRIPTION
Signed-off-by: m4wh6k <m4wh6k@users.noreply.github.com>

/kind bug
/kind rule-update
/area rules

**What this PR does / why we need it**:
The default macros modify_shell_history and truncate_shell_history match on .zsh_history.new and .zsh_history.LOCK files, which are temporary files created while using zsh. This causes rules using these macros to produce false positives. This PR changes the macros to use `endswith` rather than `contains`, which makes it work in the expected way.

**Which issue(s) this PR fixes**:
n/a

**Does this PR introduce a user-facing change?**:
No
