### PR TITLE
build(cmake): upgrade catch2 to 2.13.9

### DIFF
--- a/cmake/modules/DownloadCatch.cmake
+++ b/cmake/modules/DownloadCatch.cmake
@@ -14,8 +14,8 @@ include(ExternalProject)
 
 set(CATCH2_INCLUDE ${CMAKE_BINARY_DIR}/catch2-prefix/include)
 
-set(CATCH_EXTERNAL_URL URL https://github.com/catchorg/catch2/archive/v2.12.1.tar.gz URL_HASH
-                       SHA256=e5635c082282ea518a8dd7ee89796c8026af8ea9068cd7402fb1615deacd91c3)
+set(CATCH_EXTERNAL_URL URL https://github.com/catchorg/catch2/archive/v2.13.9.tar.gz URL_HASH
+                       SHA256=06dbc7620e3b96c2b69d57bf337028bf245a211b3cddb843835bfe258f427a52)
 
 ExternalProject_Add(
   catch2


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**Any specific area of the project related to this PR?**
/area build


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Upgrading catch2 addresses the problem reported in the following log:
```
In file included from /usr/include/signal.h:328,
                 from /home/leogr/code/github.com/falcosecurity/falco/build/catch2-prefix/include/catch.hpp:8007,
                 from /home/leogr/code/github.com/falcosecurity/falco/tests/test_base.cpp:18:
/home/leogr/code/github.com/falcosecurity/falco/build/catch2-prefix/include/catch.hpp:10791:58: error: call to non-'constexpr' function 'long int sysconf(int)'
10791 |     static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
      |                                                          ^~~~~~~~~~~
In file included from /usr/include/bits/sigstksz.h:24,
                 from /usr/include/signal.h:328,
                 from /home/leogr/code/github.com/falcosecurity/falco/build/catch2-prefix/include/catch.hpp:8007,
                 from /home/leogr/code/github.com/falcosecurity/falco/tests/test_base.cpp:18:
/usr/include/unistd.h:640:17: note: 'long int sysconf(int)' declared here
  640 | extern long int sysconf (int __name) __THROW;
      |                 ^~~~~~~
In file included from /home/leogr/code/github.com/falcosecurity/falco/tests/test_base.cpp:18:
/home/leogr/code/github.com/falcosecurity/falco/build/catch2-prefix/include/catch.hpp:10850:45: error: size of array 'altStackMem' is not an integral constant-expression
10850 |     char FatalConditionHandler::altStackMem[sigStackSize] = {};
      |                                             ^~~~~~~~~~~~
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.32.0

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
build(cmake): upgrade catch2 to 2.13.9
```
