### PR TITLE
new(configuration): support defining plugin init config as a YAML

### DIFF
--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -168,6 +168,10 @@ private:
 					int nodeIdx = std::stoi(key.substr(i + 1, close_param_idx - i - 1));
 					ret.reset(ret[nodeIdx]);
 					i = close_param_idx;
+					if (i < key.size() - 1 && key[i + 1] == '.')
+					{
+						i++;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind design

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR cleans up the plugin configuration reading, and supports init configs defined in YAML format. With this, users can define the `init_config` fields either as a string, or as a YAML map. In the first case, the string is opaque and passed as-is to the plugin framework of `libs`. In the second case, the YAML is parsed and converted to a JSON string. This is useful for two purposes:
- Coupled with the feature of https://github.com/falcosecurity/libs/pull/175, this allows defining structured configuration data more easily, along with automatic validation and error checking
- Defining/overriding plugin init configs with Falco's `-o` cli parameter

The YAML data is converted in JSON format for simplicity and because that is the only schema-based data format we support as for https://github.com/falcosecurity/libs/pull/175. This can easily be extended in the future to more formats if required, as the plugin-provided schema dictates the format expected by a given plugin.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This also includes a minor fix to the changes introduced in #1792, and removes the `init_config_file` configuration field.

**Does this PR introduce a user-facing change?**:

```release-note
new(configuration): support defining plugin init config as a YAML
```
