### PR TITLE
fix(engine): correctly format json output in json_event

### DIFF
--- a/userspace/engine/json_evt.cpp
+++ b/userspace/engine/json_evt.cpp
@@ -1529,12 +1529,9 @@ void json_event_formatter::set_format(output_format of, const std::string &forma
 bool json_event_formatter::tostring_withformat(gen_event *gevt, std::string &output, gen_event_formatter::output_format of)
 {
 	json_event *ev = static_cast<json_event *>(gevt);
-
-	std::string ret;
-
 	if(of == OF_JSON)
 	{
-		ret = tojson(ev);
+		output = tojson(ev);
 		return true;
 	}
 	else


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Due to the changes of https://github.com/falcosecurity/falco/pull/1715, `json_event_formatter` does not format events properly when the JSON output is enabled. This is caused by the return value not being propagated properly. This seems to be what caused the issues of #1845.

**Which issue(s) this PR fixes**:

Fixes #1845

**Special notes for your reviewer**:

This has been tested by building Falco locally from source. Running the following tests without the changes of this PR made me reproduce the issues of #1845, which now seem to be fixed.

```
mkdir build
cd build
cmake ..
make falco
userspace/falco/falco -r ../rules/k8s_audit_rules.yaml -e ../test/trace_files/k8s_audit/anonymous_creates_namespace_foo.json -o json_output=true
```

**Does this PR introduce a user-facing change?**:

```release-note
fix(engine): correctly format json output in json_event
```
