### PR TITLE
fix(userspace/engine): actually make m_filter_all_event_types useful by properly using it as fallback when no filter event types is provided

### DIFF
--- a/cmake/modules/plugins.cmake
+++ b/cmake/modules/plugins.cmake
@@ -27,8 +27,8 @@ install(FILES "${PROJECT_BINARY_DIR}/cloudtrail-plugin-prefix/src/cloudtrail-plu
 
 ExternalProject_Add(
   json-plugin
-  URL "https://download.falco.org/plugins/stable/json-0.2.1-${PLUGINS_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}.tar.gz"
-  URL_HASH "SHA256=14d1cf4c3c651af0daec7a45162ef91172d6f0baba787f0eff0227b3cf2ca39c"
+  URL "https://download.falco.org/plugins/stable/json-0.2.2-${PLUGINS_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}.tar.gz"
+  URL_HASH "SHA256=83eb411c9f2125695875b229c6e7974e6a4cc7f028be146b79d26db30372af5e"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND "")

--- a/userspace/engine/ruleset.cpp
+++ b/userspace/engine/ruleset.cpp
@@ -68,9 +68,6 @@ void falco_ruleset::ruleset_filters::add_filter(std::shared_ptr<filter_wrapper> 
 {
 	std::set<uint16_t> fevttypes = wrap->filter->evttypes();
 
-	// TODO: who fills this one for rules without evt.type specified?
-	// Can this be actually empty?
-	// Is m_filter_all_event_types useful?
 	if(fevttypes.empty())
 	{
 		// Should run for all event types
@@ -121,18 +118,16 @@ uint64_t falco_ruleset::ruleset_filters::num_filters()
 
 bool falco_ruleset::ruleset_filters::run(gen_event *evt)
 {
-	if(evt->get_type() >= m_filter_by_event_type.size())
-	{
-		return false;
-	}
-
-	for(auto &wrap : m_filter_by_event_type[evt->get_type()])
-	{
-		if(wrap->filter->run(evt))
-		{
-			return true;
-		}
-	}
+    if(evt->get_type() < m_filter_by_event_type.size())
+    {
+        for(auto &wrap : m_filter_by_event_type[evt->get_type()])
+        {
+            if(wrap->filter->run(evt))
+            {
+                return true;
+            }
+        }
+    }
 
 	// Finally, try filters that are not specific to an event type.
 	for(auto &wrap : m_filter_all_event_types)


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

/area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Experimenting together with @jasondellaluce and @leogr  a possible solution for https://github.com/falcosecurity/plugins/issues/57

The issue was that `m_filter_all_event_types` was actually unused: for `syscalls` event source, we always have a `m_filter_by_event_type` value for the filter, event if `evt.type` is missing in the condition: in fact when it is missing, a default set of "all events" is used.  

For k8s audit logs the bug is not appearing because its filter check provides a default `evttypes()` impl that basically means "force-use any event type", even when negated.

Plugins filter checks instead is returning `PPME_PLUGINEVENT_E` as only possible event associated; but, when rule condition gets negated, there is no other set of event type possible and thus the filter check gets added to `m_filter_all_event_types`.

Unfortunately, the old check in `ruleset_filters::run`:
```
if(evt->get_type() >= m_filter_by_event_type.size())
{
	return false;
}
```
prevented it to actually run the filterchecks stored in `m_filter_all_event_types`, de facto making it useless.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Edit by @leogr: we also bumped the json plugin version to include a fix for https://github.com/falcosecurity/plugins/issues/56

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```