### PR TITLE
fix: adapt regressions after dup change and version bump

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2991,7 +2991,7 @@
   condition: dup and container and evt.rawres in (0, 1, 2) and fd.type in ("ipv4", "ipv6") and not user_known_stand_streams_redirect_activities
   output: >
     Redirect stdout/stdin to network connection (user=%user.name user_loginuid=%user.loginuid %container.info process=%proc.name parent=%proc.pname cmdline=%proc.cmdline terminal=%proc.tty container_id=%container.id image=%container.image.repository fd.name=%fd.name fd.num=%fd.num fd.type=%fd.type fd.sip=%fd.sip)
-  priority: WARNING
+  priority: NOTICE
 
 # The two Container Drift rules below will fire when a new executable is created in a container.
 # There are two ways to create executables - file is created with execution permissions or permissions change of existing file.

--- a/test/falco_tests_plugins.yaml
+++ b/test/falco_tests_plugins.yaml
@@ -75,7 +75,7 @@ trace_files: !mux
 
   incompat_plugin_api:
     exit_status: 1
-    stderr_contains: "Unsupported plugin required api version 10000000.0.0"
+    stderr_contains: "Plugin required API version '10000000.0.0' is not supported by the plugin API version of the framework '.*'"
     conf_file: BUILD_DIR/test/confs/plugins/incompatible_plugin_api.yaml
     rules_file:
       - rules/plugins/cloudtrail_create_instances.yaml

--- a/test/falco_traces.yaml.in
+++ b/test/falco_traces.yaml.in
@@ -164,3 +164,12 @@ traces: !mux
     detect_level: ERROR
     detect_counts:
       - "Write below rpm database": 1
+
+  # This generates two notices starting from https://github.com/falcosecurity/falco/pull/2092
+  # When a new version of the scap files is generated this should then become "traces-positive"
+  docker-compose:
+    trace_file: traces-negative/docker-compose.scap
+    detect: True
+    detect_level: NOTICE
+    detect_counts:
+      - "Redirect STDOUT/STDIN to Network Connection in Container": 2


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

/kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

/kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area rules

/area tests

> /area proposals


Fixes #

**Special notes for your reviewer**:

/milestone 0.32.1

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rule(Redirect STDOUT/STDIN to Network Connection in Container): changed priority to NOTICE
```
