### PR TITLE
refactor(userspace/engine): strengthen and document thread-safety guarantees of falco_engine::process_event

### DIFF
--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -332,6 +332,12 @@ std::shared_ptr<gen_event_formatter> falco_engine::create_formatter(const std::s
 unique_ptr<falco_engine::rule_result> falco_engine::process_event(std::size_t source_idx, gen_event *ev, uint16_t ruleset_id)
 {
 	falco_rule rule;
+
+	// note: there are no thread-safety guarantees on the filter_ruleset::run()
+	// method, but the thread-safety assumptions of falco_engine::process_event()
+	// imply that concurrent invokers use different and non-switchable values of
+	// source_idx, which means that at any time each filter_ruleset will only
+	// be accessed by a single thread.
 	if(should_drop_evt() || !find_source(source_idx)->ruleset->run(ev, rule, ruleset_id))
 	{
 		return unique_ptr<struct rule_result>();

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -194,6 +194,15 @@ std::unique_ptr<load_result> falco_engine::load_rules(const std::string &rules_c
 		m_rule_loader.compile(cfg, m_rules);
 	}
 
+	if (cfg.res->successful())
+	{
+		m_rule_stats_manager.clear();
+		for (const auto &r : m_rules)
+		{
+			m_rule_stats_manager.on_rule_loaded(r);
+		}
+	}
+
 	return std::move(cfg.res);
 }
 

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -179,8 +179,8 @@ public:
 	// is safe to assume that each invoker will pass a different event
 	// to this method too, since two distinct sources cannot possibly produce
 	// the same event. Lastly, filterchecks and formatters (and their factories)
-	// that used to populate the conditions for a given event-source ruleset,
-	// must not be reused across rulesets of other event sources.
+	// that are used to populate the conditions for a given event-source
+	// ruleset must not be reused across rulesets of other event sources.
 	// These assumptions guarantee thread-safety because internally the engine
 	// is partitioned by event sources. However, each ruleset assigned to each
 	// event source is not thread-safe of its own, so invoking this method

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -174,7 +174,7 @@ public:
 	// 
 	// This method is thread-safe only with the assumption that every invoker
 	// uses a different source_idx. Moreover, each invoker must not switch
-	// source_idx in subsequent invokations of this method.
+	// source_idx in subsequent invocations of this method.
 	// Considering that each invoker is related to a unique event source, it
 	// is safe to assume that each invoker will pass a different event
 	// to this method too, since two distinct sources cannot possibly produce

--- a/userspace/engine/stats_manager.cpp
+++ b/userspace/engine/stats_manager.cpp
@@ -84,7 +84,7 @@ void stats_manager::on_event(const falco_rule& rule)
 	if (m_by_rule_id.size() <= rule.id
 		|| m_by_priority.size() <= (size_t) rule.priority)
 	{
-		throw falco_exception("rule id or priority is out of boubnds");
+		throw falco_exception("rule id or priority out of bounds");
 	}
 	m_total.fetch_add(1, std::memory_order_relaxed);
 	m_by_rule_id[rule.id]->fetch_add(1, std::memory_order_relaxed);


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR is focused on guaranteeing (and documenting) that concurrent access to `falco_engine::process_event()` is safe for different event sources.

Since the new plugin system got implemented, and due to the recent refactoring of the Falco engine for Falco v0.32, the engine is not internally split by event sources. This means that the engine contains multiple rulesets, each mapped 1-1 with an event source. Accordingly, it is possible to assume that `falco_engine::process_event()` is now thread-safe with some assumptions:
1. Each concurrent invoker must use a distinct and unique `source_idx`
2. Each concurrent invoker must not switch values of `source_idx` across subsequent calls to `falco_engine::process_event()`
3. Each concurrent invoker must use pass a different event (which is an implicit consequence of point 1)
4. Filterchecks and formatters used to populate the conditions for a given event-source ruleset are not reused across rulesets of other event sources

Considering the above, the only synchronization point is `stats_manager::on_event()`, which has been modified to be thread-safe and lock-free.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Thread safety is not a requirement for Falco, but future developments such as the ones described in https://github.com/falcosecurity/falco/issues/2074 could require it. Among the many things that can be useful to make thread safe, the most crucial one is the rule-event matching routine, of which `falco_engine::process_event()` is entrypoint. With this implementation, it is possible to consider processing events coming from different event sources in different parallel threads.

Assuming a single-threaded scenario, the changes involved in `stats_manager::on_event()` are a no-op in both expected behavior and performance. This is true because `stats_manager::on_event()` is invoked when an event matches a given rule exclusively, which happens with less frequency than the production of events by some orders of magnitude. As such, we can consider these changes as non-noticeable for single-thread scenarios (which is what we have right now). Moreover, when events are matched with a rule we then have to queue them in the Falco output engine, which is still an asynchronous sequential synchronization point.

**Does this PR introduce a user-facing change?**:

```release-note
refactor(userspace/engine): strengthen and document thread-safety guarantees of falco_engine::process_event
```
