### PR TITLE
fix(falco-scripts): remove driver versions with `dkms-3.0.3`

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -282,7 +282,7 @@ clean_kernel_module() {
 
 	# Remove all versions of this module from dkms.
 	echo "* 2. Check all versions of kernel module '${KMOD_NAME}' in dkms:"
-	DRIVER_VERSIONS=$(dkms status -m "${KMOD_NAME}" | tr -d "," | tr "/" " " | cut -d' ' -f2)
+	DRIVER_VERSIONS=$(dkms status -m "${KMOD_NAME}" | tr -d "," | tr -d ":" | tr "/" " " | cut -d' ' -f2)
 	if [ -z "${DRIVER_VERSIONS}" ]; then
 		echo "- OK! There are no '${KMOD_NAME}' module versions in dkms."
 	else


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>


**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

New versions of `dkms` have a new format for `dkms status -m`:

```
module/version: added
```

The other two formats that we support (as said in https://github.com/falcosecurity/falco/pull/1950) are:

```
module, version, kernel, architecture: installed
module/version, kernel, architecture: installed
```

With this PR we should support all `dkms` formats, we will see in the next future if a new format will come out... 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
