### PR TITLE
update: support non-enumerable event sources in gRPC outputs service

### DIFF
--- a/userspace/falco/outputs.proto
+++ b/userspace/falco/outputs.proto
@@ -45,10 +45,11 @@ message request {
 message response {
   google.protobuf.Timestamp time = 1;
   falco.schema.priority priority = 2;
-  falco.schema.source source = 3;
+  falco.schema.source source_deprecated = 3 [deprecated=true];
   string rule = 4;
   string output = 5;
   map<string, string> output_fields = 6;
   string hostname = 7;
   repeated string tags = 8;
+  string source = 9;
 }

--- a/userspace/falco/outputs_grpc.cpp
+++ b/userspace/falco/outputs_grpc.cpp
@@ -21,6 +21,20 @@ limitations under the License.
 #include "formats.h"
 #include "banned.h" // This raises a compilation error when certain functions are used
 
+#if __has_attribute(deprecated)
+#define DISABLE_WARNING_PUSH                        _Pragma("GCC diagnostic push")
+#define DISABLE_WARNING_POP                         _Pragma("GCC diagnostic pop")
+#define DISABLE_WARNING_DEPRECATED_DECLARATIONS     _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif defined(_MSC_VER)
+#define DISABLE_WARNING_PUSH                        __pragma(warning(push))
+#define DISABLE_WARNING_POP                         __pragma(warning(pop)) 
+#define DISABLE_WARNING_DEPRECATED_DECLARATIONS     __pragma(warning(disable: 4996))
+#else
+#define DISABLE_WARNING_PUSH
+#define DISABLE_WARNING_POP
+#define DISABLE_WARNING_DEPRECATED_DECLARATIONS
+#endif
+
 void falco::outputs::output_grpc::output(const message *msg)
 {
 	falco::outputs::response grpc_res;
@@ -46,7 +60,10 @@ void falco::outputs::output_grpc::output(const message *msg)
 		// unknown source names are expected to come from plugins
 		s = falco::schema::source::PLUGIN;
 	}
+	DISABLE_WARNING_PUSH
+	DISABLE_WARNING_DEPRECATED_DECLARATIONS
 	grpc_res.set_source_deprecated(s);
+	DISABLE_WARNING_POP
 
 	// priority
 	falco::schema::priority p = falco::schema::priority::EMERGENCY;

--- a/userspace/falco/schema.proto
+++ b/userspace/falco/schema.proto
@@ -60,4 +60,7 @@ enum source {
   INTERNAL = 2;
   internal = 2;
   Internal = 2;
+  PLUGIN = 3;
+  plugin = 3;
+  Plugin = 3;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind design

/kind feature

**Any specific area of the project related to this PR?**

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

See https://github.com/falcosecurity/falco/issues/1826 for details about the issue.

This deprecates the `source` field in `outputs.proto`, and adds a `PLUGIN` entry in the source enum. The goal is to maintain backward compatibility for clients relying on old protobufs versions. Accordingly, a new string field for the event source is added. This is required by plugin system, as the source name is determined by the source plugin loaded and it's not enumerable anymore.

**Which issue(s) this PR fixes**:

Fixes #1826 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
update: support non-enumerable event sources in gRPC outputs service
```
