### PR TITLE
update(userspace/falco): support libs logging

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -98,6 +98,17 @@ log_syslog: true
 # "alert", "critical", "error", "warning", "notice", "info", "debug".
 log_level: info
 
+# Falco is capable of managing the logs coming from libs. If enabled,
+# the libs logger send its log records the same outputs supported by
+# Falco (stderr and syslog). Disabled by default.
+libs_logger:
+  enabled: false
+  # Minimum log severity to include in the libs logs. Note: this value is
+  # separate from the log level of the Falco logger and does not affect it.
+  # Can be one of "fatal", "critical", "error", "warning", "notice",
+  # "info", "debug", "trace".
+  severity: debug
+
 # Minimum rule priority level to load and run. All rules having a
 # priority more severe than this level will be loaded/run.  Can be one
 # of "emergency", "alert", "critical", "error", "warning", "notice",

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -183,6 +183,12 @@ void falco_configuration::init(string conf_filename, const vector<string> &cmdli
 
 	falco_logger::set_level(m_log_level);
 
+
+	falco_logger::set_sinsp_logging(
+		m_config->get_scalar<bool>("libs_logger.enabled", false),
+		m_config->get_scalar<std::string>("libs_logger.severity", "debug"),
+		"[libs]: ");
+
 	m_output_timeout = m_config->get_scalar<uint32_t>("output_timeout", 2000);
 
 	m_notifications_rate = m_config->get_scalar<uint32_t>("outputs.rate", 1);

--- a/userspace/falco/logger.cpp
+++ b/userspace/falco/logger.cpp
@@ -23,44 +23,41 @@ limitations under the License.
 int falco_logger::level = LOG_INFO;
 bool falco_logger::time_format_iso_8601 = false;
 
-static void decode_sinsp_severity(const string& s, sinsp_logger::severity& sev)
+static sinsp_logger::severity decode_sinsp_severity(const string& s)
 {
 	if(s == "trace")
 	{
-		sev = sinsp_logger::SEV_TRACE;
+		return sinsp_logger::SEV_TRACE;
 	}
 	else if(s == "debug")
 	{
-		sev = sinsp_logger::SEV_DEBUG;
+		return sinsp_logger::SEV_DEBUG;
 	}
 	else if(s == "info")
 	{
-		sev = sinsp_logger::SEV_INFO;
+		return sinsp_logger::SEV_INFO;
 	}
 	else if(s == "notice")
 	{
-		sev = sinsp_logger::SEV_NOTICE;
+		return sinsp_logger::SEV_NOTICE;
 	}
 	else if(s == "warning")
 	{
-		sev = sinsp_logger::SEV_WARNING;
+		return sinsp_logger::SEV_WARNING;
 	}
 	else if(s == "error")
 	{
-		sev = sinsp_logger::SEV_ERROR;
+		return sinsp_logger::SEV_ERROR;
 	}
 	else if(s == "critical")
 	{
-		sev = sinsp_logger::SEV_CRITICAL;
+		return sinsp_logger::SEV_CRITICAL;
 	}
 	else if(s == "fatal")
 	{
-		sev = sinsp_logger::SEV_FATAL;
+		return sinsp_logger::SEV_FATAL;
 	}
-	else
-	{
-		throw falco_exception("Unknown sinsp log severity " + s);
-	}
+	throw falco_exception("Unknown sinsp log severity " + s);
 }
 
 void falco_logger::set_time_format_iso_8601(bool val)
@@ -114,11 +111,8 @@ void falco_logger::set_sinsp_logging(bool enable, const std::string& severity, c
 {
 	if (enable)
 	{
-		sinsp_logger::severity sevcode = sinsp_logger::SEV_DEBUG;
-		decode_sinsp_severity(severity, sevcode);
-
 		s_sinsp_logger_prefix = prefix;
-		g_logger.set_severity(sevcode);
+		g_logger.set_severity(decode_sinsp_severity(severity));
 		g_logger.disable_timestamps();
 		g_logger.add_callback_log(
 			[](std::string&& str, const sinsp_logger::severity sev)

--- a/userspace/falco/logger.h
+++ b/userspace/falco/logger.h
@@ -28,6 +28,8 @@ class falco_logger
 	// Will throw exception if level is unknown.
 	static void set_level(string &level);
 
+	static void set_sinsp_logging(bool enable, const std::string& severity, const std::string& prefix);
+
 	static void log(int priority, const string msg);
 
 	static int level;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR adds support to logs coming from libsinsp, which are now piped into the Falco logger. By default this is disabled in order to avoid breaking changes in the UX as for the messages printed to stderr. A new option `libs_logger` has been added in the `falco.yaml` configuration.

**Which issue(s) this PR fixes**:

Fixes #2068

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/falco): support libs logging
```
