### PR TITLE
docs: fix priority level "info" to "informational"

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -92,7 +92,7 @@ log_level: info
 # Minimum rule priority level to load and run. All rules having a
 # priority more severe than this level will be loaded/run.  Can be one
 # of "emergency", "alert", "critical", "error", "warning", "notice",
-# "info", "debug".
+# "informational", "debug".
 priority: debug
 
 # Whether or not output to any of the output channels below is


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

Thanks to @kirin-13 [reporting](https://github.com/falcosecurity/charts/pull/302), this PR fixes a typo in the `falco.yaml` comments. It changes the priority level from `info` to `informational`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```