### PR TITLE
update(scripts/falco-driver-loader): load the latest version first

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -167,7 +167,7 @@ load_kernel_module_compile() {
 			elif [ -f "$KO_FILE.ko.gz" ]; then
 				KO_FILE="$KO_FILE.ko.gz"
 			elif [ -f "$KO_FILE.ko.xz" ]; then
-				KO_FILE="$KO_FILE.ko.gz"
+				KO_FILE="$KO_FILE.ko.xz"
 			elif [ -f "$KO_FILE.ko.zst" ]; then
 				KO_FILE="$KO_FILE.ko.zst"
 			else

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -160,14 +160,25 @@ load_kernel_module_compile() {
 		echo "make CC=${CURRENT_GCC} \$@" >> /tmp/falco-dkms-make
 		chmod +x /tmp/falco-dkms-make
 		if dkms install --directive="MAKE='/tmp/falco-dkms-make'" -m "${DRIVER_NAME}" -v "${DRIVER_VERSION}" -k "${KERNEL_RELEASE}" 2>/dev/null; then
-			echo "* ${DRIVER_NAME} module installed in dkms, trying to insmod"
-			chcon -t modules_object_t "/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}.ko" > /dev/null 2>&1 || true
-			chcon -t modules_object_t "/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}.ko.xz" > /dev/null 2>&1 || true
-			if insmod "/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}.ko" > /dev/null 2>&1; then
+			echo "* ${DRIVER_NAME} module installed in dkms"
+			KO_FILE="/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}"
+			if [ -f "$KO_FILE.ko" ]; then
+				KO_FILE="$KO_FILE.ko"
+			elif [ -f "$KO_FILE.ko.gz" ]; then
+				KO_FILE="$KO_FILE.ko.gz"
+			elif [ -f "$KO_FILE.ko.xz" ]; then
+				KO_FILE="$KO_FILE.ko.gz"
+			elif [ -f "$KO_FILE.ko.zst" ]; then
+				KO_FILE="$KO_FILE.ko.zst"
+			else
+				>&2 echo "${DRIVER_NAME} module file not found"
+				return
+			fi
+			echo "* ${DRIVER_NAME} module found: ${KO_FILE}"
+			echo "* Trying insmod"
+			chcon -t modules_object_t "$KO_FILE" > /dev/null 2>&1 || true
+			if insmod "$KO_FILE" > /dev/null 2>&1; then
 				echo "* Success: ${DRIVER_NAME} module found and loaded in dkms"
-				exit 0
-			elif insmod "/var/lib/dkms/${DRIVER_NAME}/${DRIVER_VERSION}/${KERNEL_RELEASE}/${ARCH}/module/${DRIVER_NAME}.ko.xz" > /dev/null 2>&1; then
-				echo "* Success: ${DRIVER_NAME} module found and loaded in dkms (xz)"
 				exit 0
 			else
 				echo "* Unable to insmod ${DRIVER_NAME} module"

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -196,8 +196,12 @@ load_kernel_module_download() {
 	if curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${URL}"; then
 		echo "* Download succeeded"
 		chcon -t modules_object_t "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" > /dev/null 2>&1 || true
-		insmod "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" && echo "* Success: ${DRIVER_NAME} module found and inserted"
-		exit $?
+		if insmod "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}"; then
+			echo "* Success: ${DRIVER_NAME} module found and inserted"
+			exit 0
+		else
+			>&2 echo "Unable to insmod the prebuilt ${DRIVER_NAME} module"
+		fi	
 	else
 		>&2 echo "Unable to find a prebuilt ${DRIVER_NAME} module"
 		return
@@ -241,11 +245,6 @@ load_kernel_module() {
 		exit 0
 	fi
 
-	echo "* Trying to load a system ${DRIVER_NAME} module, if present"
-	if modprobe "${DRIVER_NAME}" > /dev/null 2>&1; then
-		echo "* Success: ${DRIVER_NAME} module found and loaded with modprobe"
-		exit 0
-	fi
 
 	echo "* Looking for a ${DRIVER_NAME} module locally (kernel ${KERNEL_RELEASE})"
 
@@ -266,6 +265,13 @@ load_kernel_module() {
 
 	if [ -n "$ENABLE_COMPILE" ]; then
 		load_kernel_module_compile
+	fi
+
+	# Last try (might load a previous driver version)
+	echo "* Trying to load a system ${DRIVER_NAME} module, if present"
+	if modprobe "${DRIVER_NAME}" > /dev/null 2>&1; then
+		echo "* Success: ${DRIVER_NAME} module found and loaded with modprobe"
+		exit 0
 	fi
 
 	# Not able to download a prebuilt module nor to compile one on-the-fly


### PR DESCRIPTION
Signed-off-by: Leonardo Grasso <me@leonardograsso.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR changes the try order for the kernel module installation.

Previously, the first attempt was to load an already installed module (if any) by using `modprobe`. However, that way would possibly load an older module version without even trying to build/download the latest available version.

With this PR, the `modprobe` step is moved later, as a last resort. 
It also includes a further fix for #1862.

**Which issue(s) this PR fixes**:

Fixes #1862

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(scripts/falco-driver-loader): first try to load the latest kmod version, then fallback to an already installed if any
fix(scripts/falco-driver-loader): support kernel object files in `.zst` and `.gz` compression formats
```
