### PR TITLE
chore(falco_scripts): Update `falco-driver-loader` cleaning phase

### DIFF
--- a/scripts/debian/postinst.in
+++ b/scripts/debian/postinst.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2021 The Falco Authors.
+# Copyright (C) 2022 The Falco Authors.
 #
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/debian/postrm.in
+++ b/scripts/debian/postrm.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2021 The Falco Authors.
+# Copyright (C) 2022 The Falco Authors.
 #
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/debian/prerm.in
+++ b/scripts/debian/prerm.in
@@ -17,13 +17,8 @@
 #
 set -e
 
-DKMS_PACKAGE_NAME="@PACKAGE_NAME@"
-DKMS_VERSION="@DRIVER_VERSION@"
-
 case "$1" in
 	remove|upgrade|deconfigure)
-		if [  "$(dkms status -m $DKMS_PACKAGE_NAME -v $DKMS_VERSION)" ]; then
-			dkms remove -m $DKMS_PACKAGE_NAME -v $DKMS_VERSION --all
-		fi
+		/usr/bin/falco-driver-loader --clean
 	;;
 esac

--- a/scripts/debian/prerm.in
+++ b/scripts/debian/prerm.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2021 The Falco Authors.
+# Copyright (C) 2022 The Falco Authors.
 #
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -219,43 +219,93 @@ load_kernel_module_download() {
 	fi
 }
 
