### PR TITLE
fix(userspace/falco): correct plugins init config conversion from YAML to JSON

### DIFF
--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -288,12 +288,12 @@ namespace YAML {
 			double double_val;
 			bool bool_val;
 			std::string str_val;
-			nlohmann::json sub{};
 
 			switch (node.Type()) {
 				case YAML::NodeType::Map:
 					for (auto &&it: node)
 					{
+						nlohmann::json sub{};
 						YAML::convert<nlohmann::json>::decode(it.second, sub);
 						res[it.first.as<std::string>()] = sub;
 					}
@@ -301,6 +301,7 @@ namespace YAML {
 				case YAML::NodeType::Sequence:
 					for (auto &&it : node)
 					{
+						nlohmann::json sub{};
 						YAML::convert<nlohmann::json>::decode(it, sub);
 						res.emplace_back(sub);
 					}


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This fixes the bug of #1906. The error was related to a misuse of the `nlohmann` library during array construction when converting plugins init configs from YAML to JSON.

**Which issue(s) this PR fixes**:

Fixes #1906

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/falco): correct plugins init config conversion from YAML to JSON
```
