### PR TITLE
rules: whitelist GCP's container threat detection image

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1833,6 +1833,7 @@
     gke.gcr.io/kube-proxy,
     gke.gcr.io/gke-metadata-server,
     gke.gcr.io/netd-amd64,
+    gke.gcr.io/watcher-daemonset,
     gcr.io/google-containers/prometheus-to-sd,
     k8s.gcr.io/ip-masq-agent-amd64,
     k8s.gcr.io/kube-proxy,

--- a/rules/k8s_audit_rules.yaml
+++ b/rules/k8s_audit_rules.yaml
@@ -288,6 +288,7 @@
     k8s.gcr.io/kube-apiserver,
     gke.gcr.io/kube-proxy,
     gke.gcr.io/netd-amd64,
+    gke.gcr.io/watcher-daemonset,
     k8s.gcr.io/addon-resizer
     k8s.gcr.io/prometheus-to-sd,
     k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind rule-update

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area rules

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

[Container threat detection](https://cloud.google.com/security-command-center/docs/how-to-use-container-threat-detection) is a feature of GCP security center that monitors cos nodes for changes and remote access attempts (it kinds of duplicate falco). It spawns a privileged DaemonSet in GKE clusters `kube-system` namespace, hence the need for  ignoring this image.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
