### PR TITLE
known_shell_spawn_cmdlines - lighttpd

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2064,7 +2064,7 @@
     '"sh -c  -t -i"',
     '"sh -c openssl version"',
     '"bash -c id -Gn kafadmin"',
-    '"sh -c /bin/sh -c ''date +%%s''"'
+    '"sh -c /bin/sh -c ''date +%%s''"',
     '"sh -c /usr/share/lighttpd/create-mime.conf.pl"'
     ]
 

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1917,7 +1917,7 @@
     or thread.cap_permitted contains CAP_BPF)
 
 - rule: Launch Excessively Capable Container
-  desc: Detect container started with a powerful set of capabilities. Exceptions are made for known trusted images. 
+  desc: Detect container started with a powerful set of capabilities. Exceptions are made for known trusted images.
   condition: >
     container_started and container
     and excessively_capable_container
@@ -2065,6 +2065,7 @@
     '"sh -c openssl version"',
     '"bash -c id -Gn kafadmin"',
     '"sh -c /bin/sh -c ''date +%%s''"'
+    '"sh -c /usr/share/lighttpd/create-mime.conf.pl"'
     ]
 
 # This list allows for easy additions to the set of commands allowed


### PR DESCRIPTION
Signed-off-by: Matan Monitz <mmonitz@gmail.com>


**What type of PR is this?**

/kind bug
/kind rule-update

/area rules

**What this PR does / why we need it**:
lighttpd is spawning create-mime.conf.pl on startup, causing a false positive for "Run Shell Untrusted"
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
lighttpd is spawning create-mime.conf.pl on startup, causing a false positive for "Run Shell Untrusted"
add `sh -c /usr/share/lighttpd/create-mime.conf.pl` to `known_shell_spawn_cmdlines` macro
```
