### PR TITLE
refactor: remove apt-config utility from debian_packages monitoring

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -216,7 +216,7 @@
 - list: deb_binaries
   items: [dpkg, dpkg-preconfigu, dpkg-reconfigur, dpkg-divert, apt, apt-get, aptitude,
     frontend, preinst, add-apt-reposit, apt-auto-remova, apt-key,
-    apt-listchanges, unattended-upgr, apt-add-reposit, apt-config, apt-cache, apt.systemd.dai
+    apt-listchanges, unattended-upgr, apt-add-reposit, apt-cache, apt.systemd.dai
     ]
 
 # The truncated dpkg-preconfigu is intentional, process names are


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

As suggested by @karthikc911 we could avoid several false positives by removing the `apt-config` utility from debian packages monitoring list. I open this PR only because it could be useful to have it merged in Falco 0.31 but @karthikc911 had the original idea. For more details refer to [the original Pull Request](https://github.com/falcosecurity/falco/pull/1576) or to the [slack channel](https://kubernetes.slack.com/archives/CMWH3EH32/p1615341172249000).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
rule(list deb_binaries): remove `apt-config`
```