### PR TITLE
fix: force-set evt.type for plugin source events

### DIFF
--- a/cmake/modules/plugins.cmake
+++ b/cmake/modules/plugins.cmake
@@ -17,8 +17,8 @@ string(TOLOWER ${CMAKE_HOST_SYSTEM_NAME} PLUGINS_SYSTEM_NAME)
 
 ExternalProject_Add(
   cloudtrail-plugin
-  URL "https://download.falco.org/plugins/stable/cloudtrail-0.2.2-${PLUGINS_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}.tar.gz"
-  URL_HASH "SHA256=1628717e48b2ba1b9c78c9081e2ec23e4d88bb1a7b68b12cf8dff7f247b5b9b1"
+  URL "https://download.falco.org/plugins/stable/cloudtrail-0.2.3-${PLUGINS_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}.tar.gz"
+  URL_HASH "SHA256=3dfce36f37a4f834b6078c6b78776414472a6ee775e8f262535313cc4031d0b7"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND "")

--- a/rules/aws_cloudtrail_rules.yaml
+++ b/rules/aws_cloudtrail_rules.yaml
@@ -22,9 +22,9 @@
 # anything semver-compatible.
 - required_plugin_versions:
   - name: cloudtrail
-    version: 0.2.2
+    version: 0.2.3
   - name: json
-    version: 0.2.1
+    version: 0.2.2
 
 # Note that this rule is disabled by default. It's useful only to
 # verify that the cloudtrail plugin is sending events properly.  The

