### PR TITLE
chore: improve --list output using is_source_valid 

### DIFF
--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -466,9 +466,9 @@ static void check_for_ignored_events(sinsp &inspector, falco_engine &engine)
 static void list_source_fields(falco_engine *engine, bool verbose, bool names_only, std::string &source)
 {
 	if(source.size() > 0 &&
-	   !(source == syscall_source || source == k8s_audit_source))
+	   !engine->is_source_valid(source))
 	{
-		throw std::invalid_argument("Value for --list must be \"syscall\" or \"k8s_audit\"");
+		throw std::invalid_argument("Value for --list must be a valid source type");
 	}
 	engine->list_fields(source, verbose, names_only);
 }


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area rules

> /area tests

> /area proposals

**What this PR does / why we need it**:
This PR allows using the `--list` Falco option to selectively list fields related to sources introduced by plugins, for instance `--list=aws_cloudtrail`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
chore: --list option can be used to selectively list fields related to new sources that are introduced by plugins
```