-load_kernel_module() {
-	if ! hash lsmod > /dev/null 2>&1; then
-		>&2 echo "This program requires lsmod"
-		exit 1
-	fi
+clean_kernel_module() {
+	echo 
+	echo "================ Cleaning phase ================"
+	echo 
 
-	if ! hash modprobe > /dev/null 2>&1; then
-		>&2 echo "This program requires modprobe"
+	if ! hash lsmod > /dev/null 2>&1; then
+		>&2 echo "* Error: This program requires lsmod."
 		exit 1
 	fi
 
 	if ! hash rmmod > /dev/null 2>&1; then
-		>&2 echo "This program requires rmmod"
+		>&2 echo "* Error: This program requires rmmod."
 		exit 1
 	fi
 
-	echo "* Unloading ${DRIVER_NAME} module, if present"
-	rmmod "${DRIVER_NAME}" 2>/dev/null
-	WAIT_TIME=0
 	KMOD_NAME=$(echo "${DRIVER_NAME}" | tr "-" "_")
-	while lsmod | cut -d' ' -f1 | grep -qx "${KMOD_NAME}" && [ $WAIT_TIME -lt "${MAX_RMMOD_WAIT}" ]; do
-		if rmmod "${DRIVER_NAME}" 2>/dev/null; then
-			echo "* Unloading ${DRIVER_NAME} module succeeded after ${WAIT_TIME}s"
-			break
-		fi
-		((++WAIT_TIME))
-		if (( WAIT_TIME % 5 == 0 )); then
-			echo "* ${DRIVER_NAME} module still loaded, waited ${WAIT_TIME}s (max wait ${MAX_RMMOD_WAIT}s)"
-		fi
-		sleep 1
-	done
+	echo "* 1. Check if kernel module '${KMOD_NAME}' is still loaded:"
 
-	if lsmod | cut -d' ' -f1 | grep -qx "${KMOD_NAME}" > /dev/null 2>&1; then
-		echo "* ${DRIVER_NAME} module seems to still be loaded, hoping the best"
-		exit 0
+	if ! lsmod | cut -d' ' -f1 | grep -qx "${KMOD_NAME}"; then
+		echo "- OK! There is no '${KMOD_NAME}' module loaded."
+		echo
 	fi
 
+	# Wait 50s = MAX_RMMOD_WAIT * 5s
+	MAX_RMMOD_WAIT=10
+	# Remove kernel module if is still loaded.
+	while lsmod | cut -d' ' -f1 | grep -qx "${KMOD_NAME}" && [ $MAX_RMMOD_WAIT -gt 0 ]; do
+		echo "- Kernel module '${KMOD_NAME}' is still loaded."
+		echo "- Trying to unload it with 'rmmod ${KMOD_NAME}'..."
+		if rmmod ${KMOD_NAME}; then
+			echo "- OK! Unloading '${KMOD_NAME}' module succeeded."
+			echo
+		else
+		    echo "- Nothing to do...'falco-driver-loader' will wait until you remove the kernel module to have a clean termination."
+		    echo "- Checkout here what to do (link to documentation)."
+		    echo "- Sleep 5 seconds..."
+		    echo
+			((--MAX_RMMOD_WAIT))
+		    sleep 5
+		fi
+	done
+
+	if [ ${MAX_RMMOD_WAIT} -eq 0 ]; then
+		echo "* [WARNING] '${KMOD_NAME}' module is still loaded, you could have incompatibility issues."
+		return
+	fi
+	
+	if ! hash dkms >/dev/null 2>&1; then
+		echo "* Skipping dkms remove (dkms not found)"
+		return
+	fi
+	
+	echo "* 2. Check kernel module '${KMOD_NAME}' in dkms:"
+
+	# Remove all versions of this module from dkms.
+	DRIVER_VERSIONS=$(dkms status -m "${KMOD_NAME}" | cut -d',' -f2 | sed -e 's/^[[:space:]]*//')
+	if [ -z "${DRIVER_VERSIONS}" ]; then
+		echo "- OK! There is no '${KMOD_NAME}' module in dkms-"
+		return
+	else
+		echo "- There are some verions of '${KMOD_NAME}' module in dkms."
+		echo
+		echo "* 3. Removing all the following versions of '${KMOD_NAME}' module from dkms:"
+		echo "- ${DRIVER_VERSIONS}"	
+		echo
+	fi
+
+	for CURRENT_VER in ${DRIVER_VERSIONS}; do
+		echo "- Removing ${CURRENT_VER}..."
+		if dkms remove -m ${KMOD_NAME} -v "${CURRENT_VER}" --all; then
+			echo
+			echo "- OK! Removing '${CURRENT_VER}' succeeded"
+			echo
+		else
+			echo "-  Removing '${KMOD_NAME}' version '${CURRENT_VER}' failed"
+			return
+		fi
+	done
+
+	echo "* [SUCCESS] Cleaning phase correctly terminated."
+	echo 
+	echo "================ Cleaning phase ================"
+	echo 
+}
+
+load_kernel_module() {
+	clean_kernel_module
 
 	echo "* Looking for a ${DRIVER_NAME} module locally (kernel ${KERNEL_RELEASE})"
 
@@ -288,48 +338,6 @@ load_kernel_module() {
 	# Not able to download a prebuilt module nor to compile one on-the-fly
 	>&2 echo "Consider compiling your own ${DRIVER_NAME} driver and loading it or getting in touch with the Falco community"
 	exit 1
-}
-
-clean_kernel_module() {
-	if ! hash lsmod > /dev/null 2>&1; then
-		>&2 echo "This program requires lsmod"
-		exit 1
-	fi
-
-	if ! hash rmmod > /dev/null 2>&1; then
-		>&2 echo "This program requires rmmod"
-		exit 1
-	fi
-
-	KMOD_NAME=$(echo "${DRIVER_NAME}" | tr "-" "_")
-	if lsmod | cut -d' ' -f1 | grep -qx "${KMOD_NAME}"; then
-		if rmmod "${DRIVER_NAME}" 2>/dev/null; then
-			echo "* Unloading ${DRIVER_NAME} module succeeded"
-		else
-			echo "* Unloading ${DRIVER_NAME} module failed"
-		fi
-	else
-		echo "* There is no ${DRIVER_NAME} module loaded"
-	fi
-
-	if ! hash dkms >/dev/null 2>&1; then
-		echo "* Skipping dkms remove (dkms not found)"
-		return
-	fi
-
-	DRIVER_VERSIONS=$(dkms status -m "${DRIVER_NAME}" | cut -d',' -f1 | sed -e 's/^[[:space:]]*//')
-	if [ -z "${DRIVER_VERSIONS}" ]; then
-		echo "* There is no ${DRIVER_NAME} module in dkms"
-		return
-	fi
-	for CURRENT_VER in ${DRIVER_VERSIONS}; do
-		if dkms remove "${CURRENT_VER}" --all 2>/dev/null; then
-			echo "* Removing ${CURRENT_VER} succeeded"
-		else
-			echo "* Removing ${CURRENT_VER} failed"
-			exit 1
-		fi
-	done
 }
 
 load_bpf_probe_compile() {

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -221,7 +221,7 @@ load_kernel_module_download() {
 
 print_clean_termination() {
 	echo
-	echo "* [SUCCESS] Cleaning phase correctly terminated."
+	echo "[SUCCESS] Cleaning phase correctly terminated."
 	echo 
 	echo "================ Cleaning phase ================"
 	echo 
@@ -233,12 +233,12 @@ clean_kernel_module() {
 	echo 
 
 	if ! hash lsmod > /dev/null 2>&1; then
-		>&2 echo "* [ERROR]: This program requires lsmod."
+		>&2 echo "This program requires lsmod."
 		exit 1
 	fi
 
 	if ! hash rmmod > /dev/null 2>&1; then
-		>&2 echo "* [ERROR]: This program requires rmmod."
+		>&2 echo "This program requires rmmod."
 		exit 1
 	fi
 
@@ -270,7 +270,7 @@ clean_kernel_module() {
 	done
 
 	if [ ${MAX_RMMOD_WAIT} -eq 0 ]; then
-		echo "* [WARNING] '${KMOD_NAME}' module is still loaded, you could have incompatibility issues."
+		echo "[WARNING] '${KMOD_NAME}' module is still loaded, you could have incompatibility issues."
 		echo
 	fi
 	
@@ -288,7 +288,7 @@ clean_kernel_module() {
 			echo
 			echo "- OK! Removing '${DRIVER_VERSION}' succeeded."
 		else
-			echo "* [WARNING] Removing '${KMOD_NAME}' version '${DRIVER_VERSION}' failed."
+			echo "[WARNING] Removing '${KMOD_NAME}' version '${DRIVER_VERSION}' failed."
 		fi
 	else
 		echo "- OK! There is no '${KMOD_NAME}' module in dkms."

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -219,18 +219,26 @@ load_kernel_module_download() {
 	fi
 }
 
+print_clean_termination() {
+	echo
+	echo "* [SUCCESS] Cleaning phase correctly terminated."
+	echo 
+	echo "================ Cleaning phase ================"
+	echo 
+}
+
 clean_kernel_module() {
 	echo 
 	echo "================ Cleaning phase ================"
 	echo 
 
 	if ! hash lsmod > /dev/null 2>&1; then
-		>&2 echo "* Error: This program requires lsmod."
+		>&2 echo "* [ERROR]: This program requires lsmod."
 		exit 1
 	fi
 
 	if ! hash rmmod > /dev/null 2>&1; then
-		>&2 echo "* Error: This program requires rmmod."
+		>&2 echo "* [ERROR]: This program requires rmmod."
 		exit 1
 	fi
 
@@ -252,56 +260,41 @@ clean_kernel_module() {
 			echo "- OK! Unloading '${KMOD_NAME}' module succeeded."
 			echo
 		else
-		    echo "- Nothing to do...'falco-driver-loader' will wait until you remove the kernel module to have a clean termination."
-		    echo "- Checkout here what to do (link to documentation)."
-		    echo "- Sleep 5 seconds..."
-		    echo
+			echo "- Nothing to do...'falco-driver-loader' will wait until you remove the kernel module to have a clean termination."
+			echo "- Checkout here what to do (link to documentation)."
+			echo "- Sleep 5 seconds..."
+			echo
 			((--MAX_RMMOD_WAIT))
-		    sleep 5
+			sleep 5
 		fi
 	done
 
 	if [ ${MAX_RMMOD_WAIT} -eq 0 ]; then
 		echo "* [WARNING] '${KMOD_NAME}' module is still loaded, you could have incompatibility issues."
-		return
+		echo
 	fi
 	
 	if ! hash dkms >/dev/null 2>&1; then
-		echo "* Skipping dkms remove (dkms not found)"
+		echo "- Skipping dkms remove (dkms not found)"
+		print_clean_termination
 		return
 	fi
 	
-	echo "* 2. Check kernel module '${KMOD_NAME}' in dkms:"
-
-	# Remove all versions of this module from dkms.
-	DRIVER_VERSIONS=$(dkms status -m "${KMOD_NAME}" | cut -d',' -f2 | sed -e 's/^[[:space:]]*//')
-	if [ -z "${DRIVER_VERSIONS}" ]; then
-		echo "- OK! There is no '${KMOD_NAME}' module in dkms-"
-		return
+	# Remove the module version from dkms.
+	echo "* 2. Check kernel module '${KMOD_NAME}' with version '${DRIVER_VERSION}' in dkms:"
+	if [ "$(dkms status -m $KMOD_NAME -v $DRIVER_VERSION)" ]; then
+		echo "- Removing version '${DRIVER_VERSION}' from dkms..."
+		if dkms remove -m $KMOD_NAME -v $DRIVER_VERSION --all; then
+			echo
+			echo "- OK! Removing '${DRIVER_VERSION}' succeeded."
+		else
+			echo "* [WARNING] Removing '${KMOD_NAME}' version '${DRIVER_VERSION}' failed."
+		fi
 	else
-		echo "- There are some verions of '${KMOD_NAME}' module in dkms."
-		echo
-		echo "* 3. Removing all the following versions of '${KMOD_NAME}' module from dkms:"
-		echo "- ${DRIVER_VERSIONS}"	
-		echo
+		echo "- OK! There is no '${KMOD_NAME}' module in dkms."
 	fi
 
-	for CURRENT_VER in ${DRIVER_VERSIONS}; do
-		echo "- Removing ${CURRENT_VER}..."
-		if dkms remove -m ${KMOD_NAME} -v "${CURRENT_VER}" --all; then
-			echo
-			echo "- OK! Removing '${CURRENT_VER}' succeeded"
-			echo
-		else
-			echo "-  Removing '${KMOD_NAME}' version '${CURRENT_VER}' failed"
-			return
-		fi
-	done
-
-	echo "* [SUCCESS] Cleaning phase correctly terminated."
-	echo 
-	echo "================ Cleaning phase ================"
-	echo 
+	print_clean_termination
 }
 
 load_kernel_module() {

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -279,20 +279,30 @@ clean_kernel_module() {
 		print_clean_termination
 		return
 	fi
-	
-	# Remove the module version from dkms.
-	echo "* 2. Check kernel module '${KMOD_NAME}' with version '${DRIVER_VERSION}' in dkms:"
-	if [ "$(dkms status -m $KMOD_NAME -v $DRIVER_VERSION)" ]; then
-		echo "- Removing version '${DRIVER_VERSION}' from dkms..."
-		if dkms remove -m $KMOD_NAME -v $DRIVER_VERSION --all; then
-			echo
-			echo "- OK! Removing '${DRIVER_VERSION}' succeeded."
-		else
-			echo "[WARNING] Removing '${KMOD_NAME}' version '${DRIVER_VERSION}' failed."
-		fi
+
+	# Remove all versions of this module from dkms.
+	echo "* 2. Check all versions of kernel module '${KMOD_NAME}' in dkms:"
+	DRIVER_VERSIONS=$(dkms status -m "${KMOD_NAME}" | tr -d "," | tr "/" " " | cut -d' ' -f2)
+	if [ -z "${DRIVER_VERSIONS}" ]; then
+		echo "- OK! There are no '${KMOD_NAME}' module versions in dkms."
 	else
-		echo "- OK! There is no '${KMOD_NAME}' module in dkms."
+		echo "- There are some verions of '${KMOD_NAME}' module in dkms."
+		echo
+		echo "* 3. Removing all the following versions from dkms:"
+		echo "${DRIVER_VERSIONS}"
+		echo
 	fi
+
+	for CURRENT_VER in ${DRIVER_VERSIONS}; do
+		echo "- Removing ${CURRENT_VER}..."
+		if dkms remove -m ${KMOD_NAME} -v "${CURRENT_VER}" --all; then
+			echo
+			echo "- OK! Removing '${CURRENT_VER}' succeeded"
+			echo
+		else
+			echo "[WARNING] Removing '${KMOD_NAME}' version '${CURRENT_VER}' failed"
+		fi
+	done
 
 	print_clean_termination
 }

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2021 The Falco Authors.
+# Copyright (C) 2022 The Falco Authors.
 #
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -261,7 +261,7 @@ clean_kernel_module() {
 			echo
 		else
 			echo "- Nothing to do...'falco-driver-loader' will wait until you remove the kernel module to have a clean termination."
-			echo "- Checkout here what to do (link to documentation)."
+			echo "- Check that no process is using the kernel module with 'lsmod | grep ${KMOD_NAME}'."
 			echo "- Sleep 5 seconds..."
 			echo
 			((--MAX_RMMOD_WAIT))
@@ -275,7 +275,7 @@ clean_kernel_module() {
 	fi
 	
 	if ! hash dkms >/dev/null 2>&1; then
-		echo "- Skipping dkms remove (dkms not found)"
+		echo "- Skipping dkms remove (dkms not found)."
 		print_clean_termination
 		return
 	fi
@@ -286,7 +286,7 @@ clean_kernel_module() {
 	if [ -z "${DRIVER_VERSIONS}" ]; then
 		echo "- OK! There are no '${KMOD_NAME}' module versions in dkms."
 	else
-		echo "- There are some verions of '${KMOD_NAME}' module in dkms."
+		echo "- There are some versions of '${KMOD_NAME}' module in dkms."
 		echo
 		echo "* 3. Removing all the following versions from dkms:"
 		echo "${DRIVER_VERSIONS}"
@@ -297,10 +297,10 @@ clean_kernel_module() {
 		echo "- Removing ${CURRENT_VER}..."
 		if dkms remove -m ${KMOD_NAME} -v "${CURRENT_VER}" --all; then
 			echo
-			echo "- OK! Removing '${CURRENT_VER}' succeeded"
+			echo "- OK! Removing '${CURRENT_VER}' succeeded."
 			echo
 		else
-			echo "[WARNING] Removing '${KMOD_NAME}' version '${CURRENT_VER}' failed"
+			echo "[WARNING] Removing '${KMOD_NAME}' version '${CURRENT_VER}' failed."
 		fi
 	done
 

--- a/scripts/rpm/postinstall.in
+++ b/scripts/rpm/postinstall.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 The Falco Authors.
+# Copyright (C) 2022 The Falco Authors.
 #
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/rpm/postuninstall.in
+++ b/scripts/rpm/postuninstall.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 The Falco Authors.
+# Copyright (C) 2022 The Falco Authors.
 #
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/rpm/preuninstall.in
+++ b/scripts/rpm/preuninstall.in
@@ -15,5 +15,4 @@
 # limitations under the License.
 #
 
-mod_version="@DRIVER_VERSION@"
-dkms remove -m falco -v $mod_version --all --rpm_safe_upgrade
+/usr/bin/falco-driver-loader --clean

--- a/scripts/rpm/preuninstall.in
+++ b/scripts/rpm/preuninstall.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 The Falco Authors.
+# Copyright (C) 2022 The Falco Authors.
 #
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This PR slightly modifies the behavior of the `falco-driver-loader` script. Now the cleaning phase enforces the deletion of the kernel module if it is still loaded. If the script is not able to detach the module, it waits until the user removes it manually. The user can do this by following some specific instructions that will be provided in the documentation... This is necessary to avoid incompatibility issues with driver versions, obtaining errors like the following:

```
Runtime error: Kernel module does not support PPM_IOCTL_GET_API_VERSION. Exiting.
```

This happens with Falco 0.31.1 because we introduced a mechanism to detect incompatible driver versions.

This new cleaning phase is called every time we try to load a new kernel module typing `falco-driver-loader` or explicitly calling it with `falco-driver-loader --clean`.

Since both `.deb` and `.rpm` packages have to perform the same cleaning phase when uninstalled now they call directly `falco-driver-loader --clean`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
