### PR TITLE
refactor(userspace/falco): make signal handlers thread safe

### DIFF
--- a/userspace/falco/app_actions/create_signal_handlers.cpp
+++ b/userspace/falco/app_actions/create_signal_handlers.cpp
@@ -36,16 +36,19 @@ static int inot_fd;
 
 static void signal_callback(int signal)
 {
+	falco_logger::log(LOG_INFO, "SIGINT received, exiting...\n");
 	s_app.get().terminate();
 }
 
 static void reopen_outputs(int signal)
 {
+	falco_logger::log(LOG_INFO, "SIGUSR1 received, reopening outputs...\n");
 	s_app.get().reopen_outputs();
 }
 
 static void restart_falco(int signal)
 {
+	falco_logger::log(LOG_INFO, "SIGHUP received, restarting...\n");
 	s_app.get().restart();
 }
 

--- a/userspace/falco/app_actions/process_events.cpp
+++ b/userspace/falco/app_actions/process_events.cpp
@@ -90,13 +90,8 @@ application::run_result application::do_inspect(syscall_evt_drop_mgr &sdropmgr,
 
 		writer.handle();
 
-		if(m_state->reopen_outputs)
-		{
-			m_state->outputs->reopen_outputs();
-			m_state->reopen_outputs = false;
-		}
-
-		if(m_state->terminate || m_state->restart)
+		if(m_state->terminate.load(std::memory_order_acquire)
+			|| m_state->restart.load(std::memory_order_acquire))
 		{
 			break;
 		}

--- a/userspace/falco/app_actions/process_events.cpp
+++ b/userspace/falco/app_actions/process_events.cpp
@@ -92,19 +92,12 @@ application::run_result application::do_inspect(syscall_evt_drop_mgr &sdropmgr,
 
 		if(m_state->reopen_outputs)
 		{
-			falco_logger::log(LOG_INFO, "SIGUSR1 received, reopening outputs...\n");
 			m_state->outputs->reopen_outputs();
 			m_state->reopen_outputs = false;
 		}
 
-		if(m_state->terminate)
+		if(m_state->terminate || m_state->restart)
 		{
-			falco_logger::log(LOG_INFO, "SIGINT received, exiting...\n");
-			break;
-		}
-		else if (m_state->restart)
-		{
-			falco_logger::log(LOG_INFO, "SIGHUP received, restarting...\n");
 			break;
 		}
 		else if(rc == SCAP_TIMEOUT)

--- a/userspace/falco/application.h
+++ b/userspace/falco/application.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "app_cmdline_options.h"
 
 #include <string>
+#include <atomic>
 
 namespace falco {
 namespace app {
@@ -61,9 +62,8 @@ private:
 		state();
 		virtual ~state();
 
-		bool restart;
-		bool terminate;
-		bool reopen_outputs;
+		std::atomic<bool> restart;
+		std::atomic<bool> terminate;
 
 		std::shared_ptr<falco_configuration> config;
 		std::shared_ptr<falco_outputs> outputs;

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -110,7 +110,8 @@ private:
 	falco_outputs_cbq m_queue;
 
 	std::thread m_worker_thread;
-	inline void push(ctrl_msg_type cmt);
+	inline void push(const ctrl_msg& cmsg);
+	inline void push_ctrl(ctrl_msg_type cmt);
 	void worker() noexcept;
 	void stop_worker();
 	void add_output(falco::outputs::config oc);


### PR DESCRIPTION
**What type of PR is this?**

/kind design

kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR refactors the signal handlers, and their effects, to be thread-safe. Thread-safety is not something we need right now, but it is preparatory for https://github.com/falcosecurity/falco/issues/2074.

Also, this defines a termination condition for the Falco output engine. Basically, a full queue would generally imply a deadlock for Falco, so we exit with an error in that case.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
refactor(userspace/falco): make signal handlers thread safe
```
