### PR TITLE
refactor(userspace/engine): increase const coherence in falco engine

### DIFF
--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -67,7 +67,7 @@ uint32_t falco_engine::engine_version()
 	return (uint32_t) FALCO_ENGINE_VERSION;
 }
 
-falco_source* falco_engine::find_source(const std::string& name)
+const falco_source* falco_engine::find_source(const std::string& name) const
 {
 	auto ret = m_sources.at(name);
 	if(!ret)
@@ -77,7 +77,7 @@ falco_source* falco_engine::find_source(const std::string& name)
 	return ret;
 }
 
-falco_source* falco_engine::find_source(std::size_t index)
+const falco_source* falco_engine::find_source(std::size_t index) const
 {
 	auto ret = m_sources.at(index);
 	if(!ret)
@@ -94,7 +94,7 @@ static std::string fieldclass_key(const gen_event_filter_factory::filter_fieldcl
 	return fld_info.name + fld_info.shortdesc;
 }
 
-void falco_engine::list_fields(std::string &source, bool verbose, bool names_only, bool markdown)
+void falco_engine::list_fields(std::string &source, bool verbose, bool names_only, bool markdown) const
 {
 	// Maps from field class name + short desc to list of event
 	// sources for which this field class can be used.
@@ -102,14 +102,14 @@ void falco_engine::list_fields(std::string &source, bool verbose, bool names_onl
 
 	// Do a first pass to group together classes that are
 	// applicable to multiple event sources.
-	for(auto &it : m_sources)
+	for(const auto &it : m_sources)
 	{
 		if(source != "" && source != it.name)
 		{
 			continue;
 		}
 
-		for(auto &fld_class : it.filter_factory->get_fields())
+		for(const auto &fld_class : it.filter_factory->get_fields())
 		{
 			fieldclass_event_sources[fieldclass_key(fld_class)].insert(it.name);
 		}
@@ -121,7 +121,7 @@ void falco_engine::list_fields(std::string &source, bool verbose, bool names_onl
 
 	// In the second pass, actually print info, skipping duplicate
 	// field classes and also printing info on supported sources.
-	for(auto &it : m_sources)
+	for(const auto &it : m_sources)
 	{
 		if(source != "" && source != it.name)
 		{
@@ -234,7 +234,7 @@ void falco_engine::enable_rule(const string &substring, bool enabled, const stri
 	uint16_t ruleset_id = find_ruleset_id(ruleset);
 	bool match_exact = false;
 
-	for(auto &it : m_sources)
+	for(const auto &it : m_sources)
 	{
 		if(enabled)
 		{
@@ -252,7 +252,7 @@ void falco_engine::enable_rule_exact(const string &rule_name, bool enabled, cons
 	uint16_t ruleset_id = find_ruleset_id(ruleset);
 	bool match_exact = true;
 
-	for(auto &it : m_sources)
+	for(const auto &it : m_sources)
 	{
 		if(enabled)
 		{
@@ -269,7 +269,7 @@ void falco_engine::enable_rule_by_tag(const set<string> &tags, bool enabled, con
 {
 	uint16_t ruleset_id = find_ruleset_id(ruleset);
 
-	for(auto &it : m_sources)
+	for(const auto &it : m_sources)
 	{
 		if(enabled)
 		{
@@ -302,7 +302,7 @@ uint64_t falco_engine::num_rules_for_ruleset(const std::string &ruleset)
 {
 	uint16_t ruleset_id = find_ruleset_id(ruleset);
 	uint64_t ret = 0;
-	for (auto &src : m_sources)
+	for (const auto &src : m_sources)
 	{
 		ret += src.ruleset->enabled_count(ruleset_id);
 	}
@@ -315,7 +315,7 @@ void falco_engine::evttypes_for_ruleset(std::string &source, std::set<uint16_t> 
 }
 
 std::shared_ptr<gen_event_formatter> falco_engine::create_formatter(const std::string &source,
-								    const std::string &output)
+								    const std::string &output) const
 {
 	return find_source(source)->formatter_factory->create_formatter(output);
 }
@@ -369,7 +369,7 @@ std::size_t falco_engine::add_source(const std::string &source,
 	return m_sources.insert(src, source);
 }
 
-void falco_engine::describe_rule(string *rule)
+void falco_engine::describe_rule(string *rule) const
 {
 	static const char* rule_fmt = "%-50s %s\n";
 	fprintf(stdout, rule_fmt, "Rule", "Description");
@@ -390,7 +390,7 @@ void falco_engine::describe_rule(string *rule)
 	}
 }
 
-void falco_engine::print_stats()
+void falco_engine::print_stats() const
 {
 	string out;
 	m_rule_stats_manager.format(m_rules, out);
@@ -398,7 +398,7 @@ void falco_engine::print_stats()
 	fprintf(stdout, "%s", out.c_str());
 }
 
-bool falco_engine::is_source_valid(const std::string &source)
+bool falco_engine::is_source_valid(const std::string &source) const
 {
 	return m_sources.at(source) != nullptr;
 }
@@ -443,7 +443,7 @@ void falco_engine::interpret_load_result(std::unique_ptr<load_result>& res,
 
 bool falco_engine::check_plugin_requirements(
 		const std::vector<plugin_version_requirement>& plugins,
-		std::string& err)
+		std::string& err) const
 {
 	for (const auto &req : m_rule_loader.required_plugin_versions())
 	{
@@ -484,9 +484,9 @@ bool falco_engine::check_plugin_requirements(
 	return true;
 }
 
-void falco_engine::complete_rule_loading()
+void falco_engine::complete_rule_loading() const
 {
-	for (auto &src : m_sources)
+	for (const auto &src : m_sources)
 	{
 		src.ruleset->on_loading_complete();
 	}
@@ -508,7 +508,7 @@ void falco_engine::set_extra(string &extra, bool replace_container_info)
 	m_replace_container_info = replace_container_info;
 }
 
-inline bool falco_engine::should_drop_evt()
+inline bool falco_engine::should_drop_evt() const
 {
 	if(m_sampling_multiplier == 0)
 	{

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -56,7 +56,7 @@ public:
 
 	// Print to stdout (using printf) a description of each field supported by this engine.
 	// If source is non-empty, only fields for the provided source are printed.
-	void list_fields(std::string &source, bool verbose, bool names_only, bool markdown);
+	void list_fields(std::string &source, bool verbose, bool names_only, bool markdown) const;
 
 	//
 	// Load rules either directly or from a filename.
@@ -98,7 +98,7 @@ public:
 	// Internally, this can be used to release unused resources before starting
 	// processing events with process_event().
 	//
-	void complete_rule_loading();
+	void complete_rule_loading() const;
 
 	// Only load rules having this priority or more severe.
 	void set_min_priority(falco_common::priority_type priority);
@@ -121,12 +121,12 @@ public:
 	// Print details on the given rule. If rule is NULL, print
 	// details on all rules.
 	//
-	void describe_rule(std::string *rule);
+	void describe_rule(std::string *rule) const;
 
 	//
 	// Print statistics on how many events matched each rule.
 	//
-	void print_stats();
+	void print_stats() const;
 
 	//
 	// Set the sampling ratio, which can affect which events are
@@ -200,7 +200,7 @@ public:
 
 	// Return whether or not there is a valid filter/formatter
 	// factory for this source.
-	bool is_source_valid(const std::string &source);
+	bool is_source_valid(const std::string &source) const;
 
 	//
 	// Given an event source and ruleset, fill in a bitset
@@ -216,7 +216,7 @@ public:
 	// event.
 	//
 	std::shared_ptr<gen_event_formatter> create_formatter(const std::string &source,
-							      const std::string &output);
+							      const std::string &output) const;
 
 	// The rule loader definition is aliased as it is exactly what we need
 	typedef rule_loader::plugin_version_info plugin_version_requirement;
@@ -230,7 +230,7 @@ public:
 	//
 	bool check_plugin_requirements(
 		const std::vector<plugin_version_requirement>& plugins,
-		std::string& err);
+		std::string& err) const;
 
 private:
 
@@ -246,15 +246,15 @@ private:
 
 	indexed_vector<falco_source> m_sources;
 
-	falco_source* find_source(std::size_t index);
-	falco_source* find_source(const std::string& name);
+	const falco_source* find_source(std::size_t index) const;
+	const falco_source* find_source(const std::string& name) const;
 
 	//
 	// Determine whether the given event should be matched at all
 	// against the set of rules, given the current sampling
 	// ratio/multiplier.
 	//
-	inline bool should_drop_evt();
+	inline bool should_drop_evt() const;
 
 	rule_loader m_rule_loader;
 	indexed_vector<falco_rule> m_rules;

--- a/userspace/engine/formats.cpp
+++ b/userspace/engine/formats.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 #include "falco_engine.h"
 #include "banned.h" // This raises a compilation error when certain functions are used
 
-falco_formats::falco_formats(std::shared_ptr<falco_engine> engine,
+falco_formats::falco_formats(std::shared_ptr<const falco_engine> engine,
 			     bool json_include_output_property,
 			     bool json_include_tags_property)
 	: m_falco_engine(engine),
@@ -35,7 +35,7 @@ falco_formats::~falco_formats()
 
 string falco_formats::format_event(gen_event *evt, const std::string &rule, const std::string &source,
 				   const std::string &level, const std::string &format, std::set<std::string> &tags,
-				   const std::string &hostname)
+				   const std::string &hostname) const
 {
 	string line;
 
@@ -132,7 +132,7 @@ string falco_formats::format_event(gen_event *evt, const std::string &rule, cons
 }
 
 map<string, string> falco_formats::get_field_values(gen_event *evt, const std::string &source,
-						    const std::string &format)
+						    const std::string &format) const
 {
 	std::shared_ptr<gen_event_formatter> formatter;
 

--- a/userspace/engine/formats.h
+++ b/userspace/engine/formats.h
@@ -24,20 +24,20 @@ limitations under the License.
 class falco_formats
 {
 public:
-	falco_formats(std::shared_ptr<falco_engine> engine,
+	falco_formats(std::shared_ptr<const falco_engine> engine,
 		      bool json_include_output_property,
 		      bool json_include_tags_property);
 	virtual ~falco_formats();
 
 	std::string format_event(gen_event *evt, const std::string &rule, const std::string &source,
 				 const std::string &level, const std::string &format, std::set<std::string> &tags,
-				 const std::string &hostname);
+				 const std::string &hostname) const;
 
 	map<string, string> get_field_values(gen_event *evt, const std::string &source,
-					     const std::string &format);
+					     const std::string &format) const ;
 
 protected:
-	std::shared_ptr<falco_engine> m_falco_engine;
+	std::shared_ptr<const falco_engine> m_falco_engine;
 	bool m_json_include_output_property;
 	bool m_json_include_tags_property;
 };


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind design

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR uses the `const` keyword with coherence across the falco engine interface and classes. Although this does not introduce any practical change, it is useful to make it more explicit which operations alter the state of the engine and which not.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
