### PR TITLE
build: updated some warning strings; properly refresh lua files embedded in falco

### DIFF
--- a/userspace/engine/lua/CMakeLists.txt
+++ b/userspace/engine/lua/CMakeLists.txt
@@ -10,7 +10,7 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-file(GLOB_RECURSE lua_module_files ${CMAKE_CURRENT_SOURCE_DIR} *.lua)
+file(GLOB_RECURSE lua_files ${CMAKE_CURRENT_SOURCE_DIR} *.lua)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/falco_engine_lua_files.cpp
 	COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/lua-to-cpp.sh ${CMAKE_CURRENT_SOURCE_DIR} ${LYAML_LUA_DIR} ${CMAKE_CURRENT_BINARY_DIR}

--- a/userspace/engine/lua/rule_loader.lua
+++ b/userspace/engine/lua/rule_loader.lua
@@ -1061,7 +1061,7 @@ function load_rules(rules_content,
 	    num_evttypes = falco_rules.add_filter(rules_mgr, lua_parser, v['rule'], v['source'], v['tags'])
 	    if v['source'] == "syscall" and (num_evttypes == 0 or num_evttypes > 100) then
 	       if warn_evttypes == true then
-		  msg = "Rule "..v['rule']..": warning (no-evttype):\n".."         matches too many evt.type values.\n".."         This has a significant performance penalty.\n"
+		  msg = "Rule "..v['rule']..": warning (no-evttype):\n".."         matches too many evt.type values.\n".."         This has a significant performance penalty."
 		  warnings[#warnings + 1] = msg
 	       end
 	    end

--- a/userspace/engine/lua/rule_loader.lua
+++ b/userspace/engine/lua/rule_loader.lua
@@ -1061,7 +1061,9 @@ function load_rules(rules_content,
 	    num_evttypes = falco_rules.add_filter(rules_mgr, lua_parser, v['rule'], v['source'], v['tags'])
 	    if num_evttypes == 0 or num_evttypes > 100 then
 	       if warn_evttypes == true then
-		  msg = "Rule "..v['rule']..": warning (no-evttype):"
+		  msg = "Rule "..v['rule']..": warning (no-evttype):\n"
+		  msg = msg.."         did not contain any evt.type restriction, meaning it will run for all event types.\n"
+		  msg = msg.."         This has a significant performance penalty. Consider adding an evt.type restriction if possible.\n"
 		  warnings[#warnings + 1] = msg
 	       end
 	    end

--- a/userspace/engine/lua/rule_loader.lua
+++ b/userspace/engine/lua/rule_loader.lua
@@ -1059,11 +1059,9 @@ function load_rules(rules_content,
 
 	 else
 	    num_evttypes = falco_rules.add_filter(rules_mgr, lua_parser, v['rule'], v['source'], v['tags'])
-	    if num_evttypes == 0 or num_evttypes > 100 then
+	    if v['source'] == "syscall" and (num_evttypes == 0 or num_evttypes > 100) then
 	       if warn_evttypes == true then
-		  msg = "Rule "..v['rule']..": warning (no-evttype):\n"
-		  msg = msg.."         did not contain any evt.type restriction, meaning it will run for all event types.\n"
-		  msg = msg.."         This has a significant performance penalty. Consider adding an evt.type restriction if possible.\n"
+		  msg = "Rule "..v['rule']..": warning (no-evttype):\n".."         matches too many evt.type values.\n".."         This has a significant performance penalty.\n"
 		  warnings[#warnings + 1] = msg
 	       end
 	    end

--- a/userspace/engine/rules.cpp
+++ b/userspace/engine/rules.cpp
@@ -452,7 +452,7 @@ void falco_rules::load_rules(const string &rules_content,
 			throw falco_exception(os.str());
 		}
 
-		if (verbose && os.str() != "") {
+		if (os.str() != "") {
 			// We don't really have a logging callback
 			// from the falco engine, but this would be a
 			// good place to use it.

--- a/userspace/engine/rules.cpp
+++ b/userspace/engine/rules.cpp
@@ -452,7 +452,7 @@ void falco_rules::load_rules(const string &rules_content,
 			throw falco_exception(os.str());
 		}
 
-		if (os.str() != "") {
+		if (verbose && os.str() != "") {
 			// We don't really have a logging callback
 			// from the falco engine, but this would be a
 			// good place to use it.

--- a/userspace/engine/ruleset.cpp
+++ b/userspace/engine/ruleset.cpp
@@ -68,6 +68,9 @@ void falco_ruleset::ruleset_filters::add_filter(std::shared_ptr<filter_wrapper> 
 {
 	std::set<uint16_t> fevttypes = wrap->filter->evttypes();
 
+	// TODO: who fills this one for rules without evt.type specified?
+	// Can this be actually empty?
+	// Is m_filter_all_event_types useful?
 	if(fevttypes.empty())
 	{
 		// Should run for all event types

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -477,7 +477,7 @@ static void check_for_ignored_events(sinsp &inspector, falco_engine &engine)
 				skipped_events += "," + evtname;
 			}
 		}
-		fprintf(stderr,"Loaded rules match events (%s), but these events are not returned unless running falco with -A\n", skipped_events.c_str());
+		fprintf(stderr,"Rules match ignored syscall: warning (ignored-evttype):\n         loaded rules match the following events: %s;\n         but these events are not returned unless running falco with -A\n", skipped_events.c_str());
 	}
 }
 

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -1059,6 +1059,7 @@ int falco_init(int argc, char **argv)
 				{
 					os << "Type: extractor plugin" << std::endl;
 				}
+				os << std::endl;
 			}
 
 			printf("%lu Plugins Loaded:\n\n%s\n", infos.size(), os.str().c_str());


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

/area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

* Any load_rules warning is now printed (not only on verbose mode)
* Added back a "performance hit" comment when ruleset has a rule without evt.type
* Check for ignored events warning only when "-A" flag is not actually passed
* Fixed a lua CMakeLists issue that prevented updated lua files to be refreshed in falco

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
