### PR TITLE
new(docker,scripts): port all docker images to be multiarch ready

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,74 +389,80 @@ jobs:
   # Publish docker packages
   "publish/docker-dev":
     docker:
-      - image: docker:stable
+      - image: cimg/base:stable
     steps:
       - attach_workspace:
           at: /
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.12
       - run:
           name: Build and publish no-driver-dev
           command: |
             FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            docker build --build-arg VERSION_BUCKET=bin-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t falcosecurity/falco-no-driver:master docker/no-driver
-            docker tag falcosecurity/falco-no-driver:master falcosecurity/falco:master-slim
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
-            docker push falcosecurity/falco-no-driver:master
-            docker push falcosecurity/falco:master-slim
+            docker buildx build --build-arg VERSION_BUCKET=bin-dev --build-arg FALCO_VERSION=${FALCO_VERSION} --platform "arm64,amd64" --push \ 
+              -t falcosecurity/falco-no-driver:master \
+              -t falcosecurity/falco:master-slim \
+              docker/no-driver
       - run:
           name: Build and publish dev
           command: |
             FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            docker build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t falcosecurity/falco:master docker/falco
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
-            docker push falcosecurity/falco:master
+            docker buildx build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} --platform "arm64,amd64" --push \ 
+              -t falcosecurity/falco:master \
+              docker/falco
       - run:
           name: Build and publish dev falco-driver-loader-dev
           command: |
-            docker build --build-arg FALCO_IMAGE_TAG=master -t falcosecurity/falco-driver-loader:master docker/driver-loader
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
-            docker push falcosecurity/falco-driver-loader:master
+            docker buildx build --build-arg FALCO_IMAGE_TAG=master --platform "arm64,amd64" --push \ 
+              -t falcosecurity/falco-driver-loader:master \
+              docker/driver-loader
   # Publish container images to AWS ECR Public
   "publish/container-images-aws-dev":
     docker:
-      - image: docker:stable
+      - image: cimg/base:stable
     steps:
       - attach_workspace:
           at: /
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.12
       - run:
           name: Build and publish no-driver (dev) to AWS
           command: |
             apk update
             apk add --update groff less py-pip
             pip install awscli
-            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            docker build --build-arg VERSION_BUCKET=bin-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t "public.ecr.aws/falcosecurity/falco-no-driver:master" docker/no-driver
-            docker tag public.ecr.aws/falcosecurity/falco-no-driver:master public.ecr.aws/falcosecurity/falco:master-slim
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
-            docker push "public.ecr.aws/falcosecurity/falco-no-driver:master"
-            docker push "public.ecr.aws/falcosecurity/falco:master-slim"
+            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
+            docker buildx build --build-arg VERSION_BUCKET=bin-dev --build-arg FALCO_VERSION=${FALCO_VERSION} --platform "arm64,amd64" --push \ 
+              -t "public.ecr.aws/falcosecurity/falco-no-driver:master" \
+              -t public.ecr.aws/falcosecurity/falco:master-slim \
+              docker/no-driver
       - run:
           name: Build and publish falco (dev) to AWS
           command: |
             apk update
             apk add --update groff less py-pip
             pip install awscli
-            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
-            docker build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} -t "public.ecr.aws/falcosecurity/falco:master" docker/falco
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
-            docker push "public.ecr.aws/falcosecurity/falco:master"
+            FALCO_VERSION=$(cat /build/release/userspace/falco/config_falco.h | grep 'FALCO_VERSION ' | cut -d' ' -f3 | sed -e 's/^"//' -e 's/"$//')
+            docker buildx build --build-arg VERSION_BUCKET=deb-dev --build-arg FALCO_VERSION=${FALCO_VERSION} --platform "arm64,amd64" --push \ 
+              -t "public.ecr.aws/falcosecurity/falco:master" \
+              docker/falco
       - run:
           name: Build and publish driver-loader (dev) to AWS
           command: |
             apk update
             apk add --update groff less py-pip
             pip install awscli
-            docker build --build-arg FALCO_IMAGE_TAG=master -t "public.ecr.aws/falcosecurity/falco-driver-loader:master" docker/driver-loader
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
-            docker push "public.ecr.aws/falcosecurity/falco-driver-loader:master"
+            docker buildx build --build-arg FALCO_IMAGE_TAG=master --platform "arm64,amd64" --push \
+              -t "public.ecr.aws/falcosecurity/falco-driver-loader:master" \
+              docker/driver-loader
   # Publish the packages
   "publish/packages":
     docker:
@@ -509,86 +515,83 @@ jobs:
   # Publish docker packages
   "publish/docker":
     docker:
-      - image: docker:stable
+      - image: cimg/base:stable
     steps:
       - attach_workspace:
           at: /
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.12
       - run:
           name: Build and publish no-driver
           command: |
-            docker build --build-arg VERSION_BUCKET=bin --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "falcosecurity/falco-no-driver:${CIRCLE_TAG}" docker/no-driver
-            docker tag "falcosecurity/falco-no-driver:${CIRCLE_TAG}" falcosecurity/falco-no-driver:latest
-            docker tag "falcosecurity/falco-no-driver:${CIRCLE_TAG}" "falcosecurity/falco:${CIRCLE_TAG}-slim"
-            docker tag "falcosecurity/falco-no-driver:${CIRCLE_TAG}" "falcosecurity/falco:latest-slim"
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
-            docker push "falcosecurity/falco-no-driver:${CIRCLE_TAG}"
-            docker push "falcosecurity/falco-no-driver:latest"
-            docker push "falcosecurity/falco:${CIRCLE_TAG}-slim"
-            docker push "falcosecurity/falco:latest-slim"
+            docker buildx build --build-arg VERSION_BUCKET=bin --build-arg FALCO_VERSION=${CIRCLE_TAG} --platform "arm64,amd64" --push \
+              -t "falcosecurity/falco-no-driver:${CIRCLE_TAG}" \
+              -t falcosecurity/falco-no-driver:latest \
+              -t "falcosecurity/falco:${CIRCLE_TAG}-slim" \
+              -t "falcosecurity/falco:latest-slim" \
+              docker/no-driver
       - run:
           name: Build and publish falco
           command: |
