### PR TITLE
build: dropped centos8 circleci build because it is useless

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,38 +176,6 @@ jobs:
             pushd build
             make tests
             popd
-  # Build using CentOS 8
-  # This build is static, dependencies are bundled in the Falco binary
-  "build/centos8":
-    docker:
-      - image: centos:8
-    steps:
-      - checkout
-      - run:
-          name: Update base image
-          command: dnf update -y
-      - run:
-          name: Install dependencies
-          command: dnf install gcc gcc-c++ git make cmake autoconf automake pkg-config patch libtool elfutils-libelf-devel diffutils kernel-devel kernel-headers kernel-core clang llvm which -y
-      - run:
-          name: Prepare project
-          command: |
-            mkdir build
-            pushd build
-            cmake -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=On ..
-            popd
-      - run:
-          name: Build
-          command: |
-            pushd build
-            KERNELDIR=/lib/modules/$(ls /lib/modules)/build make -j4 all
-            popd
-      - run:
-          name: Run unit tests
-          command: |
-            pushd build
-            make tests
-            popd
   # Build using our own builder base image using centos 7
   # This build is static, dependencies are bundled in the Falco binary
   "build/centos7":
@@ -630,7 +598,6 @@ workflows:
       - "build/ubuntu-focal"
       - "build/ubuntu-focal-debug"
       - "build/ubuntu-bionic"
-      - "build/centos8"
       - "build/centos7"
       - "build/centos7-debug"
       - "tests/integration":


### PR DESCRIPTION
`Signed-off-by: Federico Di Pierro <nierro92@gmail.com>`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Centos8 is EoL since Dec 31th and its contents will be dropped on january 31th: https://www.centos.org/centos-linux-eol/

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
