### PR TITLE
refactor: update definitions of falco_common

### DIFF
--- a/userspace/engine/falco_common.h
+++ b/userspace/engine/falco_common.h
@@ -54,9 +54,6 @@ namespace falco_common
 {
 	const string syscall_source = "syscall";
 
-	// Priority levels, as a vector of strings
-	extern std::vector<std::string> priority_names;
-
 	// Same as numbers/indices into the above vector
 	enum priority_type
 	{
@@ -71,5 +68,7 @@ namespace falco_common
 	};
 	
 	bool parse_priority(std::string v, priority_type& out);
-	bool format_priority(priority_type v, std::string& out);
+	priority_type parse_priority(std::string v);
+	bool format_priority(priority_type v, std::string& out, bool shortfmt=false);
+	std::string format_priority(priority_type v, bool shortfmt=false);
 };

--- a/userspace/engine/stats_manager.cpp
+++ b/userspace/engine/stats_manager.cpp
@@ -38,7 +38,8 @@ void stats_manager::format(
 	{
 		if (m_by_priority[i] > 0)
 		{
-			falco_common::format_priority((falco_common::priority_type) i, fmt);
+			falco_common::format_priority(
+				(falco_common::priority_type) i, fmt, true);
 			transform(fmt.begin(), fmt.end(), fmt.begin(), ::toupper);
 			out += "   " + fmt;
 			out += ": " + to_string(m_by_priority[i]) + "\n";

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -190,17 +190,10 @@ void falco_configuration::init(string conf_filename, const vector<string> &cmdli
 	m_notifications_max_burst = m_config->get_scalar<uint32_t>("outputs.max_burst", 1000);
 
 	string priority = m_config->get_scalar<string>("priority", "debug");
-	vector<string>::iterator it;
-
-	auto comp = [priority](string &s) {
-		return (strcasecmp(s.c_str(), priority.c_str()) == 0);
-	};
-
-	if((it = std::find_if(falco_common::priority_names.begin(), falco_common::priority_names.end(), comp)) == falco_common::priority_names.end())
+	if (!falco_common::parse_priority(priority, m_min_priority))
 	{
 		throw logic_error("Unknown priority \"" + priority + "\"--must be one of emergency, alert, critical, error, warning, notice, informational, debug");
 	}
-	m_min_priority = (falco_common::priority_type)(it - falco_common::priority_names.begin());
 
 	m_buffered_outputs = m_config->get_scalar<bool>("buffered_outputs", false);
 	m_time_format_iso_8601 = m_config->get_scalar<bool>("time_format_iso_8601", false);

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -61,7 +61,7 @@ bool g_reopen_outputs = false;
 bool g_restart = false;
 bool g_daemonized = false;
 
-static std::string syscall_source = "syscall";
+static std::string syscall_source = falco_common::syscall_source;
 static std::size_t syscall_source_idx;
 static std::string k8s_audit_source = "k8s_audit";
 static std::size_t k8s_audit_source_idx;

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -159,24 +159,25 @@ void falco_outputs::handle_event(gen_event *evt, string &rule, string &source,
 	{
 		if(m_time_format_iso_8601)
 		{
-			sformat = "*%evt.time.iso8601: " + falco_common::priority_names[priority];
+			sformat = "*%evt.time.iso8601: ";
 		}
 		else
 		{
-			sformat = "*%evt.time: " + falco_common::priority_names[priority];
+			sformat = "*%evt.time: ";
 		}
 	}
 	else
 	{
 		if(m_time_format_iso_8601)
 		{
-			sformat = "*%jevt.time.iso8601: " + falco_common::priority_names[priority];
+			sformat = "*%jevt.time.iso8601: ";
 		}
 		else
 		{
-			sformat = "*%jevt.time: " + falco_common::priority_names[priority];
+			sformat = "*%jevt.time: ";
 		}
 	}
+	sformat += falco_common::format_priority(priority);
 
 	// if format starts with a *, remove it, as we added our own prefix
 	if(format[0] == '*')
@@ -188,7 +189,7 @@ void falco_outputs::handle_event(gen_event *evt, string &rule, string &source,
 		sformat += " " + format;
 	}
 
-	cmsg.msg = m_formats->format_event(evt, rule, source, falco_common::priority_names[priority], sformat, tags);
+	cmsg.msg = m_formats->format_event(evt, rule, source, falco_common::format_priority(priority), sformat, tags);
 	cmsg.fields = m_formats->get_field_values(evt, source, sformat);
 	cmsg.tags.insert(tags.begin(), tags.end());
 
@@ -225,7 +226,7 @@ void falco_outputs::handle_msg(uint64_t ts,
 		iso8601evttime += time_ns;
 
 		jmsg["output"] = msg;
-		jmsg["priority"] = falco_common::priority_names[priority];
+		jmsg["priority"] = falco_common::format_priority(priority);
 		jmsg["rule"] = rule;
 		jmsg["time"] = iso8601evttime;
 		jmsg["output_fields"] = output_fields;
@@ -238,7 +239,7 @@ void falco_outputs::handle_msg(uint64_t ts,
 		bool first = true;
 
 		sinsp_utils::ts_to_string(ts, &timestr, false, true);
-		cmsg.msg = timestr + ": " + falco_common::priority_names[priority] + " " + msg + " (";
+		cmsg.msg = timestr + ": " + falco_common::format_priority(priority) + " " + msg + " (";
 		for(auto &pair : output_fields)
 		{
 			if(first)

--- a/userspace/falco/outputs_grpc.cpp
+++ b/userspace/falco/outputs_grpc.cpp
@@ -67,7 +67,7 @@ void falco::outputs::output_grpc::output(const message *msg)
 
 	// priority
 	falco::schema::priority p = falco::schema::priority::EMERGENCY;
-	if(!falco::schema::priority_Parse(falco_common::priority_names[msg->priority], &p))
+	if(!falco::schema::priority_Parse(falco_common::format_priority(msg->priority), &p))
 	{
 		throw falco_exception("Unknown priority passed to output_grpc::output()");
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR updates the Falco codebase to comply with the newest definitions of `falco_common` introduced in #1966. This also fixes the priority `info`/`informational` inconsistency that causes some bugs (e.g. gRPC enums).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
refactor: update definitions of falco_common
```