-            docker build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "falcosecurity/falco:${CIRCLE_TAG}" docker/falco
-            docker tag "falcosecurity/falco:${CIRCLE_TAG}" falcosecurity/falco:latest
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
-            docker push "falcosecurity/falco:${CIRCLE_TAG}"
-            docker push "falcosecurity/falco:latest"
+            docker buildx build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${CIRCLE_TAG} --platform "arm64,amd64" --push \
+              -t "falcosecurity/falco:${CIRCLE_TAG}" \
+              -t "falcosecurity/falco:latest" \
+              docker/falco
       - run:
           name: Build and publish falco-driver-loader
           command: |
-            docker build --build-arg FALCO_IMAGE_TAG=${CIRCLE_TAG} -t "falcosecurity/falco-driver-loader:${CIRCLE_TAG}" docker/driver-loader
-            docker tag "falcosecurity/falco-driver-loader:${CIRCLE_TAG}" falcosecurity/falco-driver-loader:latest
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
-            docker push "falcosecurity/falco-driver-loader:${CIRCLE_TAG}"
-            docker push "falcosecurity/falco-driver-loader:latest"
+            docker buildx build --build-arg FALCO_IMAGE_TAG=${CIRCLE_TAG} --platform "arm64,amd64" --push \
+              -t "falcosecurity/falco-driver-loader:${CIRCLE_TAG}" \
+              -t "falcosecurity/falco-driver-loader:latest" \
+              docker/driver-loader
   # Publish container images to AWS ECR Public
   "publish/container-images-aws":
     docker:
-      - image: docker:stable
+      - image: cimg/base:stable
     steps:
       - attach_workspace:
           at: /
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.12
       - run:
           name: Build and publish no-driver to AWS
           command: |
             apk update
             apk add --update groff less py-pip
             pip install awscli
-            docker build --build-arg VERSION_BUCKET=bin --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" docker/no-driver
-            docker tag "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" public.ecr.aws/falcosecurity/falco-no-driver:latest
-            docker tag "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}-slim"
-            docker tag "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" "public.ecr.aws/falcosecurity/falco:latest-slim"
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
-            docker push "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}-slim"
-            docker push "public.ecr.aws/falcosecurity/falco:latest-slim"
-            docker push "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}"
-            docker push "public.ecr.aws/falcosecurity/falco-no-driver:latest"
+            docker buildx build --build-arg VERSION_BUCKET=bin --build-arg FALCO_VERSION=${CIRCLE_TAG} --platform "arm64,amd64" --push \
+              -t "public.ecr.aws/falcosecurity/falco-no-driver:${CIRCLE_TAG}" \
+              -t public.ecr.aws/falcosecurity/falco-no-driver:latest \
+              -t "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}-slim" \
+              -t "public.ecr.aws/falcosecurity/falco:latest-slim" \
+              docker/no-driver
       - run:
           name: Build and publish falco to AWS
           command: |
             apk update
             apk add --update groff less py-pip
             pip install awscli
-            docker build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${CIRCLE_TAG} -t "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}" docker/falco
-            docker tag "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}" public.ecr.aws/falcosecurity/falco:latest
             aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
-            docker push "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}"
-            docker push "public.ecr.aws/falcosecurity/falco:latest"
+            docker buildx build --build-arg VERSION_BUCKET=deb --build-arg FALCO_VERSION=${CIRCLE_TAG} --platform "arm64,amd64" --push \
+              -t "public.ecr.aws/falcosecurity/falco:${CIRCLE_TAG}" \
+              -t public.ecr.aws/falcosecurity/falco:latest \
+            docker/falco
       - run:
           name: Build and publish falco-driver-loader to AWS
           command: |
             apk update
             apk add --update groff less py-pip
             pip install awscli
-            docker build --build-arg FALCO_IMAGE_TAG=${CIRCLE_TAG} -t "public.ecr.aws/falcosecurity/falco-driver-loader:${CIRCLE_TAG}" docker/driver-loader
-            docker tag "public.ecr.aws/falcosecurity/falco-driver-loader:${CIRCLE_TAG}" public.ecr.aws/falcosecurity/falco-driver-loader:latest
-            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
-            docker push "public.ecr.aws/falcosecurity/falco-driver-loader:${CIRCLE_TAG}"
-            docker push "public.ecr.aws/falcosecurity/falco-driver-loader:latest"
+            docker buildx build --build-arg FALCO_IMAGE_TAG=${CIRCLE_TAG} --platform "arm64,amd64" --push \
+              -t "public.ecr.aws/falcosecurity/falco-driver-loader:${CIRCLE_TAG}" \
+              -t public.ecr.aws/falcosecurity/falco-driver-loader:latest \
+            docker/driver-loader
 workflows:
   version: 2
   build_and_test:

--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -4,6 +4,8 @@ LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
 LABEL usage="docker run -i -t --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc --name NAME IMAGE"
 
+ARG TARGETARCH
+
 ARG FALCO_VERSION=latest
 ARG VERSION_BUCKET=deb
 ENV VERSION_BUCKET=${VERSION_BUCKET}
@@ -29,12 +31,15 @@ RUN apt-get update \
 	jq \
 	libc6-dev \
 	libelf-dev \
