### PR TITLE
rule(Anonymous Request Allowed): exclude {/livez, /readyz}

### DIFF
--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -120,6 +120,12 @@
 - macro: health_endpoint
   condition: ka.uri=/healthz
 
+- macro: live_endpoint
+  condition: ka.uri=/livez
+
+- macro: ready_endpoint
+  condition: ka.uri=/readyz
+
 - rule: Create Disallowed Pod
   desc: >
     Detect an attempt to start a pod with a container image outside of a list of allowed images.
@@ -208,7 +214,7 @@
 - rule: Anonymous Request Allowed
   desc: >
     Detect any request made by the anonymous user that was allowed
-  condition: kevt and ka.user.name=system:anonymous and ka.auth.decision="allow" and not health_endpoint
+  condition: kevt and ka.user.name=system:anonymous and ka.auth.decision="allow" and not health_endpoint and not live_endpoint and not ready_endpoint
   output: Request by anonymous user allowed (user=%ka.user.name verb=%ka.verb uri=%ka.uri reason=%ka.auth.reason))
   priority: WARNING
   source: k8s_audit
@@ -667,4 +673,3 @@
   priority: WARNING
   source: k8s_audit
   tags: [k8s]
-


### PR DESCRIPTION
Fixes #1794.

/livez and /readyz don't require authentication and can generate a lot
of noise if the cluster is checked by an anonymous external
system.

Some k8s systems have those endpoints required to be anonymous, as per this
[link to an OpenShift
setup](http://static.open-scap.org/ssg-guides/ssg-ocp4-guide-cis.html#xccdf_org.ssgproject.content_rule_api_server_anonymous_auth).

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

/kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #1794

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
