### PR TITLE
fix(rules): use exit event in reverse shell detection rule

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2985,7 +2985,7 @@
 
 - rule: Redirect STDOUT/STDIN to Network Connection in Container
   desc: Detect redirecting stdout/stdin to network connection in container (potential reverse shell).
-  condition: evt.type=dup and evt.dir=> and container and fd.num in (0, 1, 2) and fd.type in ("ipv4", "ipv6") and not user_known_stand_streams_redirect_activities
+  condition: evt.type in (dup, dup2, dup3) and container and evt.rawres in (0, 1, 2) and fd.type in ("ipv4", "ipv6") and not user_known_stand_streams_redirect_activities
   output: >
     Redirect stdout/stdin to network connection (user=%user.name user_loginuid=%user.loginuid %container.info process=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository fd.name=%fd.name fd.num=%fd.num fd.type=%fd.type fd.sip=%fd.sip)
   priority: WARNING

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2983,9 +2983,12 @@
 - macro: user_known_stand_streams_redirect_activities
   condition: (never_true)
 
+- macro: dup
+  condition: evt.type in (dup, dup2, dup3)
+
 - rule: Redirect STDOUT/STDIN to Network Connection in Container
   desc: Detect redirecting stdout/stdin to network connection in container (potential reverse shell).
-  condition: evt.type in (dup, dup2, dup3) and container and evt.rawres in (0, 1, 2) and fd.type in ("ipv4", "ipv6") and not user_known_stand_streams_redirect_activities
+  condition: dup and container and evt.rawres in (0, 1, 2) and fd.type in ("ipv4", "ipv6") and not user_known_stand_streams_redirect_activities
   output: >
     Redirect stdout/stdin to network connection (user=%user.name user_loginuid=%user.loginuid %container.info process=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository fd.name=%fd.name fd.num=%fd.num fd.type=%fd.type fd.sip=%fd.sip)
   priority: WARNING


### PR DESCRIPTION
```
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>
```
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

/kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR updates the reverse shell detection rule to be triggered when a `dup2` or `dup3` is called. Before the falcosecurity/libs#385 the `dup2` and `dup3` events were sent to userspace as `dup` events.

**Which issue(s) this PR fixes**:

In some cases the rule is not triggered when a reverse shell is spawned. That's because in the rule we are checking that the file descriptor passed to the dup functions is of type `socket` and its fd number is `0, 1 or 2` and the event direction is `enter`. The following code snippet is not detected as a reverse shell:
```
    connect(socket_fd, (struct sockaddr *)&sock_addr, sizeof(struct sockaddr_in));
    dup2(socket_fd, STDIN_FILENO);
    dup2(socket_fd, STDOUT_FILENO);
    dup2(socket_fd, STDERR_FILENO);
```
That's obvious since we are not passing a file descriptor to the `dup2` syscall that satisfies the conditions required by the rule.

On the other hand a command like this one: `/bin/bash -i >& /dev/tcp/127.0.0.1/9999 0>&1` (#1152 ) triggers the rule.
Digging a little bit deeper we see that the following syscalls are involved:
```
23889 socket(AF_INET, SOCK_STREAM, IPPROTO_TCP) = 3
23889 connect(3, {sa_family=AF_INET, sin_port=htons(9999), sin_addr=inet_addr("127.0.0.1")}, 16) = 0
23889 dup2(3, 1)                        = 1
23889 close(3)                          = 0
23889 dup2(1, 2)                        = 2
23889 dup2(1, 0)                        = 0
23889 fcntl(1, F_GETFD)                 = 0
23889 execve("/usr/bin/bash", ["bash", "-i"], 0x56212e810be0 /* 21 vars */) = 0
23889 brk(NULL)                         = 0x5571dcec9000
```
The first `dup2(3,1)` is not detected by the rule but the subsequent calls are. 

The right way to detect such scenarios is to check the returned file descriptor in the `exit` events. In order to avoid dealing explicitly with the event direction we use the following field `evt.rawres in (0, 1, 2)` present in the `exit` events.
 
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

As @leogr noted [here](https://github.com/falcosecurity/libs/pull/385#issuecomment-1155308507l), this PR needs to be merged after we bump Falco with a new driver version.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix(rules): use exit event in reverse shell detection rule
```
