### PR TITLE
rule(Java Process JNDI Connection): detect potential log4shell exploitation

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3177,6 +3177,24 @@
   priority: CRITICAL
   tags: [container, mitre_privilege_escalation, mitre_lateral_movement]
 
+# Rule for detecting potential successful Log4Shell (CVE-2021-44228) exploitation
+- macro: java_network_write
+  condition: (evt.type = sendto and evt.dir=< and fd.type in (ipv4, ipv6) and proc.name=java)
+
+- macro: jndi_ldap_indicator
+  condition: (evt.buffer contains "2.16.840")
+
+- macro: jndi_rmi_indicator
+  condition: (evt.buffer startswith "JRMI")
+
+- rule: Java Process JNDI Connection
+  desc: Potential exploitation of the log4shell Log4j vulnerability (CVE-2021-44228)
+  condition: >
+        java_network_write and (jndi_ldap_indicator or jndi_rmi_indicator)
+  output: Java process JNDI connection (user=%user.name user_loginname=%user.loginname user_loginuid=%user.loginuid event=%evt.type connection=%fd.name server_ip=%fd.sip server_port=%fd.sport proto=%fd.l4proto process=%proc.name command=%proc.cmdline parent=%proc.pname buffer=%evt.buffer container_id=%container.id image=%container.image.repository)
+  priority: CRITICAL
+  tags: [mitre_initial_access]
+
 # Application rules have moved to application_rules.yaml. Please look
 # there if you want to enable them by adding to
 # falco_rules.local.yaml.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area rules


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This detects potential log4shell exploitation by monitoring `sendto()` syscall and the buffer data from Java processes. See [this](https://pirx.io/posts/2022-05-20-syscall-based-detection-of-log4shell-cve-2021-44228-on-linux/) blog post for more details.

**Which issue(s) this PR fixes**:

N/A

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

The rule as it is written in the PR can detect jndi for Java versions lower than 17. On 17, Java switched from using `sendto` to `write` syscalls (this is based on my own testing but happy to be corrected here).

The ideal `java_network_write` macro is actually:

```
- macro: java_network_write
  condition: (evt.type in (write, sendto) and evt.dir=< and fd.type in (ipv4, ipv6) and proc.name=java)
```

but falco needs to run with the `-A` flag.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
