### PR TITLE
refactor!(userspace/falco): remove output rate limiter and make output engine explicitly thread-safe

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -173,22 +173,6 @@ syscall_event_timeouts:
 
 output_timeout: 2000
 
-# A throttling mechanism implemented as a token bucket limits the
-# rate of falco notifications. This throttling is controlled by the following configuration
-# options:
-#  - rate: the number of tokens (i.e. right to send a notification)
-#    gained per second. Defaults to 1.
-#  - max_burst: the maximum number of tokens outstanding. Defaults to 1000.
-#
-# With these defaults, falco could send up to 1000 notifications after
-# an initial quiet period, and then up to 1 notification per second
-# afterward. It would gain the full burst back after 1000 seconds of
-# no activity.
-
-outputs:
-  rate: 1
-  max_burst: 1000
-
 # Where security notifications should go.
 # Multiple outputs can be enabled.
 

--- a/userspace/falco/app_actions/init_outputs.cpp
+++ b/userspace/falco/app_actions/init_outputs.cpp
@@ -40,19 +40,16 @@ application::run_result application::init_outputs()
 		hostname = c_hostname;
 	}
 
-	m_state->outputs->init(m_state->engine,
-			      m_state->config->m_json_output,
-			      m_state->config->m_json_include_output_property,
-			      m_state->config->m_json_include_tags_property,
-			      m_state->config->m_output_timeout,
-			      m_state->config->m_buffered_outputs,
-			      m_state->config->m_time_format_iso_8601,
-			      hostname);
-
-	for(auto output : m_state->config->m_outputs)
-	{
-		m_state->outputs->add_output(output);
-	}
+	m_state->outputs.reset(new falco_outputs(
+		m_state->engine,
+		m_state->config->m_outputs,
+		m_state->config->m_json_output,
+		m_state->config->m_json_include_output_property,
+		m_state->config->m_json_include_tags_property,
+		m_state->config->m_output_timeout,
+		m_state->config->m_buffered_outputs,
+		m_state->config->m_time_format_iso_8601,
+		hostname));
 
 	return run_result::ok();
 }

--- a/userspace/falco/app_actions/init_outputs.cpp
+++ b/userspace/falco/app_actions/init_outputs.cpp
@@ -45,7 +45,6 @@ application::run_result application::init_outputs()
 			      m_state->config->m_json_include_output_property,
 			      m_state->config->m_json_include_tags_property,
 			      m_state->config->m_output_timeout,
-			      m_state->config->m_notifications_rate, m_state->config->m_notifications_max_burst,
 			      m_state->config->m_buffered_outputs,
 			      m_state->config->m_time_format_iso_8601,
 			      hostname);

