### PR TITLE
update(build): bump libs to latest version

### DIFF
--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -24,8 +24,8 @@ else()
   # default below In case you want to test against another falcosecurity/libs version just pass the variable - ie., `cmake
   # -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "b7eb0dd65226a8dc254d228c8d950d07bf3521d2")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=0f6dcdc3b94243c91294698ee343806539af81c5b33c60c6acf83fc1aa455e85")
+    set(FALCOSECURITY_LIBS_VERSION "caa0e4d0044fdaaebab086592a97f0c7f32aeaa9")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=a0cea9996b708109ff9538f343500d30b6e7ec5a860f714c61425d4598a0534d")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/plugins.cmake
+++ b/cmake/modules/plugins.cmake
@@ -15,20 +15,24 @@ include(ExternalProject)
 
 string(TOLOWER ${CMAKE_HOST_SYSTEM_NAME} PLUGINS_SYSTEM_NAME)
 
+# todo(jasondellaluce): switch this to a stable version once this plugin gets
+# released with a 1.0.0 required plugin api version
 ExternalProject_Add(
   cloudtrail-plugin
-  URL "https://download.falco.org/plugins/stable/cloudtrail-0.2.3-${PLUGINS_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}.tar.gz"
-  URL_HASH "SHA256=3dfce36f37a4f834b6078c6b78776414472a6ee775e8f262535313cc4031d0b7"
+  URL "https://download.falco.org/plugins/dev/cloudtrail-0.2.5-0.2.5-3%2B3068d86-${PLUGINS_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}.tar.gz"
+  URL_HASH "SHA256=6c697a2116eec73386ab19a0e13f6906e6697e82138f3d6435720976df3af6c2"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND "")
 
 install(FILES "${PROJECT_BINARY_DIR}/cloudtrail-plugin-prefix/src/cloudtrail-plugin/libcloudtrail.so" DESTINATION "${FALCO_PLUGINS_DIR}")
 
+# todo(jasondellaluce): switch this to a stable version once this plugin gets
+# released with a 1.0.0 required plugin api version
 ExternalProject_Add(
   json-plugin
-  URL "https://download.falco.org/plugins/stable/json-0.2.2-${PLUGINS_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}.tar.gz"
-  URL_HASH "SHA256=83eb411c9f2125695875b229c6e7974e6a4cc7f028be146b79d26db30372af5e"
+  URL "https://download.falco.org/plugins/dev/json-0.2.2-0.2.2-19%2B3068d86-${PLUGINS_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}.tar.gz"
+  URL_HASH "SHA256=e5c8cf4290b700ae92e80f693aa5a0223d917d637001fdc872430e57a1e625bc"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND "")

--- a/test/plugins/test_extract.cpp
+++ b/test/plugins/test_extract.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 #include <string.h>
 #include <plugin_info.h>
 
-static const char *pl_required_api_version = "0.1.0";
+static const char *pl_required_api_version = "1.0.0";
 static uint32_t    pl_type                 = TYPE_EXTRACTOR_PLUGIN;
 static const char *pl_name_base            = "test_extract";
 static char pl_name[1024];

--- a/test/plugins/test_source.cpp
+++ b/test/plugins/test_source.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 
 #include <plugin_info.h>
 
-static const char *pl_required_api_version = "0.1.0";
+static const char *pl_required_api_version = "1.0.0";
 static uint32_t    pl_type                 = TYPE_SOURCE_PLUGIN;
 static uint32_t    pl_id                   = 999;
 static const char *pl_name                 = "test_source";

--- a/userspace/engine/json_evt.h
+++ b/userspace/engine/json_evt.h
@@ -179,8 +179,16 @@ public:
 	void add_filter_value(const char *str, uint32_t len, uint32_t i = 0);
 	bool compare(gen_event *evt);
 
-	// This always returns a const extracted_values_t *. The pointer points to m_evalues;
-	uint8_t* extract(gen_event *evt, uint32_t* len, bool sanitize_strings = true) final;
+	// This is adapted to support the new extract() method signature that
+	// supports extracting list of values, however json_evt was implemented
+	// to support this feature in the first place through the
+	// extracted_values_t structure. As such, for now this is only used for
+	// signature compliance, and always pushes a single value. The value pushed
+	// in the vector is a a const extracted_values_t* that points to the
+	// internal m_evalues. This is a temporary workaround to sync with the
+	// latest falcosecurity/libs development without re-designing the whole K8S
+	// support, which will eventually be refactored as a plugin in the future anyway.
+	bool extract(gen_event *evt, std::vector<extract_value_t>& values, bool sanitize_strings = true) final;
 
 	const std::string &field();
 	const std::string &idx();


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This bumps the libs version, and introduces some adaptations to comply with the new `extract()` filtercheck method interface introduced in https://github.com/falcosecurity/libs/pull/201.

In Falco, the K8S Audit source implementation always supported extracting list of values natively. Since the future of that implementation is to be refactored as a plugin, this PR only introduces simple method signature adaptations without refactoring the whole `json_evt` logic.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(build): bump libs version to caa0e4d0044fdaaebab086592a97f0c7f32aeaa9
```
