### PR TITLE
Add user_known_mount_in_privileged_containers macro

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3061,6 +3061,9 @@
 - macro: mount_info
   condition: (proc.args="" or proc.args intersects ("-V", "-l", "-h"))
 
+- macro: user_known_mount_in_privileged_containers
+  condition: (never_true)
+
 - rule: Mount Launched in Privileged Container
   desc: Detect file system mount happened inside a privileged container which might lead to container escape.
   condition: >
@@ -3068,6 +3071,7 @@
     and container.privileged=true
     and proc.name=mount
     and not mount_info
+    and not user_known_mount_in_privileged_containers
   output: Mount was executed inside a privileged container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)
   priority: WARNING
   tags: [container, cis, mitre_lateral_movement]


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

This adds a new macro `user_known_mount_in_privileged_containers` which
allows the easier user-defined exclusions for the "Mount Launched in
Privileged Container" rule.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

This would be cleaner with [exceptions](https://falco.org/docs/rules/exceptions/#rule-exceptions), but this feature is not used in the default ruleset yet, if I understand correctly.


**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rule(Mount Launched in Privileged Container): added allowlist macro user_known_mount_in_privileged_containers.
```
