### PR TITLE
fix(tests): make run_regression_tests.sh work locally

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -17,13 +17,7 @@ This step assumes you already built Falco.
 
 Note that the tests are intended to be run against a [release build](https://falco.org/docs/getting-started/source/#specify-the-build-type) of Falco, at the moment.
 
-Also, it assumes you prepared [falco_traces](#falco_traces) (see the section below) and you already run the following command from the build directory:
-
-```console
-make test-trace-files
-```
-
-It prepares the fixtures (`json` and `scap` files) needed by the integration tests.
+Also, it assumes you prepared [falco_traces](#falco_traces) (see the section below).
 
 **Requirements**
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -6,7 +6,7 @@ idna==2.9
 pathtools==0.1.2
 pbr==5.4.5
 PyYAML==5.4
-requests==2.23.0
+requests==2.26.0
 six==1.14.0
 stevedore==1.32.0
 urllib3==1.26.5

--- a/test/run_regression_tests.sh
+++ b/test/run_regression_tests.sh
@@ -118,7 +118,9 @@ function run_tests() {
         XUNIT_FILE_NAME="${XUNIT_DIR}/$(basename "${mult}").xml"
         CMD="avocado run --xunit ${XUNIT_FILE_NAME} --mux-yaml $mult --job-results-dir $SCRIPTDIR/job-results -- $SCRIPTDIR/falco_test.py"
         echo "Running $CMD"
+        pushd $TRACE_DIR > /dev/null
         BUILD_DIR=${OPT_BUILD_DIR} $CMD
+        popd > /dev/null
         RC=$?
         TEST_RC=$((TEST_RC+RC))
         if [ $RC -ne 0 ]; then


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area rules

/area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The [Falco manual](https://falco.org/docs/getting-started/source/#run-the-tests) and the README in the test directory tell how to run the Falco test suite locally. I think it's very valuable during development however the instructions are a little outdated I believe since:
1. running the commands as shown would make a few test fail because they cannot find trace files
2. the instructions ask the user to run a cmake target `test-trace-files` which has been removed in PR #1905

It looks like the script assumes to be launched from the trace files directory as all of their paths are relative.

In addition, I don't exactly know why, but it looks like trace files exist both in the Falco repo and in an external storage. Maybe some other contributor or maintainers have more clues about that.

The PR updates the readme file and launches the test from the trace file directory.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
