### PR TITLE
Allow to whitelist shell config modifiers

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -443,6 +443,9 @@
 - list: shell_config_directories
   items: [/etc/zsh]
 
+- macro: user_known_shell_config_modifiers
+  condition: (never_true)
+
 - rule: Modify Shell Configuration File
   desc: Detect attempt to modify shell configuration files
   condition: >
@@ -452,6 +455,7 @@
      fd.directory in (shell_config_directories))
     and not proc.name in (shell_binaries)
     and not exe_running_docker_save
+    and not user_known_shell_config_modifiers
   output: >
     a shell configuration file has been modified (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pcmdline=%proc.pcmdline file=%fd.name container_id=%container.id image=%container.image.repository)
   priority:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

This PR allows to whitelist specific containers to modify the shell config files.

**Which issue(s) this PR fixes**:

When running on GKE with `COS_CONTAINERD` images, I get frequent messages about modified bash files, e.g.:

```
rule
Modify Shell Configuration File

container.id
host

fd.name
/var/lib/containerd/tmpmounts/containerd-mount584469562/root/.bashrc
```

Because this is a managed cluster, I can't influence what the nodes/host is doing and what processes might modify the bash config, so as a user, I'd like to be able to whitelist this false positive.

**Special notes for your reviewer**:

I can open an issue if required, but I think it's only a minor change.

**Does this PR introduce a user-facing change?**:

```release-note
rule(macro user_known_shell_config_modifiers): allow to allowlist shell config modifiers
```
