### PR TITLE
fix(userspace): compute the `drop ratio` in the right way

### DIFF
--- a/userspace/falco/event_drops.cpp
+++ b/userspace/falco/event_drops.cpp
@@ -91,8 +91,8 @@ bool syscall_evt_drop_mgr::process_event(std::shared_ptr<sinsp> inspector, sinsp
 		if(delta.n_drops > 0)
 		{
 			double ratio = delta.n_drops;
-			// Assuming the number of event does not contains the dropped ones
-			ratio /= delta.n_drops + delta.n_evts;
+			// The `n_evts` always contains the `n_drops`.
+			ratio /= delta.n_evts;
 
 			// When simulating drops the threshold is always zero
 			if(ratio > m_threshold)


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>
Co-authored-by: Shane Lawrence <shane@lawrence.dev>

**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

First of all, I would to thank  @shane-lawrence for spotting this issue in #2111! Great catch!

As I said [here](https://github.com/falcosecurity/falco/pull/2112#issuecomment-1175101375) the `n_evts` fields, both in `kmod` and in `bpf` should be intended as "events seen by the drivers" so they should contain also the number of drops. This is for example what we do in our bpf probe after [this variable increment](https://github.com/falcosecurity/libs/blob/aa8589da33a63927505100340a1a4adfe1418a73/driver/bpf/plumbing_helpers.h#L511) we will increment also the drops number in case the event cannot [be pushed into the buffer](https://github.com/falcosecurity/libs/blob/aa8589da33a63927505100340a1a4adfe1418a73/driver/bpf/fillers.h#L103) for example. 

According to it, we need to change the way in which we compute the `drop ratio`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
fix: compute the `drop ratio` in the right way
```
