### PR TITLE
Remove required_engine_version from falco engine load_rules APIs

### DIFF
--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -165,13 +165,6 @@ void falco_engine::list_fields(std::string &source, bool verbose, bool names_onl
 
 void falco_engine::load_rules(const string &rules_content, bool verbose, bool all_events)
 {
-	uint64_t dummy;
-
-	return load_rules(rules_content, verbose, all_events, dummy);
-}
-
-void falco_engine::load_rules(const string &rules_content, bool verbose, bool all_events, uint64_t &required_engine_version)
-{
 	rule_loader::configuration cfg(rules_content, m_sources);
 	cfg.min_priority = m_min_priority;
 	cfg.output_extra = m_extra;
@@ -218,13 +211,6 @@ void falco_engine::load_rules(const string &rules_content, bool verbose, bool al
 
 void falco_engine::load_rules_file(const string &rules_filename, bool verbose, bool all_events)
 {
-	uint64_t dummy;
-
-	return load_rules_file(rules_filename, verbose, all_events, dummy);
-}
-
-void falco_engine::load_rules_file(const string &rules_filename, bool verbose, bool all_events, uint64_t &required_engine_version)
-{
 	ifstream is;
 
 	is.open(rules_filename);
@@ -238,7 +224,7 @@ void falco_engine::load_rules_file(const string &rules_filename, bool verbose, b
 	string rules_content((istreambuf_iterator<char>(is)),
 			     istreambuf_iterator<char>());
 
-	load_rules(rules_content, verbose, all_events, required_engine_version);
+	load_rules(rules_content, verbose, all_events);
 }
 
 void falco_engine::enable_rule(const string &substring, bool enabled, const string &ruleset)
@@ -339,7 +325,7 @@ unique_ptr<falco_engine::rule_result> falco_engine::process_event(std::size_t so
 	{
 		return unique_ptr<struct rule_result>();
 	}
-	
+
 	unique_ptr<struct rule_result> res(new rule_result());
 	res->evt = ev;
 	res->rule = rule.name;
@@ -441,8 +427,8 @@ bool falco_engine::check_plugin_requirements(
 					if (!plugin_version.check(req_version))
 					{
 						err = "Plugin '" + plugin.name
-						+ "' version '" + plugin.version 
-						+ "' is not compatible with required plugin version '" 
+						+ "' version '" + plugin.version
+						+ "' is not compatible with required plugin version '"
 						+ reqver + "'";
 						return false;
 					}

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -64,13 +64,6 @@ public:
 	void load_rules(const std::string &rules_content, bool verbose, bool all_events);
 
 	//
-	// Identical to above, but also returns the required engine version for the file/content.
-	// (If no required engine version is specified, returns 0).
-	//
-	void load_rules_file(const std::string &rules_filename, bool verbose, bool all_events, uint64_t &required_engine_version);
-	void load_rules(const std::string &rules_content, bool verbose, bool all_events, uint64_t &required_engine_version);
-
-	//
 	// Enable/Disable any rules matching the provided substring.
 	// If the substring is "", all rules are enabled/disabled.
 	// When provided, enable/disable these rules in the

--- a/userspace/falco/app_actions/load_rules_files.cpp
+++ b/userspace/falco/app_actions/load_rules_files.cpp
@@ -96,16 +96,14 @@ application::run_result application::load_rules_files()
 	for (const auto& filename : m_state->config->m_loaded_rules_filenames)
 	{
 		falco_logger::log(LOG_INFO, "Loading rules from file " + filename + "\n");
-		uint64_t required_engine_version;
 
 		try {
-			m_state->engine->load_rules_file(filename, m_options.verbose, m_options.all_events, required_engine_version);
+			m_state->engine->load_rules_file(filename, m_options.verbose, m_options.all_events);
 		}
 		catch(falco_exception &e)
 		{
 			return run_result::fatal(string("Could not load rules file ") + filename + ": " + e.what());
 		}
-		m_state->required_engine_versions[filename] = required_engine_version;
 	}
 
 	// Ensure that all plugins are compatible with the loaded set of rules

--- a/userspace/falco/app_actions/print_support.cpp
+++ b/userspace/falco/app_actions/print_support.cpp
@@ -58,7 +58,6 @@ application::run_result application::print_support()
 			nlohmann::json finfo;
 			finfo["name"] = filename;
 			nlohmann::json variant;
-			variant["required_engine_version"] = m_state->required_engine_versions[filename];
 			variant["content"] = read_file(filename);
 			finfo["variants"].push_back(variant);
 			support["rules_files"].push_back(finfo);

--- a/userspace/falco/application.h
+++ b/userspace/falco/application.h
@@ -81,8 +81,6 @@ private:
 		// from event source to filtercheck list.
 		std::map<std::string, filter_check_list> plugin_filter_checks;
 
-		std::map<string,uint64_t> required_engine_versions;
-
 		std::string cmdline;
 
 #ifndef MINIMAL_BUILD


### PR DESCRIPTION
The only use of it was to include in --support output, which is
redundant as the support output already includes the full contents of
each rules file.

Additionally, it wasn't even being updated after the switch from lua
rules loading to c++ rules
loading (https://github.com/falcosecurity/falco/pull/1966/ or
surrounding PRs).

This will simplify follow-on changes to add a real "result" to rules
loading methods, as there will be fewer API variants to support.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Remove falco engine APIs that returned a required_engine_version.
```
