### PR TITLE
Fix falco compilation issues with new libs

### DIFF
--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -24,8 +24,8 @@ else()
   # default below In case you want to test against another falcosecurity/libs version just pass the variable - ie., `cmake
   # -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "39ae7d40496793cf3d3e7890c9bbdc202263836b")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=b9034baeff4518b044574956f5768fac080c269bacad4a1e17a7f6fdb872ce66")
+    set(FALCOSECURITY_LIBS_VERSION "075da069af359954122ed7b8a9fc98bc7bcf3116")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=4cfad3ff77afd3709cac92f244f38c998020156071138fb9edae2fb987954a84")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/userspace/engine/falco_engine_version.h
+++ b/userspace/engine/falco_engine_version.h
@@ -16,9 +16,9 @@ limitations under the License.
 
 // The version of rules/filter fields/etc supported by this Falco
 // engine.
-#define FALCO_ENGINE_VERSION (12)
+#define FALCO_ENGINE_VERSION (13)
 
 // This is the result of running "falco --list -N | sha256sum" and
 // represents the fields supported by this version of Falco. It's used
 // at build time to detect a changed set of fields.
-#define FALCO_FIELDS_CHECKSUM "a557747a209f2d16e90a3324d84d56c02cf54d000b6e3ee44598413f19885fcc"
+#define FALCO_FIELDS_CHECKSUM "94290ff98e5affc85b2287b09a3f4054918f14e90db1ac4bfd6d5ce4e910329c"

--- a/userspace/falco/app_actions/load_plugins.cpp
+++ b/userspace/falco/app_actions/load_plugins.cpp
@@ -31,11 +31,16 @@ application::run_result application::load_plugins()
 	// The only enabled event source is syscall by default
 	m_state->enabled_sources = {falco_common::syscall_source};
 
+	std::string err = "";
 	std::shared_ptr<sinsp_plugin> loaded_plugin = nullptr;
 	for(auto &p : m_state->config->m_plugins)
 	{
 		falco_logger::log(LOG_INFO, "Loading plugin (" + p.m_name + ") from file " + p.m_library_path + "\n");
-		auto plugin = m_state->inspector->register_plugin(p.m_library_path, p.m_init_config);
+		auto plugin = m_state->inspector->register_plugin(p.m_library_path);
+        if (!plugin->init(p.m_init_config, err))
+        {
+            return run_result::fatal(err);
+        }
 
 		if(plugin->caps() & CAP_SOURCING)
 		{

--- a/userspace/falco/app_actions/load_plugins.cpp
+++ b/userspace/falco/app_actions/load_plugins.cpp
@@ -37,10 +37,10 @@ application::run_result application::load_plugins()
 	{
 		falco_logger::log(LOG_INFO, "Loading plugin (" + p.m_name + ") from file " + p.m_library_path + "\n");
 		auto plugin = m_state->inspector->register_plugin(p.m_library_path);
-        if (!plugin->init(p.m_init_config, err))
-        {
-            return run_result::fatal(err);
-        }
+		if (!plugin->init(p.m_init_config, err))
+		{
+			return run_result::fatal(err);
+		}
 
 		if(plugin->caps() & CAP_SOURCING)
 		{


### PR DESCRIPTION
```
    Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>
```
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

/area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fix falco compilation issuer with the new version of the libs. The issue is related to how the plugins are loaded by falco.
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
