### PR TITLE
new(userspace/falco): added an option to listen to changes on the config file and rules files, and trigger a Falco reload

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 The Falco Authors.
+# Copyright (C) 2022 The Falco Authors.
 #
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,6 +64,11 @@ plugins:
 # and then change this to:
 # load_plugins: [cloudtrail, json]
 load_plugins: []
+
+# Watch config file and rules files for modification.
+# When a file is modified, Falco will propagate new config,
+# by reloading itself.
+watch_config_files: true
 
 # If true, the times displayed in log messages and output messages
 # will be in ISO 8601. By default, times are displayed in the local

--- a/userspace/falco/app_actions/create_signal_handlers.cpp
+++ b/userspace/falco/app_actions/create_signal_handlers.cpp
@@ -91,7 +91,7 @@ application::run_result application::create_signal_handlers()
 application::run_result application::attach_inotify_signals()
 {
 	run_result ret;
-        if (m_options.monitor_files)
+        if (m_state->config->m_watch_config_files)
 	{
 		ret.proceed = false;
 		ret.success = false;

--- a/userspace/falco/app_actions/create_signal_handlers.cpp
+++ b/userspace/falco/app_actions/create_signal_handlers.cpp
@@ -18,6 +18,8 @@ limitations under the License.
 
 #include <string.h>
 #include <signal.h>
+#include <sys/inotify.h>
+#include <fcntl.h>
 
 #include "application.h"
 
@@ -30,6 +32,7 @@ using namespace falco::app;
 
 static application dummy;
 static std::reference_wrapper<application> s_app = dummy;
+static int inot_fd;
 
 static void signal_callback(int signal)
 {
@@ -85,9 +88,86 @@ application::run_result application::create_signal_handlers()
 	return ret;
 }
 
+application::run_result application::attach_inotify_signals()
+{
+	run_result ret;
+        if (m_options.monitor_files)
+	{
+		inot_fd = inotify_init();
+		if (inot_fd == -1)
+		{
+			ret.success = false;
+			ret.errstr = std::string("Could not create inotify handler.");
+			ret.proceed = false;
+			return ret;
+		}
+
+		struct sigaction sa;
+		sigemptyset(&sa.sa_mask);
+		sa.sa_flags = SA_RESTART;
+		sa.sa_handler = restart_falco;
+		if (sigaction(SIGIO, &sa, NULL) == -1)
+		{
+			ret.success = false;
+			ret.errstr = std::string("Failed to link SIGIO to inotify handler.");
+			ret.proceed = false;
+			return ret;
+		}
+
+		/* Set owner process that is to receive "I/O possible" signal */
+		if (fcntl(inot_fd, F_SETOWN, getpid()) == -1)
+		{
+			ret.success = false;
+			ret.errstr = std::string("Failed to setting owner on inotify handler.");
+			ret.proceed = false;
+			return ret;
+		}
+
+		/*
+		 * Enable "I/O possible" signaling and make I/O nonblocking
+		 *  for file descriptor
+		 */
+		int flags = fcntl(inot_fd, F_GETFL);
+		if (fcntl(inot_fd, F_SETFL, flags | O_ASYNC | O_NONBLOCK) == -1)
+		{
+			ret.success = false;
+			ret.errstr = std::string("Failed to setting flags on inotify handler.");
+			ret.proceed = false;
+			return ret;
+		}
+
+		/* Add watchers */
+		int wd = inotify_add_watch(inot_fd, m_options.conf_filename.c_str(), IN_CLOSE_WRITE);
+		if (wd == -1)
+		{
+			ret.success = false;
+			ret.errstr = std::string("Failed to watch conf file.");
+			ret.proceed = false;
+			return ret;
+		}
+		falco_logger::log(LOG_DEBUG, "Watching " + m_options.conf_filename +"\n");
+
+		for (const auto &rule : m_state->config->m_rules_filenames) {
+			wd = inotify_add_watch(inot_fd, rule.c_str(), IN_CLOSE_WRITE);
+			if (wd == -1)
+			{
+				ret.success = false;
+				ret.errstr = std::string("Failed to watch rule file: ") + rule;
+				ret.proceed = false;
+				return ret;
+			}
+			falco_logger::log(LOG_DEBUG, "Watching " + rule +"\n");
+		}
+	}
+
+	return ret;
+}
+
 bool application::unregister_signal_handlers(std::string &errstr)
 {
 	run_result ret;
+
+	close(inot_fd);
 
 	if(! create_handler(SIGINT, SIG_DFL, ret) ||
 	   ! create_handler(SIGTERM, SIG_DFL, ret) ||

--- a/userspace/falco/app_actions/load_config.cpp
+++ b/userspace/falco/app_actions/load_config.cpp
@@ -22,7 +22,7 @@ application::run_result application::load_config()
 {
 	run_result ret;
 
-	if (m_options.conf_filename.size())
+	if (!m_options.conf_filename.empty())
 	{
 		m_state->config->init(m_options.conf_filename, m_options.cmdline_config_options);
 		falco_logger::set_time_format_iso_8601(m_state->config->m_time_format_iso_8601);

--- a/userspace/falco/app_actions/load_rules_files.cpp
+++ b/userspace/falco/app_actions/load_rules_files.cpp
@@ -86,12 +86,17 @@ application::run_result application::load_rules_files()
 	}
 
 	falco_logger::log(LOG_DEBUG, "Configured rules filenames:\n");
-	for (const auto& filename : m_state->config->m_rules_filenames)
+	for (const auto& path : m_state->config->m_rules_filenames)
 	{
-		falco_logger::log(LOG_DEBUG, string("   ") + filename + "\n");
+		falco_logger::log(LOG_DEBUG, string("   ") + path + "\n");
 	}
 
-	for (const auto& filename : m_state->config->m_rules_filenames)
+	for (const auto &path : m_state->config->m_rules_filenames)
+	{
+		falco_configuration::read_rules_file_directory(path, m_state->config->m_loaded_rules_filenames, m_state->config->m_loaded_rules_folders);
+	}
+
+	for (const auto& filename : m_state->config->m_loaded_rules_filenames)
 	{
 		falco_logger::log(LOG_INFO, "Loading rules from file " + filename + ":\n");
 		uint64_t required_engine_version;

--- a/userspace/falco/app_actions/load_rules_files.cpp
+++ b/userspace/falco/app_actions/load_rules_files.cpp
@@ -86,12 +86,12 @@ application::run_result application::load_rules_files()
 	}
 
 	falco_logger::log(LOG_DEBUG, "Configured rules filenames:\n");
-	for (auto filename : m_state->config->m_rules_filenames)
+	for (const auto& filename : m_state->config->m_rules_filenames)
 	{
 		falco_logger::log(LOG_DEBUG, string("   ") + filename + "\n");
 	}
 
-	for (auto filename : m_state->config->m_rules_filenames)
+	for (const auto& filename : m_state->config->m_rules_filenames)
 	{
 		falco_logger::log(LOG_INFO, "Loading rules from file " + filename + ":\n");
 		uint64_t required_engine_version;
@@ -125,13 +125,13 @@ application::run_result application::load_rules_files()
 	// Free-up memory for the rule loader, which is not used from now on
 	m_state->engine->clear_loader();
 
-	for (auto substring : m_options.disabled_rule_substrings)
+	for (const auto& substring : m_options.disabled_rule_substrings)
 	{
 		falco_logger::log(LOG_INFO, "Disabling rules matching substring: " + substring + "\n");
 		m_state->engine->enable_rule(substring, false);
 	}
 
-	if(m_options.disabled_rule_tags.size() > 0)
+	if(!m_options.disabled_rule_tags.empty())
 	{
 		for(auto &tag : m_options.disabled_rule_tags)
 		{
@@ -140,7 +140,7 @@ application::run_result application::load_rules_files()
 		m_state->engine->enable_rule_by_tag(m_options.disabled_rule_tags, false);
 	}
 
-	if(m_options.enabled_rule_tags.size() > 0)
+	if(!m_options.enabled_rule_tags.empty())
 	{
 		// Since we only want to enable specific
 		// rules, first disable all rules.

--- a/userspace/falco/app_actions/load_rules_files.cpp
+++ b/userspace/falco/app_actions/load_rules_files.cpp
@@ -72,12 +72,12 @@ application::run_result application::load_rules_files()
 
 	string all_rules;
 
-	if (m_options.rules_filenames.size())
+	if (!m_options.rules_filenames.empty())
 	{
 		m_state->config->m_rules_filenames = m_options.rules_filenames;
 	}
 
-	if(m_state->config->m_rules_filenames.size() == 0)
+	if(m_state->config->m_rules_filenames.empty())
 	{
 		ret.success = false;
 		ret.errstr = "You must specify at least one rules file/directory via -r or a rules_file entry in falco.yaml";

--- a/userspace/falco/app_actions/print_support.cpp
+++ b/userspace/falco/app_actions/print_support.cpp
@@ -58,7 +58,7 @@ application::run_result application::print_support()
 		support["engine_info"]["engine_version"] = FALCO_ENGINE_VERSION;
 		support["config"] = read_file(m_options.conf_filename);
 		support["rules_files"] = nlohmann::json::array();
-		for(auto filename : m_state->config->m_rules_filenames)
+		for(auto filename : m_state->config->m_loaded_rules_filenames)
 		{
 			nlohmann::json finfo;
 			finfo["name"] = filename;

--- a/userspace/falco/app_cmdline_options.cpp
+++ b/userspace/falco/app_cmdline_options.cpp
@@ -95,12 +95,11 @@ bool cmdline_options::parse(int argc, char **argv, std::string &errstr)
 		event_buffer_format = sinsp_evt::PF_BASE64;
 	}
 
-	// Expand any paths provided via -r and fill in rules_filenames
 	if(m_cmdline_parsed.count("r") > 0)
 	{
 		for(auto &path : m_cmdline_parsed["r"].as<std::vector<std::string>>())
 		{
-			falco_configuration::read_rules_file_directory(path, rules_filenames);
+			rules_filenames.push_back(path);
 		}
 	}
 

--- a/userspace/falco/app_cmdline_options.cpp
+++ b/userspace/falco/app_cmdline_options.cpp
@@ -181,7 +181,6 @@ void cmdline_options::define()
 #endif
 		("M",                             "Stop collecting after <num_seconds> reached.", cxxopts::value(duration_to_tot)->default_value("0"), "<num_seconds>")
 		("markdown",                      "When used with --list/--list-syscall-events, print the content in Markdown format", cxxopts::value<bool>(markdown))
-		("monitor_files",                 "Monitor rules and config files to reload Falco on change.", cxxopts::value<bool>(monitor_files))
 		("N",                             "When used with --list, only print field names.", cxxopts::value(names_only)->default_value("false"))
 		("o,option",                      "Set the value of option <opt> to <val>. Overrides values in configuration file. <opt> can be identified using its location in configuration file using dot notation. Elements which are entries of lists can be accessed via square brackets [].\n    E.g. base.id = val\n         base.subvalue.subvalue2 = val\n         base.list[1]=val", cxxopts::value(cmdline_config_options), "<opt>=<val>")
 		("p,print",                       "Add additional information to each falco notification's output.\nWith -pc or -pcontainer will use a container-friendly format.\nWith -pk or -pkubernetes will use a kubernetes-friendly format.\nWith -pm or -pmesos will use a mesos-friendly format.\nAdditionally, specifying -pc/-pk/-pm will change the interpretation of %container.info in rule output fields.", cxxopts::value(print_additional), "<output_format>")

--- a/userspace/falco/app_cmdline_options.cpp
+++ b/userspace/falco/app_cmdline_options.cpp
@@ -181,6 +181,7 @@ void cmdline_options::define()
 #endif
 		("M",                             "Stop collecting after <num_seconds> reached.", cxxopts::value(duration_to_tot)->default_value("0"), "<num_seconds>")
 		("markdown",                      "When used with --list/--list-syscall-events, print the content in Markdown format", cxxopts::value<bool>(markdown))
+		("monitor_files",                 "Monitor rules and config files to reload Falco on change.", cxxopts::value<bool>(monitor_files))
 		("N",                             "When used with --list, only print field names.", cxxopts::value(names_only)->default_value("false"))
 		("o,option",                      "Set the value of option <opt> to <val>. Overrides values in configuration file. <opt> can be identified using its location in configuration file using dot notation. Elements which are entries of lists can be accessed via square brackets [].\n    E.g. base.id = val\n         base.subvalue.subvalue2 = val\n         base.list[1]=val", cxxopts::value(cmdline_config_options), "<opt>=<val>")
 		("p,print",                       "Add additional information to each falco notification's output.\nWith -pc or -pcontainer will use a container-friendly format.\nWith -pk or -pkubernetes will use a kubernetes-friendly format.\nWith -pm or -pmesos will use a mesos-friendly format.\nAdditionally, specifying -pc/-pk/-pm will change the interpretation of %container.info in rule output fields.", cxxopts::value(print_additional), "<output_format>")

--- a/userspace/falco/app_cmdline_options.h
+++ b/userspace/falco/app_cmdline_options.h
@@ -60,7 +60,7 @@ public:
 	std::vector<std::string> cmdline_config_options;
 	std::string print_additional;
 	std::string pidfilename;
-	// Rules list as passed by the user, via cmdline option '-c'
+	// Rules list as passed by the user, via cmdline option '-r'
 	std::list<std::string> rules_filenames;
 	std::string stats_filename;
 	uint64_t stats_interval;

--- a/userspace/falco/app_cmdline_options.h
+++ b/userspace/falco/app_cmdline_options.h
@@ -60,6 +60,7 @@ public:
 	std::vector<std::string> cmdline_config_options;
 	std::string print_additional;
 	std::string pidfilename;
+	// Rules list as passed by the user, via cmdline option '-c'
 	std::list<std::string> rules_filenames;
 	std::string stats_filename;
 	uint64_t stats_interval;

--- a/userspace/falco/app_cmdline_options.h
+++ b/userspace/falco/app_cmdline_options.h
@@ -35,6 +35,7 @@ public:
 	// Each of these maps directly to a command line option.
 	bool help;
 	std::string conf_filename;
+	bool monitor_files;
 	bool all_events;
 	sinsp_evt::param_fmt event_buffer_format;
 	std::vector<std::string> cri_socket_paths;

--- a/userspace/falco/app_cmdline_options.h
+++ b/userspace/falco/app_cmdline_options.h
@@ -35,7 +35,6 @@ public:
 	// Each of these maps directly to a command line option.
 	bool help;
 	std::string conf_filename;
-	bool monitor_files;
 	bool all_events;
 	sinsp_evt::param_fmt event_buffer_format;
 	std::vector<std::string> cri_socket_paths;

--- a/userspace/falco/application.cpp
+++ b/userspace/falco/application.cpp
@@ -138,6 +138,7 @@ bool application::run(std::string &errstr, bool &restart)
 		std::bind(&application::print_ignored_events, this),
 		std::bind(&application::print_support, this),
 		std::bind(&application::validate_rules_files, this),
+		std::bind(&application::attach_inotify_signals, this),
 		std::bind(&application::daemonize, this),
 		std::bind(&application::init_outputs, this),
 		std::bind(&application::open_inspector, this),

--- a/userspace/falco/application.h
+++ b/userspace/falco/application.h
@@ -125,6 +125,7 @@ private:
 	// These methods comprise the code the application "runs". The
 	// order in which the methods run is in application.cpp.
 	run_result create_signal_handlers();
+	run_result attach_inotify_signals();
  	run_result daemonize();
  	run_result init_falco_engine();
  	run_result init_inspector();

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -301,6 +301,8 @@ void falco_configuration::init(string conf_filename, const vector<string> &cmdli
 			m_plugins.push_back(p);
 		}
 	}
+
+	m_watch_config_files = m_config->get_scalar<bool>("watch_config_files", true);
 }
 
 void falco_configuration::read_rules_file_directory(const string &path, list<string> &rules_filenames)

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -76,7 +76,7 @@ void falco_configuration::init(string conf_filename, const vector<string> &cmdli
 		struct stat buffer;
 		if(stat(file.c_str(), &buffer) == 0)
 		{
-			read_rules_file_directory(file, m_rules_filenames);
+			m_rules_filenames.push_back(file);
 		}
 	}
 
@@ -305,7 +305,7 @@ void falco_configuration::init(string conf_filename, const vector<string> &cmdli
 	m_watch_config_files = m_config->get_scalar<bool>("watch_config_files", true);
 }
 
-void falco_configuration::read_rules_file_directory(const string &path, list<string> &rules_filenames)
+void falco_configuration::read_rules_file_directory(const string &path, list<string> &rules_filenames, list<string> &rules_folders)
 {
 	struct stat st;
 
@@ -319,6 +319,8 @@ void falco_configuration::read_rules_file_directory(const string &path, list<str
 
 	if(st.st_mode & S_IFDIR)
 	{
+		rules_folders.push_back(path);
+
 		// It's a directory. Read the contents, sort
 		// alphabetically, and add every path to
 		// rules_filenames

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -232,6 +232,7 @@ public:
 
 	falco_common::priority_type m_min_priority;
 
+	bool m_watch_config_files;
 	bool m_buffered_outputs;
 	bool m_time_format_iso_8601;
 	uint32_t m_output_timeout;

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -219,9 +219,14 @@ public:
 	void init(std::string conf_filename, const std::vector<std::string>& cmdline_options);
 	void init(const std::vector<std::string>& cmdline_options);
 
-	static void read_rules_file_directory(const string& path, list<string>& rules_filenames);
+	static void read_rules_file_directory(const string& path, list<string>& rules_filenames, list<string> &rules_folders);
 
+	// Rules list as passed by the user
 	std::list<std::string> m_rules_filenames;
+	// Actually loaded rules, with folders inspected
+	std::list<std::string> m_loaded_rules_filenames;
+	// List of loaded rule folders
+	std::list<std::string> m_loaded_rules_folders;
 	bool m_json_output;
 	bool m_json_include_output_property;
 	bool m_json_include_tags_property;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds a new config option `watch_config_files`, to allow it to trigger a Falco restart whenever a change is detected in the rules files or conf file.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new: added new `watch_config_files` config option, to trigger a Falco restart whenever a change is detected in the rules or config files
```