--- a/tests/engine/test_rulesets.cpp
+++ b/tests/engine/test_rulesets.cpp
@@ -42,8 +42,9 @@ TEST_CASE("Should enable/disable for exact match w/ default ruleset", "[rulesets
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> filter = create_filter();
 	string rule_name = "one_rule";
+	string source = "syscall";
 
-	r.add(rule_name, tags, filter);
+	r.add(source, rule_name, tags, filter);
 
 	r.enable("one_rule", exact_match, enabled);
 	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
@@ -57,8 +58,9 @@ TEST_CASE("Should enable/disable for exact match w/ specific ruleset", "[ruleset
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> filter = create_filter();
 	string rule_name = "one_rule";
+	string source = "syscall";
 
-	r.add(rule_name, tags, filter);
+	r.add(source, rule_name, tags, filter);
 
 	r.enable("one_rule", exact_match, enabled, non_default_ruleset);
 	REQUIRE(r.num_rules_for_ruleset(non_default_ruleset) == 1);
@@ -76,8 +78,9 @@ TEST_CASE("Should not enable for exact match different rule name", "[rulesets]")
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> filter = create_filter();
 	string rule_name = "one_rule";
+	string source = "syscall";
 
-	r.add(rule_name, tags, filter);
+	r.add(source, rule_name, tags, filter);
 
 	r.enable("some_other_rule", exact_match, enabled);
 	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
@@ -88,8 +91,9 @@ TEST_CASE("Should enable/disable for exact match w/ substring and default rulese
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> filter = create_filter();
 	string rule_name = "one_rule";
+	string source = "syscall";
 
-	r.add(rule_name, tags, filter);
+	r.add(source, rule_name, tags, filter);
 
 	r.enable("one_rule", substring_match, enabled);
 	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
@@ -103,8 +107,9 @@ TEST_CASE("Should not enable for substring w/ exact_match", "[rulesets]")
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> filter = create_filter();
 	string rule_name = "one_rule";
+	string source = "syscall";
 
-	r.add(rule_name, tags, filter);
+	r.add(source, rule_name, tags, filter);
 
 	r.enable("one_", exact_match, enabled);
 	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 0);
@@ -115,8 +120,9 @@ TEST_CASE("Should enable/disable for prefix match w/ default ruleset", "[ruleset
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> filter = create_filter();
 	string rule_name = "one_rule";
+	string source = "syscall";
 
-	r.add(rule_name, tags, filter);
+	r.add(source, rule_name, tags, filter);
 
 	r.enable("one_", substring_match, enabled);
 	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
@@ -130,8 +136,9 @@ TEST_CASE("Should enable/disable for suffix match w/ default ruleset", "[ruleset
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> filter = create_filter();
 	string rule_name = "one_rule";
+	string source = "syscall";
 
-	r.add(rule_name, tags, filter);
+	r.add(source, rule_name, tags, filter);
 
 	r.enable("_rule", substring_match, enabled);
 	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
@@ -145,8 +152,9 @@ TEST_CASE("Should enable/disable for substring match w/ default ruleset", "[rule
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> filter = create_filter();
 	string rule_name = "one_rule";
+	string source = "syscall";
 
-	r.add(rule_name, tags, filter);
+	r.add(source, rule_name, tags, filter);
 
 	r.enable("ne_ru", substring_match, enabled);
 	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
@@ -160,8 +168,9 @@ TEST_CASE("Should enable/disable for substring match w/ specific ruleset", "[rul
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> filter = create_filter();
 	string rule_name = "one_rule";
+	string source = "syscall";
 
-	r.add(rule_name, tags, filter);
+	r.add(source, rule_name, tags, filter);
 
 	r.enable("ne_ru", substring_match, enabled, non_default_ruleset);
 	REQUIRE(r.num_rules_for_ruleset(non_default_ruleset) == 1);
@@ -179,9 +188,10 @@ TEST_CASE("Should enable/disable for tags w/ default ruleset", "[rulesets]")
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> filter = create_filter();
 	string rule_name = "one_rule";
+	string source = "syscall";
 	std::set<std::string> want_tags = {"some_tag"};
 
-	r.add(rule_name, tags, filter);
+	r.add(source, rule_name, tags, filter);
 
 	r.enable_tags(want_tags, enabled);
 	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
@@ -195,9 +205,10 @@ TEST_CASE("Should enable/disable for tags w/ specific ruleset", "[rulesets]")
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> filter = create_filter();
 	string rule_name = "one_rule";
+	string source = "syscall";
 	std::set<std::string> want_tags = {"some_tag"};
 
-	r.add(rule_name, tags, filter);
+	r.add(source, rule_name, tags, filter);
 
 	r.enable_tags(want_tags, enabled, non_default_ruleset);
 	REQUIRE(r.num_rules_for_ruleset(non_default_ruleset) == 1);
@@ -215,9 +226,10 @@ TEST_CASE("Should not enable for different tags", "[rulesets]")
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> filter = create_filter();
 	string rule_name = "one_rule";
+	string source = "syscall";
 	std::set<std::string> want_tags = {"some_different_tag"};
 
-	r.add(rule_name, tags, filter);
+	r.add(source, rule_name, tags, filter);
 
 	r.enable_tags(want_tags, enabled);
 	REQUIRE(r.num_rules_for_ruleset(non_default_ruleset) == 0);
@@ -228,9 +240,10 @@ TEST_CASE("Should enable/disable for overlapping tags", "[rulesets]")
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> filter = create_filter();
 	string rule_name = "one_rule";
+	string source = "syscall";
 	std::set<std::string> want_tags = {"some_tag", "some_different_tag"};
 
-	r.add(rule_name, tags, filter);
+	r.add(source, rule_name, tags, filter);
 
 	r.enable_tags(want_tags, enabled);
 	REQUIRE(r.num_rules_for_ruleset(default_ruleset) == 1);
@@ -241,16 +254,17 @@ TEST_CASE("Should enable/disable for overlapping tags", "[rulesets]")
 
 TEST_CASE("Should enable/disable for incremental adding tags", "[rulesets]")
 {
+	string source = "syscall";
 	falco_ruleset r;
 	std::shared_ptr<gen_event_filter> rule1_filter = create_filter();
 	string rule1_name = "one_rule";
 	std::set<std::string> rule1_tags = {"rule1_tag"};
-	r.add(rule1_name, rule1_tags, rule1_filter);
+	r.add(source, rule1_name, rule1_tags, rule1_filter);
 
 	std::shared_ptr<gen_event_filter> rule2_filter = create_filter();
 	string rule2_name = "two_rule";
 	std::set<std::string> rule2_tags = {"rule2_tag"};
-	r.add(rule2_name, rule2_tags, rule2_filter);
+	r.add(source, rule2_name, rule2_tags, rule2_filter);
 
 	std::set<std::string> want_tags;
 

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -450,6 +450,7 @@ bool falco_engine::is_plugin_compatible(const std::string &name,
 		sinsp_plugin::version req_version(rversion);
 		if (!plugin_version.check(req_version))
 		{
+			required_version = rversion;
 			return false;
 		}
 	}

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -432,7 +432,7 @@ bool falco_engine::is_plugin_compatible(const std::string &name,
 					const std::string &version,
 					std::string &required_version)
 {
-	sinsp_plugin::version plugin_version(version.c_str());
+	sinsp_plugin::version plugin_version(version);
 
 	if(!plugin_version.m_valid)
 	{
@@ -447,13 +447,11 @@ bool falco_engine::is_plugin_compatible(const std::string &name,
 
 	for(auto &rversion : m_required_plugin_versions[name])
 	{
-		sinsp_plugin::version req_version(rversion.c_str());
-		if(req_version.m_version_major > plugin_version.m_version_major)
+		sinsp_plugin::version req_version(rversion);
+		if (!plugin_version.check(req_version))
 		{
-			required_version = rversion;
 			return false;
 		}
-
 	}
 
 	return true;

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -420,7 +420,7 @@ void falco_engine::add_filter(std::shared_ptr<gen_event_filter> filter,
 		throw falco_exception(err);
 	}
 
-	it->second->add(rule, tags, filter);
+	it->second->add(source, rule, tags, filter);
 }
 
 bool falco_engine::is_source_valid(const std::string &source)

--- a/userspace/engine/rules.cpp
+++ b/userspace/engine/rules.cpp
@@ -145,11 +145,19 @@ int falco_rules::add_filter(lua_State *ls)
 		lua_pop(ls, 1);
 	}
 
-	size_t num_evttypes = lp->filter()->evttypes().size();
+	// todo(jasondellaluce,leogr,fededp): temp workaround, remove when fixed in libs
+	size_t num_evttypes = 1; // assume plugin
+	if(source == "syscall" || source == "k8s_audit")
+	{
+		num_evttypes = lp->filter()->evttypes().size();
+	}
 
-	try {
+	try
+	{
 		rules->add_filter(lp->filter(), rule, source, tags);
-	} catch (exception &e) {
+	}
+	catch (exception &e)
+	{
 		std::string errstr = string("Could not add rule to falco engine: ") + e.what();
 		lua_pushstring(ls, errstr.c_str());
 		lua_error(ls);

--- a/userspace/engine/ruleset.cpp
+++ b/userspace/engine/ruleset.cpp
@@ -66,7 +66,7 @@ void falco_ruleset::ruleset_filters::remove_wrapper_from_list(filter_wrapper_lis
 
 void falco_ruleset::ruleset_filters::add_filter(std::shared_ptr<filter_wrapper> wrap)
 {
-	std::set<uint16_t> fevttypes = wrap->filter->evttypes();
+	std::set<uint16_t> fevttypes = wrap->evttypes();
 
 	if(fevttypes.empty())
 	{
@@ -91,7 +91,7 @@ void falco_ruleset::ruleset_filters::add_filter(std::shared_ptr<filter_wrapper> 
 
 void falco_ruleset::ruleset_filters::remove_filter(std::shared_ptr<filter_wrapper> wrap)
 {
-	std::set<uint16_t> fevttypes = wrap->filter->evttypes();
+	std::set<uint16_t> fevttypes = wrap->evttypes();
 
 	if(fevttypes.empty())
 	{
@@ -147,16 +147,18 @@ void falco_ruleset::ruleset_filters::evttypes_for_ruleset(std::set<uint16_t> &ev
 
 	for(auto &wrap : m_filters)
 	{
-		auto fevttypes = wrap->filter->evttypes();
+		auto fevttypes = wrap->evttypes();
 		evttypes.insert(fevttypes.begin(), fevttypes.end());
 	}
 }
 
-void falco_ruleset::add(string &name,
+void falco_ruleset::add(string &source,
+			string &name,
 			set<string> &tags,
 			std::shared_ptr<gen_event_filter> filter)
 {
 	std::shared_ptr<filter_wrapper> wrap(new filter_wrapper());
+	wrap->source = source;
 	wrap->name = name;
 	wrap->tags = tags;
 	wrap->filter = filter;

--- a/userspace/engine/ruleset.h
+++ b/userspace/engine/ruleset.h
@@ -34,7 +34,8 @@ public:
 	falco_ruleset();
 	virtual ~falco_ruleset();
 
-	void add(std::string &name,
+	void add(string &source,
+		 std::string &name,
 		 std::set<std::string> &tags,
 		 std::shared_ptr<gen_event_filter> filter);
 
@@ -73,9 +74,21 @@ private:
 
 	class filter_wrapper {
 	public:
+		std::string source;
 		std::string name;
 		std::set<std::string> tags;
 		std::shared_ptr<gen_event_filter> filter;
+		std::set<uint16_t> evttypes()
+		{
+			// todo(jasondellaluce,leogr): temp workarond, remove when fixed in libs
+			if(source == "syscall" || source == "k8s_audit")
+			{
+				return filter->evttypes();
+			}
+			// else assume plugins
+			return {ppm_event_type::PPME_PLUGINEVENT_E};
+			// workaround end
+		}
 	};
 
 	typedef std::list<std::shared_ptr<filter_wrapper>> filter_wrapper_list;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

/area tests

**What this PR does / why we need it**:

This completes the changes of https://github.com/falcosecurity/falco/pull/1875, by introducing protective logic on for the `evttypes()` method for the edge case of sources coming from plugins and `k8s_audit`. This prevents rules written from those sources to be unwillingly excluded from the rule index, which caused them to never match on any event.

This also bumps the plugin versions to the latest released versions, both in the CMake dependencies an in the `aws_cloudtrail_rules.yaml` ruleset.

Finally, semver check for required plugin versions has been added.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
