### PR TITLE
fix(build): do not show plugin options in musl optimized builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,9 @@ add_subdirectory(userspace/engine)
 add_subdirectory(userspace/falco)
 add_subdirectory(tests)
 
-include(plugins)
+if(NOT MUSL_OPTIMIZED_BUILD)
+  include(plugins)
+endif()
 
 # Packages configuration
 include(CPackConfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ endif()
 
 if(MUSL_OPTIMIZED_BUILD)
   set(MUSL_FLAGS "-static -Os -fPIE -pie")
+  add_definitions(-DMUSL_OPTIMIZED)
 endif()
 
 # explicitly set hardening flags

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -137,8 +137,12 @@ static void usage()
 	   " -l <rule>                     Show the name and description of the rule with name <rule> and exit.\n"
 	   " --list [<source>]             List all defined fields. If <source> is provided, only list those fields for\n"
 	   "                               the source <source>. Current values for <source> are \"syscall\", \"k8s_audit\"\n"
-#ifndef MUSL_OPTIMIZED_BUILD
+	   " --list-fields-markdown [<source>]\n"
+	   "                               List fields in md\n"
+#ifndef MUSL_OPTIMIZED
 	   " --list-plugins                Print info on all loaded plugins and exit.\n"
+#endif
+#ifndef MINIMAL_BUILD
 	   " -m <url[,marathon_url]>, --mesos-api <url[,marathon_url]>\n"
 	   "                               Enable Mesos support by connecting to the API server\n"
 	   "                               specified as argument. E.g. \"http://admin:password@127.0.0.1:5050\".\n"
@@ -556,9 +560,7 @@ int falco_init(int argc, char **argv)
 			{"k8s-api", required_argument, 0, 'k'},
 			{"k8s-node", required_argument, 0},
 			{"list", optional_argument, 0},
-#ifndef MUSL_OPTIMIZED_BUILD
 			{"list-plugins", no_argument, 0},
-#endif
 			{"mesos-api", required_argument, 0, 'm'},
 			{"option", required_argument, 0, 'o'},
 			{"pidfile", required_argument, 0, 'P'},
@@ -751,7 +753,7 @@ int falco_init(int argc, char **argv)
 						list_flds_source = optarg;
 					}
 				}
-#ifndef MUSL_OPTIMIZED_BUILD
+#ifndef MUSL_OPTIMIZED
 				else if (string(long_options[long_index].name) == "list-plugins")
 				{
 					list_plugins = true;
@@ -947,7 +949,7 @@ int falco_init(int argc, char **argv)
 		for(auto &p : config.m_plugins)
 		{
 			std::shared_ptr<sinsp_plugin> plugin;
-#ifdef MUSL_OPTIMIZED_BUILD
+#ifdef MUSL_OPTIMIZED
 			throw std::invalid_argument(string("Can not load/use plugins with musl optimized build"));
 #else
 			falco_logger::log(LOG_INFO, "Loading plugin (" + p.m_name + ") from file " + p.m_library_path + "\n");


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Falco can be built with musl-libc but won't have plugin support in that case. Do not display the relevant option in the command line help. Likewise, do not include plugin directories as they cannot be used.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
