### PR TITLE
Use total events to calculate drop_pct

### DIFF
--- a/userspace/falco/statsfilewriter.cpp
+++ b/userspace/falco/statsfilewriter.cpp
@@ -129,7 +129,7 @@ void StatsFileWriter::handle()
 			"\"events\": " << delta.n_evts <<
 			", \"drops\": " << delta.n_drops <<
 			", \"preemptions\": " << delta.n_preemptions <<
-			"}, \"drop_pct\": " << (delta.n_evts == 0 ? 0 : (100.0*delta.n_drops/delta.n_evts)) <<
+			"}, \"drop_pct\": " << (delta.n_evts == 0 ? 0 : (100.0*delta.n_drops/(delta.n_drops + delta.n_evts))) <<
 			"}," << endl;
 
 		m_last_stats = cstats;

--- a/userspace/falco/statsfilewriter.cpp
+++ b/userspace/falco/statsfilewriter.cpp
@@ -129,8 +129,8 @@ void StatsFileWriter::handle()
 			"\"events\": " << delta.n_evts <<
 			", \"drops\": " << delta.n_drops <<
 			", \"preemptions\": " << delta.n_preemptions <<
-			"}, \"drop_pct\": " << (delta.n_evts == 0 ? 0 : (100.0*delta.n_drops/(delta.n_drops + delta.n_evts))) <<
-			"}," << endl;
+			", \"drop_pct\": " << (delta.n_evts == 0 ? 0 : (100.0*delta.n_drops/(delta.n_drops + delta.n_evts))) <<
+			"}}," << endl;
 
 		m_last_stats = cstats;
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
<!--
> Uncomment one (or more) `/kind <>` lines:

> /kind bug
-->

/kind cleanup

<!--
> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create
-->

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

<!--
> Uncomment one (or more) `/area <>` lines:

> /area build
-->

/area engine

<!--
> /area rules

> /area tests

> /area proposals
-->

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
My expectation for `drop_pct` was that it showed the percent of total events dropped by the Falco engine. While investigating some misbehaving Falco processes, I found that many were reporting more than 100% of events being dropped:
```
log: {"sample": 15, "cur": {"events": 7316740312, "drops": 13564074902, "preemptions": 0}, "delta": {"events": 488585741, "drops": 904962208, "preemptions": 0}, "drop_pct": 185.221},
```

I think that Falco is counting only the successfully processed events in the total when calculating drop_pct. This PR changes that calculation to include both the successful events (n_events) and the dropped events (n_drops) in the total. It also moves the drop_pct value into the delta subfield of the stats output since it is calculated from the delta, not the cumulative total.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2111

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
use total events to calculate drop_pct and move to delta subfield
```
