### PR TITLE
Improved detection for connections to miner pools

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1917,7 +1917,7 @@
     or thread.cap_permitted contains CAP_BPF)
 
 - rule: Launch Excessively Capable Container
-  desc: Detect container started with a powerful set of capabilities. Exceptions are made for known trusted images. 
+  desc: Detect container started with a powerful set of capabilities. Exceptions are made for known trusted images.
   condition: >
     container_started and container
     and excessively_capable_container
@@ -2838,7 +2838,7 @@
   condition: (fd.sport in (miner_ports) and fd.sip.name in (miner_domains))
 
 - macro: net_miner_pool
-  condition: (evt.type in (sendto, sendmsg) and evt.dir=< and (fd.net != "127.0.0.0/8" and not fd.snet in (rfc_1918_addresses)) and ((minerpool_http) or (minerpool_https) or (minerpool_other)))
+  condition: (evt.type in (sendto, sendmsg, connect) and evt.dir=< and (fd.net != "127.0.0.0/8" and not fd.snet in (rfc_1918_addresses)) and ((minerpool_http) or (minerpool_https) or (minerpool_other)))
 
 - macro: trusted_images_query_miner_domain_dns
   condition: (container.image.repository in (docker.io/falcosecurity/falco, falcosecurity/falco, public.ecr.aws/falcosecurity/falco))


### PR DESCRIPTION
Signed-off-by: beryxz <coppi.lore@gmail.com>

**What type of PR is this?**

/kind feature

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

/area proposals

**What this PR does / why we need it**:

While testing I noticed that the `Detect outbound connections to common miner pool ports` rule didn't work against "xmrig". The reason is that the `sendto` syscall is only used with the DNS server as shown:

```text
1336 xmrig (1980:12) > socket domain=2(AF_INET) type=526338 proto=0 
1337 xmrig (1980:12) < socket fd=14(<4>) 
1338 xmrig (1980:12) > bind fd=14(<4>) 
1339 xmrig (1980:12) < bind res=0 addr=0.0.0.0:0 
1340 xmrig (1980:12) > sendto fd=14(<4>0.0.0.0:0) size=38 tuple=0.0.0.0:38156->8.8.8.8:53 
1341 xmrig (1980:12) < sendto res=38 data=.$...........xmr-eu1.nanopool.org.....
1342 xmrig (1980:12) > sendto fd=14(<4u>10.0.2.15:38156->8.8.8.8:53) size=38 tuple=0.0.0.0:38156->8.8.4.4:53 
1343 xmrig (1980:12) < sendto res=38 data=.$...........xmr-eu1.nanopool.org.....
1344 xmrig (1980:12) > sendto fd=14(<4u>10.0.2.15:38156->8.8.4.4:53) size=38 tuple=0.0.0.0:38156->8.8.8.8:53 
1345 xmrig (1980:12) < sendto res=38 data=.............xmr-eu1.nanopool.org.....
1346 xmrig (1980:12) > sendto fd=14(<4u>10.0.2.15:38156->8.8.8.8:53) size=38 tuple=0.0.0.0:38156->8.8.4.4:53 
1347 xmrig (1980:12) < sendto res=38 data=.............xmr-eu1.nanopool.org.....
```

After retrieving the IP of the pool, `write` is used in place of `send`, I don't know exactly why, but they are equivalent after all.

```text
1364 xmrig (1978:<NA>) > socket domain=2(AF_INET) type=526337 proto=0 
1365 xmrig (1978:<NA>) < socket fd=14(<4>) 
1366 xmrig (1978:<NA>) > setsockopt 
1367 xmrig (1978:<NA>) < setsockopt res=0 fd=14(<4>) level=2(SOL_TCP) optname=0(UNKNOWN) val=.... optlen=4 
1368 xmrig (1978:<NA>) > setsockopt 
1369 xmrig (1978:<NA>) < setsockopt res=0 fd=14(<4>) level=1(SOL_SOCKET) optname=9(SO_KEEPALIVE) val=1 optlen=4 
1370 xmrig (1978:<NA>) > setsockopt 
1371 xmrig (1978:<NA>) < setsockopt res=0 fd=14(<4>) level=2(SOL_TCP) optname=0(UNKNOWN) val=<... optlen=4 
1372 xmrig (1978:<NA>) > setsockopt 
1373 xmrig (1978:<NA>) < setsockopt res=0 fd=14(<4>) level=2(SOL_TCP) optname=0(UNKNOWN) val=.... optlen=4 
1374 xmrig (1978:<NA>) > setsockopt 
1375 xmrig (1978:<NA>) < setsockopt res=0 fd=14(<4>) level=2(SOL_TCP) optname=0(UNKNOWN) val=.... optlen=4 
1376 xmrig (1978:<NA>) > connect fd=14(<4>) 
1377 xmrig (1978:<NA>) < connect res=-115(EINPROGRESS) tuple=172.17.0.2:55946->46.105.31.147:14433 
1382 xmrig (1978:<NA>) > getsockopt 
1383 xmrig (1978:<NA>) < getsockopt res=0 fd=14(<4t>172.17.0.2:55946->46.105.31.147:14433) level=1(SOL_SOCKET) optname=4(SO_ERROR) val=0 optlen=4 
1404 xmrig (1978:<NA>) > write fd=14(<4t>172.17.0.2:55946->46.105.31.147:14433) size=293 
1405 xmrig (1978:<NA>) < write res=293 data=...
1412 xmrig (1978:<NA>) > mmap addr=0 length=266240 prot=3(PROT_READ|PROT_WRITE) flags=10(MAP_PRIVATE|MAP_ANONYMOUS) fd=-1(EPERM) offset=0 
1413 xmrig (1978:<NA>) < mmap res=7F8860FBC000 vm_size=41524 vm_rss=4684 vm_swap=0 
1414 xmrig (1978:<NA>) > read fd=14(<4t>172.17.0.2:55946->46.105.31.147:14433) size=65536 
1415 xmrig (1978:<NA>) < read res=1738 data=...
```

As `getsockopt`, `read`, and `write` are not supported by Falco, the only other option seems to be the `connect` syscall. With `evt.type = connect and evt.dir = <` the rule can also detect xmrig thorugh the same `fd.sip.name` field.

```json
{
    "output": "11:51:51.410171274: Critical Outbound connection to IP/Port flagged by https://cryptoioc.ch (command=xmrig --donate-level 5 -o xmr-eu1.nanopool.org:14433 -u WALLET_ADDRESS --tls --coin monero port=14433 ip=51.15.69.136 container=xmrig-test (id=8add3bb1eab0) image=ubuntu)",
    "priority": "Critical",
    "rule": "Detect outbound connections to common miner pool ports",
    "source": "syscall",
    "tags": [ "mitre_execution", "network" ],
    "time": "2022-05-23T09:51:51.410171274Z",
    "output_fields": {
        "container.id": "8add3bb1eab0",
        "container.image.repository": "ubuntu",
        "container.name": "xmrig-test",
        "evt.time": 1653299511410171274,
        "fd.rip": "51.15.69.136",
        "fd.rport": 14433,
        "proc.cmdline": "xmrig --donate-level 5 -o xmr-eu1.nanopool.org:14433 -u WALLET_ADDRESS --tls --coin monero"
    }
}
```

**Which issue(s) this PR fixes**:

- The default `Detect outbound connections to common miner pool ports` rules doesn't detect xmrig connecting to nanopool.

**Special notes for your reviewer**:

If needed I can provide further details.

**Does this PR introduce a user-facing change?**:

```release-note
rule(macro net_miner_pool): additional syscall for detection
```
