### PR TITLE
new(falco): add CLI option to print syscall list and docs in markdown format

### DIFF
--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -81,7 +81,7 @@ static std::string fieldclass_key(const gen_event_filter_factory::filter_fieldcl
 	return fld_info.name + fld_info.shortdesc;
 }
 
-void falco_engine::list_fields(std::string &source, bool verbose, bool names_only)
+void falco_engine::list_fields(std::string &source, bool verbose, bool names_only, bool markdown)
 {
 	// Maps from field class name + short desc to list of event
 	// sources for which this field class can be used.
@@ -126,12 +126,7 @@ void falco_engine::list_fields(std::string &source, bool verbose, bool names_onl
 
 			seen_fieldclasses.insert(key);
 
-			if(!names_only)
-			{
-				printf("%s\n", fld_class.as_string(verbose,
-								   fieldclass_event_sources[fieldclass_key(fld_class)]).c_str());
-			}
-			else
+			if(names_only)
 			{
 				for(auto &field : fld_class.fields)
 				{
@@ -143,6 +138,16 @@ void falco_engine::list_fields(std::string &source, bool verbose, bool names_onl
 
 					printf("%s\n", field.name.c_str());
 				}
+			}
+			else if (markdown)
+			{
+				printf("%s\n", fld_class.as_markdown(
+									fieldclass_event_sources[fieldclass_key(fld_class)]).c_str());
+			}
+			else
+			{
+				printf("%s\n", fld_class.as_string(verbose,
+								   fieldclass_event_sources[fieldclass_key(fld_class)]).c_str());
 			}
 		}
 	}

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -54,7 +54,7 @@ public:
 
 	// Print to stdout (using printf) a description of each field supported by this engine.
 	// If source is non-empty, only fields for the provided source are printed.
-	void list_fields(std::string &source, bool verbose, bool names_only);
+	void list_fields(std::string &source, bool verbose, bool names_only, bool markdown);
 
 	//
 	// Load rules either directly or from a filename.

--- a/userspace/falco/app_cmdline_options.cpp
+++ b/userspace/falco/app_cmdline_options.cpp
@@ -172,6 +172,7 @@ void cmdline_options::define()
 		("L",                             "Show the name and description of all rules and exit.", cxxopts::value(describe_all_rules)->default_value("false"))
 		("l",                             "Show the name and description of the rule with name <rule> and exit.", cxxopts::value(describe_rule), "<rule>")
 		("list",                          "List all defined fields. If <source> is provided, only list those fields for the source <source>. Current values for <source> are \"syscall\", \"k8s_audit\", or any source from a configured source plugin.", cxxopts::value(list_source_fields)->implicit_value(""), "<source>")
+		("list-syscall-events",  		  "List all defined system call events.", cxxopts::value<bool>(list_syscall_events))
 #ifndef MUSL_OPTIMIZED
 		("list-plugins",                  "Print info on all loaded plugins and exit.", cxxopts::value(list_plugins)->default_value("false"))
 #endif
@@ -179,7 +180,8 @@ void cmdline_options::define()
 		("m,mesos-api",                   "Enable Mesos support by connecting to the API server specified as argument. E.g. \"http://admin:password@127.0.0.1:5050\". Marathon url is optional and defaults to Mesos address, port 8080. The API servers can also be specified via the environment variable FALCO_MESOS_API.", cxxopts::value(mesos_api), "<url[,marathon_url]>")
 #endif
 		("M",                             "Stop collecting after <num_seconds> reached.", cxxopts::value(duration_to_tot)->default_value("0"), "<num_seconds>")
-		("N",                             "When used with --list/--list-source, only print field names.", cxxopts::value(names_only)->default_value("false"))
+		("markdown",                      "When used with --list/--list-syscall-events, print the content in Markdown format, suitable for publication on the Falco website", cxxopts::value<bool>(markdown))
+		("N",                             "When used with --list, only print field names.", cxxopts::value(names_only)->default_value("false"))
 		("o,option",                      "Set the value of option <opt> to <val>. Overrides values in configuration file. <opt> can be identified using its location in configuration file using dot notation. Elements which are entries of lists can be accessed via square brackets [].\n    E.g. base.id = val\n         base.subvalue.subvalue2 = val\n         base.list[1]=val", cxxopts::value(cmdline_config_options), "<opt>=<val>")
 		("p,print",                       "Add additional information to each falco notification's output.\nWith -pc or -pcontainer will use a container-friendly format.\nWith -pk or -pkubernetes will use a kubernetes-friendly format.\nWith -pm or -pmesos will use a mesos-friendly format.\nAdditionally, specifying -pc/-pk/-pm will change the interpretation of %container.info in rule output fields.", cxxopts::value(print_additional), "<output_format>")
 		("P,pidfile",                     "When run as a daemon, write pid to specified file", cxxopts::value(pidfilename)->default_value("/var/run/falco.pid"), "<pid_file>")

--- a/userspace/falco/app_cmdline_options.h
+++ b/userspace/falco/app_cmdline_options.h
@@ -52,6 +52,8 @@ public:
 	bool list_fields;
 	std::string list_source_fields;
 	bool list_plugins;
+	bool list_syscall_events;
+	bool markdown;
 	std::string mesos_api;
 	int duration_to_tot;
 	bool names_only;

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -373,14 +373,14 @@ static void check_for_ignored_events(sinsp &inspector, falco_engine &engine)
 	}
 }
 
-static void list_source_fields(falco_engine *engine, bool verbose, bool names_only, std::string &source)
+static void list_source_fields(falco_engine *engine, bool verbose, bool names_only, bool markdown, std::string &source)
 {
 	if(source != "" &&
 	   !engine->is_source_valid(source))
 	{
 		throw std::invalid_argument("Value for --list must be a valid source type");
 	}
-	engine->list_fields(source, verbose, names_only);
+	engine->list_fields(source, verbose, names_only, markdown);
 }
 
 static void configure_output_format(falco::app::application &app, falco_engine *engine)
@@ -702,7 +702,13 @@ int falco_init(int argc, char **argv)
 
 		if(app.options().list_fields)
 		{
-			list_source_fields(engine, app.options().verbose, app.options().names_only, app.options().list_source_fields);
+			list_source_fields(engine, app.options().verbose, app.options().names_only, app.options().markdown, app.options().list_source_fields);
+			return EXIT_SUCCESS;
+		}
+
+		if(app.options().list_syscall_events)
+		{
+			list_events(inspector, app.options().markdown);
 			return EXIT_SUCCESS;
 		}
 


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

/kind documentation

> /kind failing-test

/kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds two options to the Falco CLI:
* `--list-syscall-events` : prints the list of syscall events, i.e. the ones that we can use in "evt.type" in Falco rules
* `--markdown` : when used with `--list` or `--list-syscall-events` will print in markdown format, the same as https://falco.org/docs/rules/supported-fields/ and https://falco.org/docs/rules/supported-events/ .

This should make it easy to update the documentation website when a new version is released!

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new(falco): add --markdown and --list-syscall-events
```
