### PR TITLE
fix(build): fix civetweb linking in cmake module

### DIFF
--- a/cmake/modules/civetweb.cmake
+++ b/cmake/modules/civetweb.cmake
@@ -12,8 +12,8 @@
 #
 
 set(CIVETWEB_SRC "${PROJECT_BINARY_DIR}/civetweb-prefix/src/civetweb/")
-set(CIVETWEB_LIB "${CIVETWEB_SRC}/install/${CMAKE_INSTALL_LIBDIR}/libcivetweb.a")
-SET(CIVETWEB_CPP_LIB "${CIVETWEB_SRC}/install/${CMAKE_INSTALL_LIBDIR}/libcivetweb-cpp.a")
+set(CIVETWEB_LIB "${CIVETWEB_SRC}/install/lib/libcivetweb.a")
+SET(CIVETWEB_CPP_LIB "${CIVETWEB_SRC}/install/lib/libcivetweb-cpp.a")
 set(CIVETWEB_INCLUDE_DIR "${CIVETWEB_SRC}/install/include")
 message(STATUS "Using bundled civetweb in '${CIVETWEB_SRC}'")
 if (USE_BUNDLED_OPENSSL)
@@ -25,6 +25,7 @@ if (USE_BUNDLED_OPENSSL)
             INSTALL_DIR ${CIVETWEB_SRC}/install
             CMAKE_ARGS
             -DBUILD_TESTING=off
+            -DCMAKE_INSTALL_LIBDIR=lib
             -DCIVETWEB_BUILD_TESTING=off
             -DCIVETWEB_ENABLE_CXX=on
             -DCIVETWEB_ENABLE_SERVER_EXECUTABLE=off


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>
Co-authored-by: Federico Di Pierro <nierro92@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

On Debian or Ubuntu systems it is possible that the GNU Install dir `LIBDIR` (`CMAKE_INSTALL_LIBDIR`) can be different depending on the install prefix chosen (https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html) . This can create issues when trying to compute the civetweb lib path using the main CMakeFile `CMAKE_INSTALL_LIBDIR`, leading to linking errors like:

```
make[2]: *** No rule to make target 'civetweb-prefix/src/civetweb/install/lib/x86_64-linux-gnu/libcivetweb.a', needed by 'userspace/falco/falco'.  Stop.
```

This forces the install directory to `lib` so it's possible to deterministically compute the path.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
