### PR TITLE
cleanup(OWNERS): remove inactive approvers

### DIFF
--- a/.circleci/OWNERS
+++ b/.circleci/OWNERS
@@ -1,4 +1,2 @@
-reviewers:
-  - jonahjon
 emeritus_approvers:
   - jonahjon

--- a/.circleci/OWNERS
+++ b/.circleci/OWNERS
@@ -1,4 +1,4 @@
-approvers:
-  - jonahjon
 reviewers:
+  - jonahjon
+emeritus_approvers:
   - jonahjon

--- a/OWNERS
+++ b/OWNERS
@@ -4,15 +4,8 @@ approvers:
   - jasondellaluce
   - fededp
 reviewers:
-  - fntlnz
   - kaizhe
-  - kris-nova
-  - leodido
   - mfdii
-  - mstemm
-  - leogr
-  - jasondellaluce
-  - fededp
 emeritus_approvers:
   - fntlnz
   - kris-nova

--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,4 @@
 approvers:
-  - fntlnz
-  - kris-nova
-  - leodido
   - mstemm
   - leogr
   - jasondellaluce
@@ -16,3 +13,7 @@ reviewers:
   - leogr
   - jasondellaluce
   - fededp
+emeritus_approvers:
+  - fntlnz
+  - kris-nova
+  - leodido

--- a/docker/OWNERS
+++ b/docker/OWNERS
@@ -2,5 +2,4 @@ labels:
   - area/integration
 approvers:
   - leogr
-reviewers:
-  - leogr
+

--- a/rules/OWNERS
+++ b/rules/OWNERS
@@ -5,7 +5,5 @@ reviewers:
   - fntlnz
   - mfdii
   - kaizhe
-  - mstemm
 labels:
   - area/rules
-


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

For https://github.com/falcosecurity/evolution/issues/157, this PR moves inactive approvers (who had very little or zero contributions over the past 6 months) from `approvers` to `emeritus_approvers` in OWNERS.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
