### PR TITLE
Escape double-quotes in aws cloudtrail rule

### DIFF
--- a/rules/aws_cloudtrail_rules.yaml
+++ b/rules/aws_cloudtrail_rules.yaml
@@ -335,7 +335,7 @@
   desc: Detect deleting blocking public access to bucket.
   condition:
     ct.name="PutBucketPublicAccessBlock" and not ct.error exists and
-    json.value[/requestParameters/publicAccessBlock]="" and
+    json.value[/requestParameters/publicAccessBlock]='""' and
       (json.value[/requestParameters/PublicAccessBlockConfiguration/RestrictPublicBuckets]=false or
       json.value[/requestParameters/PublicAccessBlockConfiguration/BlockPublicPolicy]=false or
       json.value[/requestParameters/PublicAccessBlockConfiguration/BlockPublicAcls]=false or


### PR DESCRIPTION
The rule Delete Bucket Public Access Block has a predicate
`json.value[/requestParameters/publicAccessBlock]=""` to match
an event snippet like this:

```
			"requestParameters": {
				"publicAccessBlock": "",
```

The cloudtrail plugin properly returns `""` for this field, but the
yaml representation was a literal back-to-back quote, which gets
interpreted by the yaml parser to be an empty string.

Escaping the back-to-back quote fixes the ambiguity.

This is related to https://github.com/falcosecurity/plugins/issues/56. There were actually 3 fixes in plugins/libs/falco, so I won't directly link it here.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

/kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
