### PR TITLE
replace ".." concatenation with table.concat

### DIFF
--- a/userspace/engine/lua/rule_loader.lua
+++ b/userspace/engine/lua/rule_loader.lua
@@ -303,6 +303,7 @@ function get_orig_yaml_obj(rules_lines, row)
             break
         end
     end
+    t[#t + 1] = ""
     local ret = ""
     ret = table.concat(t, "\n")
     return ret


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

When testing exceptions with a large number of auto-generated values we faced an issue with Falco validator memory starvation. That was due to the code performing string concatenation with ".." operator.  Due to the string immutability, each of such operations creates a new copy of the result string keeping the old one in the memory till the GC is run, and the GS won't run at least until the function returns. The above generates a snowball of allocated and unused memory. Rough estimates could give at least an N^2 growth rate. In our tests a ~1MB rules YAML required between 1-2 GB of memory to be parsed.

**What type of PR is this?**

>/kind bug

> /kind design

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> /area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

fix memory mismanagement when converting exceptions

**Which issue(s) this PR fixes**:

fixes memory mismanagement when converting exception


Fixes #

fixes memory mismanagement when converting exception

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE


original code formating is not consistent 3/4 spaces per indent.
indentation changed to 4 spaces. 
please use ignore whitespace when reviewing. 

```release-note
NONE
```
