### PR TITLE
[feature] Ability to set user-agent variable for http_output

### DIFF
--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -148,6 +148,10 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 		}
 		http_output.options["url"] = url;
 
+		string user_agent;
+		user_agent = m_config->get_scalar<string>("http_output.user_agent","falcosecurity/falco");
+		http_output.options["user_agent"] = user_agent;
+
 		m_outputs.push_back(http_output);
 	}
 

--- a/userspace/falco/outputs_http.cpp
+++ b/userspace/falco/outputs_http.cpp
@@ -34,10 +34,13 @@ void falco::outputs::output_http::output(const message *msg)
 		} else {
 			slist1 = curl_slist_append(slist1, "Content-Type: text/plain");
 		}
+        slist1 = curl_slist_append(slist1, m_oc.options["user_agent"].c_str());
+
 		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist1);
 		curl_easy_setopt(curl, CURLOPT_URL, m_oc.options["url"].c_str());
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, msg->msg.c_str());
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, -1L);
+
 
 		res = curl_easy_perform(curl);
 


### PR DESCRIPTION
/kind feature

/area engine


**What this PR does / why we need it**:

This allows to identify falco's datastream sent via http_output on the receiving end.

In my particular case that is logstash with its http listener. 

Since I have multiple processes submitting via http from the same machine, I need a way to distinguish falco's events from other incoming data streams for further parsing and processing.

**Which issue(s) this PR fixes**:

Fixes #1831 

**Does this PR introduce a user-facing change?**:

A config entry of user_agent: "some string" is now supported under http_output. If not provided, the value defaults to "falcosecurity/falco".

Setting it to "" ought to restore previous behaviour (that field appears to be present in http headers, but with blank value).


```release-note
Add ability to set User-Agent http header when sending http output. Provide default value of 'falcosecurit/falco'.
```
