### PR TITLE
refactor(userspace/engine): drop macro source field in rules and rule loader

### DIFF
--- a/test/falco_tests_plugins.yaml
+++ b/test/falco_tests_plugins.yaml
@@ -103,13 +103,6 @@ trace_files: !mux
       - Cloudtrail Create Instance
     stderr_contains: "Rule Cloudtrail Create Instance: warning .unknown-source.: unknown source aws_cloudtrail, skipping"
 
-  no_plugins_unknown_source_macro:
-    detect: False
-    rules_file:
-      - rules/plugins/cloudtrail_macro.yaml
-    trace_file: trace_files/empty.scap
-    stderr_contains: "Macro Some Cloudtrail Macro: warning .unknown-source.: unknown source aws_cloudtrail, skipping"
-
   no_plugins_unknown_source_rule_exception:
     detect: False
     rules_file:

--- a/test/rules/plugins/cloudtrail_macro.yaml
+++ b/test/rules/plugins/cloudtrail_macro.yaml
@@ -1,4 +1,0 @@
-- macro: Some Cloudtrail Macro
-  condition: aws.user=bob
-  source: aws_cloudtrail
-

--- a/userspace/engine/rule_loader.cpp
+++ b/userspace/engine/rule_loader.cpp
@@ -413,18 +413,6 @@ void rule_loader::append(configuration& cfg, list_info& info)
 
 void rule_loader::define(configuration& cfg, macro_info& info)
 {
-	if (!cfg.sources.at(info.source))
-	{
-		cfg.warnings.push_back("Macro " + info.name
-			+ ": warning (unknown-source): unknown source "
-			+ info.source + ", skipping");
-		return;
-	}
-	
-	auto prev = m_macro_infos.at(info.name);
-	THROW(prev && prev->source != info.source,
-		"Macro " + info.name + " has been re-defined with a different source");
-
 	define_info(m_macro_infos, info, m_cur_index++);
 }
 
@@ -566,7 +554,6 @@ void rule_loader::compile_macros_infos(
 	indexed_vector<list_info>& lists,
 	indexed_vector<macro_info>& out) const
 {
-	set<string> used;
 	const context* info_ctx = NULL;
 	try
 	{

--- a/userspace/engine/rule_loader.h
+++ b/userspace/engine/rule_loader.h
@@ -122,7 +122,6 @@ public:
 		size_t visibility;
 		std::string name;
 		std::string cond;
-		std::string source;
 		std::shared_ptr<libsinsp::filter::ast::expr> cond_ast;
 	};
 

--- a/userspace/engine/rule_reader.cpp
+++ b/userspace/engine/rule_reader.cpp
@@ -207,12 +207,10 @@ static void read_item(
 		rule_loader::macro_info v;
 		v.ctx = ctx;
 		bool append = false;
-		v.source = falco_common::syscall_source;
 		THROW(!decode_val(item["macro"], v.name) || v.name.empty(),
 			"Macro name is empty");
 		THROW(!decode_val(item["condition"], v.cond) || v.cond.empty(),
 			"Macro must have property condition");
-		decode_val(item["source"], v.source);
 		if(decode_val(item["append"], append) && append)
 		{
 			loader.append(cfg, v);


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

/area tests

**What this PR does / why we need it**:

Since being ported from Lua to C++, the Falco rule loader supported defining a `source` field in both rules and macros, meant to define compatibility with a specific event source. However, having source definitions in macros is not meaningful, and also the current implementation does not enforce any check during ruleset compilation (it just reads the value from the YAML). On the opposite, I think **not** defining a source for macros is the way to go. This would enable ruleset developers to create cross-source macros (for example, the `json` plugin can be used to build macros that are valid for all the json-based event sources such as `cloudtrail` and `k8s_audit`). As such, this PR drops the notion of macro-specific source and its related regression tests.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
refactor(userspace/engine): drop macro source field in rules and rule loader
```
