### PR TITLE
new(rules): Directory traversal monitored file read

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1366,6 +1366,19 @@
 - macro: user_known_read_sensitive_files_activities
   condition: (never_true)
 
+- rule: Directory traversal monitored file read
+  desc: >
+    Web applications can be vulnerable to directory traversal attacks that allow accessing files outside of the web app's root directory (e.g. Arbitrary File Read bugs).
+    System directories like /etc are typically accessed via absolute paths. Access patterns outside of this (here path traversal) can be regarded as suspicious.
+  condition: open_read and (fd.directory startswith "/etc" or fd.name contains ".ssh/" or fd.name contains "id_rsa") and fd.nameraw contains "../" and fd.nameraw glob *../*../* and not proc.pname in (shell_binaries)
+  enabled: true
+  output: >
+    Read monitored file via directory traversal (username=%user.name useruid=%user.uid user_loginuid=%user.loginuid program=%proc.name exe=%proc.exepath
+    command=%proc.cmdline parent=%proc.pname file=%fd.name fileraw=%fd.nameraw parent=%proc.pname
+    gparent=%proc.aname[2] container_id=%container.id image=%container.image.repository returncode=%evt.res cwd=%proc.cwd)
+  priority: WARNING
+  tags: [filesystem, mitre_discovery, mitre_exfiltration, mitre_credential_access]
+
 - rule: Read sensitive file trusted after startup
   desc: >
     an attempt to read any sensitive file (e.g. files containing user/password/authentication

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -29,13 +29,20 @@
 #   condition: (syscall.type=read and evt.dir=> and fd.type in (file, directory))
 
 - macro: open_write
-  condition: evt.type in (open,openat,openat2) and evt.is_open_write=true and fd.typechar='f' and fd.num>=0
+  condition: (evt.type in (open,openat,openat2) and evt.is_open_write=true and fd.typechar='f' and fd.num>=0)
 
 - macro: open_read
-  condition: evt.type in (open,openat,openat2) and evt.is_open_read=true and fd.typechar='f' and fd.num>=0
+  condition: (evt.type in (open,openat,openat2) and evt.is_open_read=true and fd.typechar='f' and fd.num>=0)
 
 - macro: open_directory
-  condition: evt.type in (open,openat,openat2) and evt.is_open_read=true and fd.typechar='d' and fd.num>=0
+  condition: (evt.type in (open,openat,openat2) and evt.is_open_read=true and fd.typechar='d' and fd.num>=0)
+
+# Failed file open attempts, useful to detect threat actors making mistakes
+# https://man7.org/linux/man-pages/man3/errno.3.html
+# evt.res=ENOENT - No such file or directory
+# evt.res=EACCESS - Permission denied
+- macro: open_file_failed
+  condition: (evt.type in (open,openat,openat2) and fd.typechar='f' and fd.num=-1 and evt.res startswith E)
 
 - macro: never_true
   condition: (evt.num=0)
@@ -51,32 +58,32 @@
   condition: (proc.name!="<NA>")
 
 - macro: rename
-  condition: evt.type in (rename, renameat, renameat2)
+  condition: (evt.type in (rename, renameat, renameat2))
 
 - macro: mkdir
-  condition: evt.type in (mkdir, mkdirat)
+  condition: (evt.type in (mkdir, mkdirat))
 
 - macro: remove
-  condition: evt.type in (rmdir, unlink, unlinkat)
+  condition: (evt.type in (rmdir, unlink, unlinkat))
 
 - macro: modify
-  condition: rename or remove
+  condition: (rename or remove)
 
 - macro: spawned_process
-  condition: evt.type in (execve, execveat) and evt.dir=<
+  condition: (evt.type in (execve, execveat) and evt.dir=<)
 
 - macro: create_symlink
-  condition: evt.type in (symlink, symlinkat) and evt.dir=<
+  condition: (evt.type in (symlink, symlinkat) and evt.dir=<)
 
 - macro: create_hardlink
-  condition: evt.type in (link, linkat) and evt.dir=<
+  condition: (evt.type in (link, linkat) and evt.dir=<)
 
 - macro: chmod
   condition: (evt.type in (chmod, fchmod, fchmodat) and evt.dir=<)
 
 # File categories
 - macro: bin_dir
-  condition: fd.directory in (/bin, /sbin, /usr/bin, /usr/sbin)
+  condition: (fd.directory in (/bin, /sbin, /usr/bin, /usr/sbin))
 
 - macro: bin_dir_mkdir
   condition: >
@@ -105,7 +112,7 @@
      evt.arg.newpath startswith /usr/sbin/)
 
 - macro: etc_dir
-  condition: fd.name startswith /etc/
+  condition: (fd.name startswith /etc/)
 
 # This detects writes immediately below / or any write anywhere below /root
 - macro: root_dir
@@ -964,7 +971,8 @@
   desc: >
     Web applications can be vulnerable to directory traversal attacks that allow accessing files outside of the web app's root directory (e.g. Arbitrary File Read bugs).
     System directories like /etc are typically accessed via absolute paths. Access patterns outside of this (here path traversal) can be regarded as suspicious.
-  condition: open_read and (etc_dir or user_ssh_directory or fd.name startswith /root/.ssh or fd.name contains "id_rsa") and directory_traversal and not proc.pname in (shell_binaries)
+    This rule includes failed file open attempts.
+  condition: (open_read or open_file_failed) and (etc_dir or user_ssh_directory or fd.name startswith /root/.ssh or fd.name contains "id_rsa") and directory_traversal and not proc.pname in (shell_binaries)
   enabled: true
   output: >
     Read monitored file via directory traversal (username=%user.name useruid=%user.uid user_loginuid=%user.loginuid program=%proc.name exe=%proc.exepath

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -912,7 +912,10 @@
   items: [/boot, /lib, /lib64, /usr/lib, /usr/local/lib, /usr/local/sbin, /usr/local/bin, /root/.ssh]
 
 - macro: user_ssh_directory
-  condition: (fd.name glob '/home/*/.ssh/*')
+  condition: (fd.name contains '/.ssh/' and fd.name glob '/home/*/.ssh/*')
+
+- macro: directory_traversal
+  condition: (fd.nameraw contains '../' and fd.nameraw glob '*../*../*')
 
 # google_accounts_(daemon)
 - macro: google_accounts_daemon_writing_ssh
@@ -956,6 +959,19 @@
     command=%proc.cmdline file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline gparent=%proc.aname[2] container_id=%container.id image=%container.image.repository)
   priority: ERROR
   tags: [filesystem, mitre_persistence]
+
+- rule: Directory traversal monitored file read
+  desc: >
+    Web applications can be vulnerable to directory traversal attacks that allow accessing files outside of the web app's root directory (e.g. Arbitrary File Read bugs).
+    System directories like /etc are typically accessed via absolute paths. Access patterns outside of this (here path traversal) can be regarded as suspicious.
+  condition: open_read and (etc_dir or user_ssh_directory or fd.name startswith /root/.ssh or fd.name contains "id_rsa") and directory_traversal and not proc.pname in (shell_binaries)
+  enabled: true
+  output: >
+    Read monitored file via directory traversal (username=%user.name useruid=%user.uid user_loginuid=%user.loginuid program=%proc.name exe=%proc.exepath
+    command=%proc.cmdline parent=%proc.pname file=%fd.name fileraw=%fd.nameraw parent=%proc.pname
+    gparent=%proc.aname[2] container_id=%container.id image=%container.image.repository returncode=%evt.res cwd=%proc.cwd)
+  priority: WARNING
+  tags: [filesystem, mitre_discovery, mitre_exfiltration, mitre_credential_access]
 
 # This rule is disabled by default as many system management tools
 # like ansible, etc can read these files/paths. Enable it using this macro.
@@ -1365,19 +1381,6 @@
 
 - macro: user_known_read_sensitive_files_activities
   condition: (never_true)
-
-- rule: Directory traversal monitored file read
-  desc: >
-    Web applications can be vulnerable to directory traversal attacks that allow accessing files outside of the web app's root directory (e.g. Arbitrary File Read bugs).
-    System directories like /etc are typically accessed via absolute paths. Access patterns outside of this (here path traversal) can be regarded as suspicious.
-  condition: open_read and (fd.directory startswith "/etc" or fd.name contains ".ssh/" or fd.name contains "id_rsa") and fd.nameraw contains "../" and fd.nameraw glob *../*../* and not proc.pname in (shell_binaries)
-  enabled: true
-  output: >
-    Read monitored file via directory traversal (username=%user.name useruid=%user.uid user_loginuid=%user.loginuid program=%proc.name exe=%proc.exepath
-    command=%proc.cmdline parent=%proc.pname file=%fd.name fileraw=%fd.nameraw parent=%proc.pname
-    gparent=%proc.aname[2] container_id=%container.id image=%container.image.repository returncode=%evt.res cwd=%proc.cwd)
-  priority: WARNING
-  tags: [filesystem, mitre_discovery, mitre_exfiltration, mitre_credential_access]
 
 - rule: Read sensitive file trusted after startup
   desc: >


### PR DESCRIPTION
Signed-off-by: Melissa Kilby <melissa.kilby.oss@gmail.com>


**What type of PR is this?**


/kind feature

/kind rule-create


**Any specific area of the project related to this PR?**

/area rules


**What this PR does / why we need it**:

Add new rule `Directory traversal monitored file read`.

Web applications can be vulnerable to directory traversal attacks that allow accessing files outside of the web app's root directory (e.g. Arbitrary File Read bugs). System directories like /etc are typically accessed via absolute paths. Access patterns outside of this (here path traversal) can be regarded as suspicious. This for example will allow monitoring the entire `/etc` directory. For instance while `/etc/passwd` is not regarded a sensitive file like `/etc/shadow` - reading `/etc/passwd` via directory traversal is often performed as reconnaissance / probing for Arbitrary File Read vulnerabilities especially in web applications, because `/etc/passwd` is always there and it is world readable. In addition, vulnerability scanners will often try reading `/etc/passwd` via directory traversal `../../../../../../../etc/passwd`.

Thanks @Kaizhe and @darryk10 for feedback to derive final version.

Example simulated log 
```
{"priority":"Warning","rule":"Directory traversal monitored file read","source":"syscall","time":"2022-07-15T00:00:34.758753699Z", "output_fields": {"container.id":"host","container.image.repository":null,"evt.res":"SUCCESS","evt.time":1657843234758753699,"fd.name":"/etc/shadow","fd.nameraw":".././././.././././../././././../etc/shadow","proc.aname[2]":null,"proc.cmdline":"cat ../././//.////.././././.././././///./../etc/shadow","proc.cwd":"/home/vagrant/","proc.exepath":"/bin/cat","proc.name":"cat","proc.pname":"sudo","user.loginuid":1000,"user.name":"root","user.uid":0}}
```


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Needs new filter/display field `fd.nameraw` https://github.com/falcosecurity/libs/pull/468

**Does this PR introduce a user-facing change?**:


```release-note
new rule(Directory traversal monitored file read)
new rule(macro: open_file_failed)
new rule(macro: directory_traversal)
```
