### PR TITLE
New Rule Detect Linux Cgroup Container Escape Vulnerability (CVE-2022-0492)

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3165,6 +3165,17 @@
   priority: CRITICAL
   tags: [process, mitre_privilege_escalation]
 
+# This rule helps detect CVE-2022-4092:
+# A privilege escalation container escaping in cgroup
+- rule: Linux Cgroup Container Escape Vulnerability (CVE-2022-4092)
+  desc: "Detect an attempt to exploit a container escape vulnerability in the Linux Kernel (CVE-2022-0492). By running a container with certains capabilities, a privileged user can modify release_agent file and escape from the container"
+  condition:
+    open_write and fd.name endswith release_agent and (user.uid=0 or thread.cap_permitted contains CAP_DAC_OVERRIDE) and excessively_capable_container
+  output:
+    "Detect cgroup container escaping attempt (CVE-2022-4092) (user=%user.name user_loginuid=%user.loginuid filename=%fd.name %container.info image=%container.image.repository:%container.image.tag cap_permitted=%thread.cap_permitted)"
+  priority: CRITICAL
+  tags: [container, mitre_privilege_escalation, mitre_lateral_movement]
+
 # Application rules have moved to application_rules.yaml. Please look
 # there if you want to enable them by adding to
 # falco_rules.local.yaml.

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3165,14 +3165,13 @@
   priority: CRITICAL
   tags: [process, mitre_privilege_escalation]
 
-# This rule helps detect CVE-2022-0492:
-# A privilege escalation container escaping in cgroup
-- rule: Linux Cgroup Container Escape Vulnerability (CVE-2022-0492)
-  desc: "Detect an attempt to exploit a container escape vulnerability in the Linux Kernel (CVE-2022-0492). By running a container with certains capabilities, a privileged user can modify release_agent file and escape from the container"
+
+- rule: Detect release_agent File Container Escapes
+  desc: "This rule detect an attempt to exploit a container escape using release_agent file. By running a container with certains capabilities, a privileged user can modify release_agent file and escape from the container"
   condition:
-    open_write and fd.name endswith release_agent and (user.uid=0 or thread.cap_permitted contains CAP_DAC_OVERRIDE) and excessively_capable_container
+    open_write and container and fd.name endswith release_agent and (user.uid=0 or thread.cap_permitted contains CAP_DAC_OVERRIDE) and thread.cap_effective contains CAP_SYS_ADMIN
   output:
-    "Detect cgroup container escaping attempt (CVE-2022-0492) (user=%user.name user_loginuid=%user.loginuid filename=%fd.name %container.info image=%container.image.repository:%container.image.tag cap_permitted=%thread.cap_permitted)"
+    "Detect an attempt to exploit a container escape using release_agent file (user=%user.name user_loginuid=%user.loginuid filename=%fd.name %container.info image=%container.image.repository:%container.image.tag cap_effective=%thread.cap_effective)"
   priority: CRITICAL
   tags: [container, mitre_privilege_escalation, mitre_lateral_movement]
 

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3165,14 +3165,14 @@
   priority: CRITICAL
   tags: [process, mitre_privilege_escalation]
 
-# This rule helps detect CVE-2022-4092:
+# This rule helps detect CVE-2022-0492:
 # A privilege escalation container escaping in cgroup
-- rule: Linux Cgroup Container Escape Vulnerability (CVE-2022-4092)
+- rule: Linux Cgroup Container Escape Vulnerability (CVE-2022-0492)
   desc: "Detect an attempt to exploit a container escape vulnerability in the Linux Kernel (CVE-2022-0492). By running a container with certains capabilities, a privileged user can modify release_agent file and escape from the container"
   condition:
     open_write and fd.name endswith release_agent and (user.uid=0 or thread.cap_permitted contains CAP_DAC_OVERRIDE) and excessively_capable_container
   output:
-    "Detect cgroup container escaping attempt (CVE-2022-4092) (user=%user.name user_loginuid=%user.loginuid filename=%fd.name %container.info image=%container.image.repository:%container.image.tag cap_permitted=%thread.cap_permitted)"
+    "Detect cgroup container escaping attempt (CVE-2022-0492) (user=%user.name user_loginuid=%user.loginuid filename=%fd.name %container.info image=%container.image.repository:%container.image.tag cap_permitted=%thread.cap_permitted)"
   priority: CRITICAL
   tags: [container, mitre_privilege_escalation, mitre_lateral_movement]
 

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3169,7 +3169,7 @@
 - rule: Detect release_agent File Container Escapes
   desc: "This rule detect an attempt to exploit a container escape using release_agent file. By running a container with certains capabilities, a privileged user can modify release_agent file and escape from the container"
   condition:
-    open_write and container and fd.name endswith release_agent and (user.uid=0 or thread.cap_permitted contains CAP_DAC_OVERRIDE) and thread.cap_effective contains CAP_SYS_ADMIN
+    open_write and container and fd.name endswith release_agent and (user.uid=0 or thread.cap_effective contains CAP_DAC_OVERRIDE) and thread.cap_effective contains CAP_SYS_ADMIN
   output:
     "Detect an attempt to exploit a container escape using release_agent file (user=%user.name user_loginuid=%user.loginuid filename=%fd.name %container.info image=%container.image.repository:%container.image.tag cap_effective=%thread.cap_effective)"
   priority: CRITICAL


### PR DESCRIPTION
This PR add a new rule to detect container escapes techniques (also used CVE-2022-0492 Linux Cgroup Container Escape Vulnerability) using new field available thread.cap_effective to check capabilities in the container which is part of the requirement for the exploitation. 
Reference: 
https://unit42.paloaltonetworks.com/cve-2022-0492-cgroups/
https://blog.trailofbits.com/2019/07/19/understanding-docker-container-escapes/

Signed-off-by: darryk10 <stefano.chierici@sysdig.com>
Co-authored-by: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

/kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR add a new rule to detect container escapes techniques (also used CVE-2022-0492 Linux Cgroup Container Escape Vulnerability)
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rule(Detect release_agent File Container Escapes): new rule created to detect an attempt to exploit a container escape using release_agent file
```