-	libmpx2 \
 	libssl-dev \
 	llvm-7 \
 	netcat \
 	xz-utils \
 	&& rm -rf /var/lib/apt/lists/*
+
+RUN if [ "$TARGETARCH" = "amd64" ]; \
+    then apt-get install -y --no-install-recommends libmpx2; \
+    fi
 
 # gcc 6 is no longer included in debian stable, but we need it to
 # build kernel modules on the default debian-based ami used by
@@ -42,32 +47,36 @@ RUN apt-get update \
 # prefix https://snapshot.debian.org/archive/debian/20170517T033514Z
 # or so.
 
-RUN curl -L -o cpp-6_6.3.0-18_amd64.deb https://download.falco.org/dependencies/cpp-6_6.3.0-18_amd64.deb \
-	&& curl -L -o gcc-6-base_6.3.0-18_amd64.deb https://download.falco.org/dependencies/gcc-6-base_6.3.0-18_amd64.deb \
-	&& curl -L -o gcc-6_6.3.0-18_amd64.deb https://download.falco.org/dependencies/gcc-6_6.3.0-18_amd64.deb \
-	&& curl -L -o libasan3_6.3.0-18_amd64.deb https://download.falco.org/dependencies/libasan3_6.3.0-18_amd64.deb \
-	&& curl -L -o libcilkrts5_6.3.0-18_amd64.deb https://download.falco.org/dependencies/libcilkrts5_6.3.0-18_amd64.deb \
-	&& curl -L -o libgcc-6-dev_6.3.0-18_amd64.deb https://download.falco.org/dependencies/libgcc-6-dev_6.3.0-18_amd64.deb \
-	&& curl -L -o libubsan0_6.3.0-18_amd64.deb https://download.falco.org/dependencies/libubsan0_6.3.0-18_amd64.deb \
-	&& curl -L -o libmpfr4_3.1.3-2_amd64.deb https://download.falco.org/dependencies/libmpfr4_3.1.3-2_amd64.deb \
-	&& curl -L -o libisl15_0.18-1_amd64.deb https://download.falco.org/dependencies/libisl15_0.18-1_amd64.deb \
-	&& dpkg -i cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb \
-	&& rm -f cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb
+RUN if [ "$TARGETARCH" = "amd64" ]; then curl -L -o libcilkrts5_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libcilkrts5_6.3.0-18_${TARGETARCH}.deb; fi; \
+    curl -L -o cpp-6_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/cpp-6_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o gcc-6-base_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-6-base_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o gcc-6_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-6_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o libasan3_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libasan3_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o libubsan0_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libubsan0_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o libmpfr4_3.1.3-2_${TARGETARCH}.deb https://download.falco.org/dependencies/libmpfr4_3.1.3-2_${TARGETARCH}.deb \
+	&& curl -L -o libisl15_0.18-1_${TARGETARCH}.deb https://download.falco.org/dependencies/libisl15_0.18-1_${TARGETARCH}.deb \
+	&& dpkg -i cpp-6_6.3.0-18_${TARGETARCH}.deb gcc-6-base_6.3.0-18_${TARGETARCH}.deb gcc-6_6.3.0-18_${TARGETARCH}.deb libasan3_6.3.0-18_${TARGETARCH}.deb; \
+    if [ "$TARGETARCH" = "amd64" ]; then dpkg -i libcilkrts5_6.3.0-18_${TARGETARCH}.deb; fi; \
+    dpkg -i libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb libubsan0_6.3.0-18_${TARGETARCH}.deb libmpfr4_3.1.3-2_${TARGETARCH}.deb libisl15_0.18-1_${TARGETARCH}.deb \
+	&& rm -f cpp-6_6.3.0-18_${TARGETARCH}.deb gcc-6-base_6.3.0-18_${TARGETARCH}.deb gcc-6_6.3.0-18_${TARGETARCH}.deb libasan3_6.3.0-18_${TARGETARCH}.deb libcilkrts5_6.3.0-18_${TARGETARCH}.deb libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb libubsan0_6.3.0-18_${TARGETARCH}.deb libmpfr4_3.1.3-2_${TARGETARCH}.deb libisl15_0.18-1_${TARGETARCH}.deb
 
 # gcc 5 is no longer included in debian stable, but we need it to
 # build centos kernels, which are 3.x based and explicitly want a gcc
 # version 3, 4, or 5 compiler. So grab copies we've saved from debian
 # snapshots with the prefix https://snapshot.debian.org/archive/debian/20190122T000000Z.
 
-RUN curl -L -o cpp-5_5.5.0-12_amd64.deb https://download.falco.org/dependencies/cpp-5_5.5.0-12_amd64.deb \
-	&& curl -L -o gcc-5-base_5.5.0-12_amd64.deb https://download.falco.org/dependencies/gcc-5-base_5.5.0-12_amd64.deb \
-	&& curl -L -o gcc-5_5.5.0-12_amd64.deb https://download.falco.org/dependencies/gcc-5_5.5.0-12_amd64.deb \
-	&& curl -L -o libasan2_5.5.0-12_amd64.deb	https://download.falco.org/dependencies/libasan2_5.5.0-12_amd64.deb \
-	&& curl -L -o libgcc-5-dev_5.5.0-12_amd64.deb https://download.falco.org/dependencies/libgcc-5-dev_5.5.0-12_amd64.deb \
-	&& curl -L -o libisl15_0.18-4_amd64.deb https://download.falco.org/dependencies/libisl15_0.18-4_amd64.deb \
-	&& curl -L -o libmpx0_5.5.0-12_amd64.deb https://download.falco.org/dependencies/libmpx0_5.5.0-12_amd64.deb \
-	&& dpkg -i cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb \
-	&& rm -f cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb
+RUN if [ "$TARGETARCH" = "amd64" ]; then curl -L -o libmpx0_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/libmpx0_5.5.0-12_${TARGETARCH}.deb; fi; \
+    curl -L -o cpp-5_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/cpp-5_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o gcc-5-base_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-5-base_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o gcc-5_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-5_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o libasan2_5.5.0-12_${TARGETARCH}.deb	https://download.falco.org/dependencies/libasan2_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o libisl15_0.18-4_${TARGETARCH}.deb https://download.falco.org/dependencies/libisl15_0.18-4_${TARGETARCH}.deb \
+	&& dpkg -i cpp-5_5.5.0-12_${TARGETARCH}.deb gcc-5-base_5.5.0-12_${TARGETARCH}.deb gcc-5_5.5.0-12_${TARGETARCH}.deb libasan2_5.5.0-12_${TARGETARCH}.deb; \
+    if [ "$TARGETARCH" = "amd64" ]; then dpkg -i libmpx0_5.5.0-12_${TARGETARCH}.deb; fi; \
+    dpkg -i libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb libisl15_0.18-4_${TARGETARCH}.deb \
+	&& rm -f cpp-5_5.5.0-12_${TARGETARCH}.deb gcc-5-base_5.5.0-12_${TARGETARCH}.deb gcc-5_5.5.0-12_${TARGETARCH}.deb libasan2_5.5.0-12_${TARGETARCH}.deb libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb libisl15_0.18-4_${TARGETARCH}.deb libmpx0_5.5.0-12_${TARGETARCH}.deb
 
 # Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
 # default to gcc-5.
@@ -99,10 +108,16 @@ RUN rm -df /lib/modules \
 # debian:stable head contains binutils 2.31, which generates
 # binaries that are incompatible with kernels < 4.16. So manually
 # forcibly install binutils 2.30-22 instead.
-RUN curl -L -o binutils_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils_2.30-22_amd64.deb \
-	&& curl -L -o libbinutils_2.30-22_amd64.deb https://download.falco.org/dependencies/libbinutils_2.30-22_amd64.deb \
-	&& curl -L -o binutils-x86-64-linux-gnu_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils-x86-64-linux-gnu_2.30-22_amd64.deb \
-	&& curl -L -o binutils-common_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils-common_2.30-22_amd64.deb \
+
+RUN if [ "$TARGETARCH" = "amd64" ] ; then \
+    curl -L -o binutils-x86-64-linux-gnu_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils-x86-64-linux-gnu_2.30-22_${TARGETARCH}.deb; \
+    else  \
+    curl -L -o  binutils-aarch64-linux-gnu_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils-aarch64-linux-gnu_2.30-22_${TARGETARCH}.deb; \
+    fi
+
+RUN curl -L -o binutils_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils_2.30-22_${TARGETARCH}.deb \
+	&& curl -L -o libbinutils_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/libbinutils_2.30-22_${TARGETARCH}.deb \
+	&& curl -L -o binutils-common_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils-common_2.30-22_${TARGETARCH}.deb \
 	&& dpkg -i *binutils*.deb \
 	&& rm -f *binutils*.deb
 

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -1,7 +1,9 @@
-FROM debian:stable
+FROM debian:buster
 
 LABEL usage="docker run -i -t -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --name NAME IMAGE"
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+
+ARG TARGETARCH
 
 ARG FALCO_VERSION=
 RUN test -n FALCO_VERSION
@@ -37,10 +39,12 @@ RUN apt-get update \
 	libatomic1 \
 	liblsan0 \
 	libtsan0 \
-	libmpx2 \
-	libquadmath0 \
 	libcc1-0 \
 	&& rm -rf /var/lib/apt/lists/*
+
+RUN if [ "$TARGETARCH" = "amd64" ]; \
+    then apt-get install -y --no-install-recommends libmpx2 libquadmath0; \
+    fi
 
 # gcc 6 is no longer included in debian stable, but we need it to
 # build kernel modules on the default debian-based ami used by
@@ -48,32 +52,36 @@ RUN apt-get update \
 # prefix https://snapshot.debian.org/archive/debian/20170517T033514Z
 # or so.
 
-RUN curl -L -o cpp-6_6.3.0-18_amd64.deb https://download.falco.org/dependencies/cpp-6_6.3.0-18_amd64.deb \
-	&& curl -L -o gcc-6-base_6.3.0-18_amd64.deb https://download.falco.org/dependencies/gcc-6-base_6.3.0-18_amd64.deb \
-	&& curl -L -o gcc-6_6.3.0-18_amd64.deb https://download.falco.org/dependencies/gcc-6_6.3.0-18_amd64.deb \
-	&& curl -L -o libasan3_6.3.0-18_amd64.deb https://download.falco.org/dependencies/libasan3_6.3.0-18_amd64.deb \
-	&& curl -L -o libcilkrts5_6.3.0-18_amd64.deb https://download.falco.org/dependencies/libcilkrts5_6.3.0-18_amd64.deb \
-	&& curl -L -o libgcc-6-dev_6.3.0-18_amd64.deb https://download.falco.org/dependencies/libgcc-6-dev_6.3.0-18_amd64.deb \
-	&& curl -L -o libubsan0_6.3.0-18_amd64.deb https://download.falco.org/dependencies/libubsan0_6.3.0-18_amd64.deb \
-	&& curl -L -o libmpfr4_3.1.3-2_amd64.deb https://download.falco.org/dependencies/libmpfr4_3.1.3-2_amd64.deb \
-	&& curl -L -o libisl15_0.18-1_amd64.deb https://download.falco.org/dependencies/libisl15_0.18-1_amd64.deb \
-	&& dpkg -i cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb \
-	&& rm -f cpp-6_6.3.0-18_amd64.deb gcc-6-base_6.3.0-18_amd64.deb gcc-6_6.3.0-18_amd64.deb libasan3_6.3.0-18_amd64.deb libcilkrts5_6.3.0-18_amd64.deb libgcc-6-dev_6.3.0-18_amd64.deb libubsan0_6.3.0-18_amd64.deb libmpfr4_3.1.3-2_amd64.deb libisl15_0.18-1_amd64.deb
+RUN if [ "$TARGETARCH" = "amd64" ]; then curl -L -o libcilkrts5_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libcilkrts5_6.3.0-18_${TARGETARCH}.deb; fi; \
+    curl -L -o cpp-6_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/cpp-6_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o gcc-6-base_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-6-base_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o gcc-6_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-6_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o libasan3_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libasan3_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o libubsan0_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libubsan0_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o libmpfr4_3.1.3-2_${TARGETARCH}.deb https://download.falco.org/dependencies/libmpfr4_3.1.3-2_${TARGETARCH}.deb \
+	&& curl -L -o libisl15_0.18-1_${TARGETARCH}.deb https://download.falco.org/dependencies/libisl15_0.18-1_${TARGETARCH}.deb \
+	&& dpkg -i cpp-6_6.3.0-18_${TARGETARCH}.deb gcc-6-base_6.3.0-18_${TARGETARCH}.deb gcc-6_6.3.0-18_${TARGETARCH}.deb libasan3_6.3.0-18_${TARGETARCH}.deb; \
+    if [ "$TARGETARCH" = "amd64" ]; then dpkg -i libcilkrts5_6.3.0-18_${TARGETARCH}.deb; fi; \
+    dpkg -i libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb libubsan0_6.3.0-18_${TARGETARCH}.deb libmpfr4_3.1.3-2_${TARGETARCH}.deb libisl15_0.18-1_${TARGETARCH}.deb \
+	&& rm -f cpp-6_6.3.0-18_${TARGETARCH}.deb gcc-6-base_6.3.0-18_${TARGETARCH}.deb gcc-6_6.3.0-18_${TARGETARCH}.deb libasan3_6.3.0-18_${TARGETARCH}.deb libcilkrts5_6.3.0-18_${TARGETARCH}.deb libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb libubsan0_6.3.0-18_${TARGETARCH}.deb libmpfr4_3.1.3-2_${TARGETARCH}.deb libisl15_0.18-1_${TARGETARCH}.deb
 
 # gcc 5 is no longer included in debian stable, but we need it to
 # build centos kernels, which are 3.x based and explicitly want a gcc
 # version 3, 4, or 5 compiler. So grab copies we've saved from debian
 # snapshots with the prefix https://snapshot.debian.org/archive/debian/20190122T000000Z.
 
-RUN curl -L -o cpp-5_5.5.0-12_amd64.deb https://download.falco.org/dependencies/cpp-5_5.5.0-12_amd64.deb \
-	&& curl -L -o gcc-5-base_5.5.0-12_amd64.deb https://download.falco.org/dependencies/gcc-5-base_5.5.0-12_amd64.deb \
-	&& curl -L -o gcc-5_5.5.0-12_amd64.deb https://download.falco.org/dependencies/gcc-5_5.5.0-12_amd64.deb \
-	&& curl -L -o libasan2_5.5.0-12_amd64.deb	https://download.falco.org/dependencies/libasan2_5.5.0-12_amd64.deb \
-	&& curl -L -o libgcc-5-dev_5.5.0-12_amd64.deb https://download.falco.org/dependencies/libgcc-5-dev_5.5.0-12_amd64.deb \
-	&& curl -L -o libisl15_0.18-4_amd64.deb https://download.falco.org/dependencies/libisl15_0.18-4_amd64.deb \
-	&& curl -L -o libmpx0_5.5.0-12_amd64.deb https://download.falco.org/dependencies/libmpx0_5.5.0-12_amd64.deb \
-	&& dpkg -i cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb \
-	&& rm -f cpp-5_5.5.0-12_amd64.deb gcc-5-base_5.5.0-12_amd64.deb gcc-5_5.5.0-12_amd64.deb libasan2_5.5.0-12_amd64.deb libgcc-5-dev_5.5.0-12_amd64.deb libisl15_0.18-4_amd64.deb libmpx0_5.5.0-12_amd64.deb
+RUN if [ "$TARGETARCH" = "amd64" ]; then curl -L -o libmpx0_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/libmpx0_5.5.0-12_${TARGETARCH}.deb; fi; \
+    curl -L -o cpp-5_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/cpp-5_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o gcc-5-base_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-5-base_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o gcc-5_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-5_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o libasan2_5.5.0-12_${TARGETARCH}.deb	https://download.falco.org/dependencies/libasan2_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o libisl15_0.18-4_${TARGETARCH}.deb https://download.falco.org/dependencies/libisl15_0.18-4_${TARGETARCH}.deb \
+	&& dpkg -i cpp-5_5.5.0-12_${TARGETARCH}.deb gcc-5-base_5.5.0-12_${TARGETARCH}.deb gcc-5_5.5.0-12_${TARGETARCH}.deb libasan2_5.5.0-12_${TARGETARCH}.deb; \
+    if [ "$TARGETARCH" = "amd64" ]; then dpkg -i libmpx0_5.5.0-12_${TARGETARCH}.deb; fi; \
+    dpkg -i libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb libisl15_0.18-4_${TARGETARCH}.deb \
+	&& rm -f cpp-5_5.5.0-12_${TARGETARCH}.deb gcc-5-base_5.5.0-12_${TARGETARCH}.deb gcc-5_5.5.0-12_${TARGETARCH}.deb libasan2_5.5.0-12_${TARGETARCH}.deb libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb libisl15_0.18-4_${TARGETARCH}.deb libmpx0_5.5.0-12_${TARGETARCH}.deb
 
 # Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
 # default to gcc-5.
@@ -90,8 +98,8 @@ RUN rm -rf /usr/bin/clang \
 RUN rm -df /lib/modules \
 	&& ln -s $HOST_ROOT/lib/modules /lib/modules
 
-ADD falco-${FALCO_VERSION}-x86_64.deb /
-RUN dpkg -i /falco-${FALCO_VERSION}-x86_64.deb
+ADD falco-${FALCO_VERSION}-*.deb /
+RUN dpkg -i /falco-${FALCO_VERSION}-$(uname -m).deb
 
 # Change the falco config within the container to enable ISO 8601
 # output.
@@ -101,10 +109,15 @@ RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/fa
 # debian:stable head contains binutils 2.31, which generates
 # binaries that are incompatible with kernels < 4.16. So manually
 # forcibly install binutils 2.30-22 instead.
-RUN curl -L -o binutils_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils_2.30-22_amd64.deb \
-	&& curl -L -o libbinutils_2.30-22_amd64.deb https://download.falco.org/dependencies/libbinutils_2.30-22_amd64.deb \
-	&& curl -L -o binutils-x86-64-linux-gnu_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils-x86-64-linux-gnu_2.30-22_amd64.deb \
-	&& curl -L -o binutils-common_2.30-22_amd64.deb https://download.falco.org/dependencies/binutils-common_2.30-22_amd64.deb \
+RUN if [ "$TARGETARCH" = "amd64" ] ; then \
+    curl -L -o binutils-x86-64-linux-gnu_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils-x86-64-linux-gnu_2.30-22_${TARGETARCH}.deb; \
+    else  \
+    curl -L -o  binutils-aarch64-linux-gnu_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils-aarch64-linux-gnu_2.30-22_${TARGETARCH}.deb; \
+    fi
+
+RUN curl -L -o binutils_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils_2.30-22_${TARGETARCH}.deb \
+	&& curl -L -o libbinutils_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/libbinutils_2.30-22_${TARGETARCH}.deb \
+	&& curl -L -o binutils-common_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils-common_2.30-22_${TARGETARCH}.deb \
 	&& dpkg -i *binutils*.deb \
 	&& rm -f *binutils*.deb
 

--- a/docker/no-driver/Dockerfile
+++ b/docker/no-driver/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get -y update && apt-get -y install gridsite-clients curl
 WORKDIR /
 
 RUN curl -L -o falco.tar.gz \
-    https://download.falco.org/packages/${VERSION_BUCKET}/x86_64/falco-$(urlencode ${FALCO_VERSION})-x86_64.tar.gz && \
+    https://download.falco.org/packages/${VERSION_BUCKET}/$(uname -m)/falco-$(urlencode ${FALCO_VERSION})-$(uname -m).tar.gz && \
     tar -xvf falco.tar.gz && \
     rm -f falco.tar.gz && \
-    mv falco-${FALCO_VERSION}-x86_64 falco && \
+    mv falco-${FALCO_VERSION}-$(uname -m) falco && \
     rm -rf /falco/usr/src/falco-* /falco/usr/bin/falco-driver-loader
 
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /falco/etc/falco/falco.yaml > /falco/etc/falco/falco.yaml.new \

--- a/docker/tester/Dockerfile
+++ b/docker/tester/Dockerfile
@@ -4,17 +4,24 @@ LABEL name="falcosecurity/falco-tester"
 LABEL usage="docker run -v /boot:/boot:ro -v /var/run/docker.sock:/var/run/docker.sock -v $PWD/..:/source -v $PWD/build:/build --name <name> falcosecurity/falco-tester test"
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
+ARG TARGETARCH
+
 ENV FALCO_VERSION=
 ENV BUILD_TYPE=release
 
-ADD https://github.com/fullstorydev/grpcurl/releases/download/v1.6.0/grpcurl_1.6.0_linux_x86_64.tar.gz /
+RUN if [ "$TARGETARCH" = "amd64" ] ; then curl -L -o grpcurl.tar.gz \
+    https://github.com/fullstorydev/grpcurl/releases/download/v1.8.6/grpcurl_1.8.6_linux_x86_64.tar.gz; \
+    else curl -L -o grpcurl.tar.gz \
+    https://github.com/fullstorydev/grpcurl/releases/download/v1.8.6/grpcurl_1.8.6_linux_arm64.tar.gz; \
+    fi;
+
 RUN dnf install -y python-pip python docker findutils jq unzip && dnf clean all
 ENV PATH="/root/.local/bin/:${PATH}"
 RUN pip install --user avocado-framework==69.0
 RUN pip install --user avocado-framework-plugin-varianter-yaml-to-mux==69.0
 RUN pip install --user watchdog==0.10.2
 RUN pip install --user pathtools==0.1.2
-RUN tar -C /usr/bin -xvf grpcurl_1.6.0_linux_x86_64.tar.gz
+RUN tar -C /usr/bin -xvf grpcurl.tar.gz
 
 COPY ./root /
 

--- a/docker/tester/root/runners/deb.Dockerfile
+++ b/docker/tester/root/runners/deb.Dockerfile
@@ -4,12 +4,13 @@ LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 ARG FALCO_VERSION=
 RUN test -n FALCO_VERSION
 ENV FALCO_VERSION ${FALCO_VERSION}
+ENV ARCH=$(uname -m)
 
 RUN apt update -y
 RUN apt install dkms -y
 
-ADD falco-${FALCO_VERSION}-x86_64.deb /
-RUN dpkg -i /falco-${FALCO_VERSION}-x86_64.deb
+ADD falco-${FALCO_VERSION}-*.deb /
+RUN dpkg -i /falco-${FALCO_VERSION}-$(uname -m).deb
 
 # Change the falco config within the container to enable ISO 8601 output.
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/falco/falco.yaml > /etc/falco/falco.yaml.new \

--- a/docker/tester/root/runners/rpm.Dockerfile
+++ b/docker/tester/root/runners/rpm.Dockerfile
@@ -9,8 +9,8 @@ ENV FALCO_VERSION ${FALCO_VERSION}
 RUN yum update -y
 RUN yum install epel-release -y
 
-ADD falco-${FALCO_VERSION}-x86_64.rpm /
-RUN yum install -y /falco-${FALCO_VERSION}-x86_64.rpm
+ADD falco-${FALCO_VERSION}-*.rpm /
+RUN yum install -y /falco-${FALCO_VERSION}-$(uname -m).rpm
 
 # Change the falco config within the container to enable ISO 8601 output.
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/falco/falco.yaml > /etc/falco/falco.yaml.new \

--- a/docker/tester/root/runners/tar.gz.Dockerfile
+++ b/docker/tester/root/runners/tar.gz.Dockerfile
@@ -8,8 +8,8 @@ ENV FALCO_VERSION ${FALCO_VERSION}
 RUN apt update -y
 RUN apt install dkms curl -y
 
-ADD falco-${FALCO_VERSION}-x86_64.tar.gz /
-RUN cp -R /falco-${FALCO_VERSION}-x86_64/* /
+ADD falco-${FALCO_VERSION}-*.tar.gz /
+RUN cp -R /falco-${FALCO_VERSION}-$(uname -m)/* /
 
 # Change the falco config within the container to enable ISO 8601 output.
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/falco/falco.yaml > /etc/falco/falco.yaml.new \

--- a/docker/tester/root/usr/bin/entrypoint
+++ b/docker/tester/root/usr/bin/entrypoint
@@ -25,7 +25,7 @@ build_image() {
     BUILD_TYPE=$2
     FALCO_VERSION=$3
     PACKAGE_TYPE=$4
-    PACKAGE="$BUILD_DIR/$BUILD_TYPE/falco-$FALCO_VERSION-x86_64.${PACKAGE_TYPE}"
+    PACKAGE="$BUILD_DIR/$BUILD_TYPE/falco-$FALCO_VERSION-$(uname -m).${PACKAGE_TYPE}"
     if [ ! -f "$PACKAGE" ]; then
         echo "Package not found: ${PACKAGE}." >&2
         exit 1

--- a/docker/ubi/Dockerfile
+++ b/docker/ubi/Dockerfile
@@ -35,8 +35,8 @@ RUN  dnf -y update && \
 RUN mkdir /build && cd /build/ && curl --remote-name-all -L https://github.com/dell/dkms/archive/refs/tags/v3.0.3.tar.gz && \
      tar xvf v3.0.3.tar.gz && cd dkms-3.0.3 && make install-redhat && rm -rf /build
 
-RUN mkdir /deploy && cd /deploy/ && curl --remote-name-all -L https://download.falco.org/packages/bin/x86_64/falco-${FALCO_VERSION}-x86_64.tar.gz && \
-     cd / && tar --strip-components=1 -xvf /deploy/falco-${FALCO_VERSION}-x86_64.tar.gz && \
+RUN mkdir /deploy && cd /deploy/ && curl --remote-name-all -L https://download.falco.org/packages/bin/$(uname -m)/falco-${FALCO_VERSION}-$(uname -m).tar.gz && \
+     cd / && tar --strip-components=1 -xvf /deploy/falco-${FALCO_VERSION}-$(uname -m).tar.gz && \
      rm -rf /deploy
 
 COPY ./docker-entrypoint.sh /

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -201,7 +201,12 @@ load_kernel_module_download() {
 	local FALCO_KERNEL_MODULE_FILENAME="${DRIVER_NAME}_${TARGET_ID}_${KERNEL_RELEASE}_${KERNEL_VERSION}.ko"
 
 	local URL
-	URL=$(echo "${DRIVERS_REPO}/${DRIVER_VERSION}/${FALCO_KERNEL_MODULE_FILENAME}" | sed s/+/%2B/g)
+	if [ "${ARCH}" == "x86_64" ]; then
+		# x86_64 still uses root
+		URL=$(echo "${DRIVERS_REPO}/${DRIVER_VERSION}/${FALCO_KERNEL_MODULE_FILENAME}" | sed s/+/%2B/g)
+	else
+		URL=$(echo "${DRIVERS_REPO}/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" | sed s/+/%2B/g)
+	fi
 
 	echo "* Trying to download a prebuilt ${DRIVER_NAME} module from ${URL}"
 	if curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${URL}"; then

--- a/scripts/publish-deb
+++ b/scripts/publish-deb
@@ -2,7 +2,7 @@
 set -e
 
 usage() {
-    echo "usage: $0 -f <package.deb> -r <deb|deb-dev>"
+    echo "usage: $0 -f <package_x86_64.deb> -f <package_aarch64.deb> -r <deb|deb-dev>"
     exit 1
 }
 
@@ -12,6 +12,13 @@ check_program() {
       echo "$1 is required and could not be found"
       exit
   fi
+}
+
+# Used to get comma separated list of architectures
+join_arr() {
+  local IFS="$1"
+  shift
+  echo "$*"
 }
 
 # Add a package to the local DEB repository
@@ -25,6 +32,11 @@ add_deb() {
     rm -f $(basename -- $3).asc
     gpg --detach-sign --digest-algo SHA256 --armor $(basename -- $3)
     popd > /dev/null
+
+    # Get package architecture from dpkg
+    local arch=$(dpkg --info $3 |  awk '/Architecture/ {printf "%s", $2}')
+    # Store architecture in array
+    architectures+=("${arch}")
 }
 
 # Update the local DEB repository
@@ -32,26 +44,20 @@ add_deb() {
 # $1: path of the repository
 # $2: suite (eg. "stable")
 update_repo() {
-    # fixme(leogr): we cannot use apt-ftparchive --arch packages ...
-    # since our .deb files ends with "_x86_64" instead of "amd64".
-    # See https://manpages.debian.org/jessie/apt-utils/apt-ftparchive.1.en.html
-    #
-    # As a workaround, we temporarily stick here with "amd64" 
-    # (the only supported arch at the moment)
-    local arch=amd64
-
     local component=main
     local debs_dir=$2
     local release_dir=dists/$2
-    local packages_dir=${release_dir}/${component}/binary-${arch}
 
     pushd $1 > /dev/null
 
     # packages metadata
-    apt-ftparchive packages ${debs_dir} > ${packages_dir}/Packages
-    gzip -c ${packages_dir}/Packages > ${packages_dir}/Packages.gz
-    bzip2 -z -c ${packages_dir}/Packages > ${packages_dir}/Packages.bz2
-    
+    for arch in "${architectures[@]}"; do
+      local packages_dir=${release_dir}/${component}/binary-${arch}
+      apt-ftparchive packages --arch=${arch} ${debs_dir} > ${packages_dir}/Packages
+      gzip -c ${packages_dir}/Packages > ${packages_dir}/Packages.gz
+      bzip2 -z -c ${packages_dir}/Packages > ${packages_dir}/Packages.bz2
+    done
+
     # release metadata
     apt-ftparchive release \
       -o APT::FTPArchive::Release::Origin=Falco \
@@ -59,7 +65,7 @@ update_repo() {
       -o APT::FTPArchive::Release::Suite=$2 \
       -o APT::FTPArchive::Release::Codename=$2 \
       -o APT::FTPArchive::Release::Components=${component} \
-      -o APT::FTPArchive::Release::Architectures=${arch} \
+      -o APT::FTPArchive::Release::Architectures="$(join_arr , "${architectures[@]}")" \
       ${release_dir} > ${release_dir}/Release
 
     # release signature
@@ -74,7 +80,7 @@ update_repo() {
 while getopts ":f::r:" opt; do
     case "${opt}" in
         f )
-          file=${OPTARG}
+          files+=("${OPTARG}")
           ;;
         r )
           repo="${OPTARG}"
@@ -93,7 +99,7 @@ done
 shift $((OPTIND-1))
 
 # check options
-if [ -z "${file}" ] || [ -z "${repo}" ]; then
+if [ ${#files[@]} -eq 0 ] || [ -z "${repo}" ]; then
     usage
 fi
 
@@ -103,6 +109,7 @@ check_program gzip
 check_program bzip2
 check_program gpg
 check_program aws
+check_program dpkg
 
 # settings
 debSuite=stable
@@ -116,17 +123,23 @@ mkdir -p ${tmp_repo_path}
 aws s3 cp ${s3_bucket_repo} ${tmp_repo_path} --recursive
 
 # update the repo
-echo "Adding ${file}..."
-add_deb ${tmp_repo_path} ${debSuite} ${file}
+for file in "${files[@]}"; do
+  echo "Adding ${file}..."
+  add_deb ${tmp_repo_path} ${debSuite} ${file}
+done
 update_repo ${tmp_repo_path} ${debSuite}
 
 # publish
-package=$(basename -- ${file})
-echo "Publishing ${package} to ${s3_bucket_repo}..."
-aws s3 cp ${tmp_repo_path}/${debSuite}/${package} ${s3_bucket_repo}/${debSuite}/${package} --acl public-read
-aws s3 cp ${tmp_repo_path}/${debSuite}/${package}.asc ${s3_bucket_repo}/${debSuite}/${package}.asc --acl public-read
-aws s3 sync ${tmp_repo_path}/dists ${s3_bucket_repo}/dists --delete --acl public-read
+for file in "${files[@]}"; do
+  package=$(basename -- ${file})
+  echo "Publishing ${package} to ${s3_bucket_repo}..."
+  aws s3 cp ${tmp_repo_path}/${debSuite}/${package} ${s3_bucket_repo}/${debSuite}/${package} --acl public-read
+  aws s3 cp ${tmp_repo_path}/${debSuite}/${package}.asc ${s3_bucket_repo}/${debSuite}/${package}.asc --acl public-read
 
-aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}
-aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}.asc
+  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}
+  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}.asc
+done
+
+# sync dists
+aws s3 sync ${tmp_repo_path}/dists ${s3_bucket_repo}/dists --delete --acl public-read
 aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/dists/*

--- a/scripts/publish-rpm
+++ b/scripts/publish-rpm
@@ -2,7 +2,7 @@
 set -e
 
 usage() {
-    echo "usage: $0 -f <package.rpm> -r <rpm|rpm-dev>"
+    echo "usage: $0 -f <package_x86_64.rpm> -f <package_aarch64.rpm> -r <rpm|rpm-dev>"
     exit 1
 }
 
@@ -42,7 +42,7 @@ update_repo() {
 while getopts ":f::r:" opt; do
     case "${opt}" in
         f )
-          file=${OPTARG}
+          files+=("${OPTARG}")
           ;;
         r )
           repo="${OPTARG}"
@@ -60,7 +60,7 @@ while getopts ":f::r:" opt; do
 done
 shift $((OPTIND-1))
 
-if [ -z "${file}" ] || [ -z "${repo}" ]; then
+if [ ${#files[@]} -eq 0 ] || [ -z "${repo}" ]; then
     usage
 fi
 
@@ -80,17 +80,23 @@ mkdir -p ${tmp_repo_path}
 aws s3 cp ${s3_bucket_repo} ${tmp_repo_path} --recursive
 
 # update the repo
-echo "Adding ${file}..."
-add_rpm ${tmp_repo_path} ${file}
+for file in "${files[@]}"; do
+  echo "Adding ${file}..."
+  add_rpm ${tmp_repo_path} ${file}
+done
 update_repo ${tmp_repo_path}
 
 # publish
-package=$(basename -- ${file})
-echo "Publishing ${package} to ${s3_bucket_repo}..."
-aws s3 cp ${tmp_repo_path}/${package} ${s3_bucket_repo}/${package} --acl public-read
-aws s3 cp ${tmp_repo_path}/${package}.asc ${s3_bucket_repo}/${package}.asc --acl public-read
-aws s3 sync ${tmp_repo_path}/repodata ${s3_bucket_repo}/repodata --delete --acl public-read
+for file in "${files[@]}"; do
+  package=$(basename -- ${file})
+  echo "Publishing ${package} to ${s3_bucket_repo}..."
+  aws s3 cp ${tmp_repo_path}/${package} ${s3_bucket_repo}/${package} --acl public-read
+  aws s3 cp ${tmp_repo_path}/${package}.asc ${s3_bucket_repo}/${package}.asc --acl public-read
 
-aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}
-aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}.asc
+  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}
+  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}.asc
+done
+
+# sync repodata
+aws s3 sync ${tmp_repo_path}/repodata ${s3_bucket_repo}/repodata --delete --acl public-read
 aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/repodata/*


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

New dockerfiles are multiplatform ready: they can be pushed with `docker buildx` for various architectures.
Moreover, updated falco-driver-loader to support multiple architectures.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1813
Fixes #1589

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