--- a/userspace/falco/application.cpp
+++ b/userspace/falco/application.cpp
@@ -45,9 +45,9 @@ application::state::state()
 	  enabled_sources({falco_common::syscall_source})
 {
 	config = std::make_shared<falco_configuration>();
-	outputs = std::make_shared<falco_outputs>();
 	engine = std::make_shared<falco_engine>();
 	inspector = std::make_shared<sinsp>();
+	outputs = nullptr;
 }
 
 application::state::~state()

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -185,9 +185,6 @@ void falco_configuration::init(string conf_filename, const vector<string> &cmdli
 
 	m_output_timeout = m_config->get_scalar<uint32_t>("output_timeout", 2000);
 
-	m_notifications_rate = m_config->get_scalar<uint32_t>("outputs.rate", 1);
-	m_notifications_max_burst = m_config->get_scalar<uint32_t>("outputs.max_burst", 1000);
-
 	string priority = m_config->get_scalar<string>("priority", "debug");
 	if (!falco_common::parse_priority(priority, m_min_priority))
 	{

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -232,8 +232,6 @@ public:
 	bool m_json_include_tags_property;
 	std::string m_log_level;
 	std::vector<falco::outputs::config> m_outputs;
-	uint32_t m_notifications_rate;
-	uint32_t m_notifications_max_burst;
 
 	falco_common::priority_type m_min_priority;
 

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -80,8 +80,6 @@ void falco_outputs::init(std::shared_ptr<falco_engine> engine,
 
 	m_timeout = std::chrono::milliseconds(timeout);
 
-	m_notifications_tb.init(rate, max_burst);
-
 	m_buffered = buffered;
 	m_time_format_iso_8601 = time_format_iso_8601;
 	m_hostname = hostname;
@@ -142,12 +140,6 @@ void falco_outputs::add_output(falco::outputs::config oc)
 void falco_outputs::handle_event(gen_event *evt, string &rule, string &source,
 				 falco_common::priority_type priority, string &format, std::set<std::string> &tags)
 {
-	if(!m_notifications_tb.claim())
-	{
-		falco_logger::log(LOG_DEBUG, "Skipping rate-limited notification for rule " + rule + "\n");
-		return;
-	}
-
 	falco_outputs::ctrl_msg cmsg = {};
 	cmsg.ts = evt->get_ts();
 	cmsg.priority = priority;

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -66,30 +66,20 @@ falco_outputs::falco_outputs(
 	}
 
 	m_worker_thread = std::thread(&falco_outputs::worker, this);
-
-	m_initialized = true;
 }
 
 falco_outputs::~falco_outputs()
 {
-	if(m_initialized)
+	this->stop_worker();
+	for(auto o : m_outputs)
 	{
-		this->stop_worker();
-		for(auto o : m_outputs)
-		{
-			delete o;
-		}
+		delete o;
 	}
 }
 
 // This function is called only at initialization-time by the constructor
 void falco_outputs::add_output(falco::outputs::config oc)
 {
-	if(!m_initialized)
-	{
-		throw falco_exception("cannot add output: falco_outputs not initialized yet");
-	}
-
 	falco::outputs::abstract_output *oo;
 
 	if(oc.name == "file")

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -65,8 +65,9 @@ void falco_outputs::init(std::shared_ptr<falco_engine> engine,
 			 bool json_include_output_property,
 			 bool json_include_tags_property,
 			 uint32_t timeout,
-			 uint32_t rate, uint32_t max_burst, bool buffered,
-			 bool time_format_iso_8601, std::string hostname)
+			 bool buffered,
+			 bool time_format_iso_8601,
+			 std::string hostname)
 {
 	// Cannot be initialized more than one time.
 	if(m_initialized)

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -39,12 +39,13 @@ public:
 	virtual ~falco_outputs();
 
 	void init(std::shared_ptr<falco_engine> engine,
-		  bool json_output,
-		  bool json_include_output_property,
-		  bool json_include_tags_property,
-		  uint32_t timeout,
-		  uint32_t rate, uint32_t max_burst, bool buffered,
-		  bool time_format_iso_8601, std::string hostname);
+		bool json_output,
+		bool json_include_output_property,
+		bool json_include_tags_property,
+		uint32_t timeout,
+		bool buffered,
+		bool time_format_iso_8601,
+		std::string hostname);
 
 	void add_output(falco::outputs::config oc);
 

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -84,7 +84,6 @@ public:
 
 private:
 	std::unique_ptr<falco_formats> m_formats;
-	bool m_initialized;
 
 	std::vector<falco::outputs::abstract_output *> m_outputs;
 

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -69,9 +69,6 @@ private:
 
 	std::vector<falco::outputs::abstract_output *> m_outputs;
 
-	// Rate limits notifications
-	token_bucket m_notifications_tb;
-
 	bool m_buffered;
 	bool m_json_output;
 	bool m_time_format_iso_8601;

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -27,18 +27,21 @@ limitations under the License.
 #include "formats.h"
 #include "tbb/concurrent_queue.h"
 
-//
-// This class acts as the primary interface between a program and the
-// falco output engine. The falco rules engine is implemented by a
-// separate class falco_engine.
-//
+/*!
+	\brief This class acts as the primary interface between a program and the
+	falco output engine. The falco rules engine is implemented by a
+	separate class falco_engine.
+
+	All methods in this class are thread-safe. The output framework supports
+	a multi-producer model where messages are stored in a queue and consumed
+	by each configured output asynchrounously.
+*/
 class falco_outputs
 {
 public:
-	falco_outputs();
-	virtual ~falco_outputs();
-
-	void init(std::shared_ptr<falco_engine> engine,
+	falco_outputs(
+		std::shared_ptr<falco_engine> engine,
+		const std::vector<falco::outputs::config>& outputs,
 		bool json_output,
 		bool json_include_output_property,
 		bool json_include_tags_property,
@@ -47,21 +50,36 @@ public:
 		bool time_format_iso_8601,
 		std::string hostname);
 
-	void add_output(falco::outputs::config oc);
+	virtual ~falco_outputs();
 
-	// Format then send the event to all configured outputs (`evt` is an event that has matched some rule).
+	/*!
+		\brief Format then send the event to all configured outputs (`evt`
+		is an event that has matched some rule).
+	*/
 	void handle_event(gen_event *evt, std::string &rule, std::string &source,
 			  falco_common::priority_type priority, std::string &format, std::set<std::string> &tags);
 
-	// Format then send a generic message to all outputs. Not necessarily associated with any event.
+	/*!
+		\brief Format then send a generic message to all outputs.
+		Not necessarily associated with any event.
+	*/
 	void handle_msg(uint64_t now,
 			falco_common::priority_type priority,
 			std::string &msg,
 			std::string &rule,
 			std::map<std::string, std::string> &output_fields);
 
+	/*!
+		\brief Sends a cleanup message to all outputs.
+		Each output can have an implementation-specific behavior.
+		In general, this is used to flush or clean output buffers.
+	*/
 	void cleanup_outputs();
 
+	/*!
+		\brief Sends a message to all outputs that causes them to be closed and
+		reopened. Each output can have an implementation-specific behavior.
+	*/
 	void reopen_outputs();
 
 private:
@@ -97,4 +115,5 @@ private:
 	inline void push(ctrl_msg_type cmt);
 	void worker() noexcept;
 	void stop_worker();
+	void add_output(falco::outputs::config oc);
 };


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind design

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR removes the rate limiter based on token bucket from the output engine of Falco and from the default configuration.

Since removing the rete limiting logic, the output engine became fully thread-safe. The class interface and its documentation have been update to reflect the thread-safety properties (and Doxygen-compliant).

**Which issue(s) this PR fixes**:

Fixes #1333 

**Special notes for your reviewer**:

Thread-safety guarantees is something we should aim for in some parts of the Falco codebase in order to achieve the feature proposed in https://github.com/falcosecurity/falco/issues/2074. At any level, thread-safety in the output engine is high in priority, because it would become a synchronization point almost in any event source parallelization scenario.

**Does this PR introduce a user-facing change?**:

```release-note
refactor!(userspace/falco): remove output rate limiter and make output engine explicitly thread-safe
```
