### PR TITLE
new: add a `drop_pct` referred to the global number of events

### DIFF
--- a/userspace/falco/statsfilewriter.cpp
+++ b/userspace/falco/statsfilewriter.cpp
@@ -126,10 +126,11 @@ void StatsFileWriter::handle()
 		jmsg["cur"]["events"] = cstats.n_evts;
 		jmsg["cur"]["drops"] = cstats.n_drops;
 		jmsg["cur"]["preemptions"] = cstats.n_preemptions;
+		jmsg["cur"]["drop_pct"] = (cstats.n_evts == 0 ? 0 : (100.0*cstats.n_drops/cstats.n_evts));
 		jmsg["delta"]["events"] = delta.n_evts;
 		jmsg["delta"]["drops"] = delta.n_drops;
 		jmsg["delta"]["preemptions"] = delta.n_preemptions;
-		jmsg["drop_pct"] = (delta.n_evts == 0 ? 0 : (100.0*delta.n_drops/delta.n_evts));
+		jmsg["delta"]["drop_pct"] = (delta.n_evts == 0 ? 0 : (100.0*delta.n_drops/delta.n_evts));
 		m_output << jmsg.dump() << endl;
 
 		m_last_stats = cstats;

--- a/userspace/falco/statsfilewriter.cpp
+++ b/userspace/falco/statsfilewriter.cpp
@@ -30,8 +30,6 @@ static void timer_handler (int signum)
 	g_save_stats = true;
 }
 
-extern char **environ;
-
 StatsFileWriter::StatsFileWriter()
 	: m_num_stats(0)
 {
@@ -69,30 +67,6 @@ bool StatsFileWriter::init(std::shared_ptr<sinsp> inspector, string &filename, u
 		return false;
 	}
 
-	// (Undocumented) feature. Take any environment keys prefixed
-	// with FALCO_STATS_EXTRA_XXX and add them to the output. Used by
-	// run_performance_tests.sh.
-	for(uint32_t i=0; environ[i]; i++)
-	{
-		char *p = strstr(environ[i], "=");
-		if(!p)
-		{
-			errstr = string("Could not find environment separator in ") + string(environ[i]);
-			return false;
-		}
-		string key(environ[i], p-environ[i]);
-		string val(p+1, strlen(environ[i])-(p-environ[i])-1);
-		if(key.compare(0, 18, "FALCO_STATS_EXTRA_") == 0)
-		{
-			string sub = key.substr(18);
-			if (m_extra != "")
-			{
-				m_extra += ", ";
-			}
-			m_extra += "\"" + sub + "\": " + "\"" + val + "\"";
-		}
-	}
-
 	return true;
 }
 
@@ -122,10 +96,6 @@ void StatsFileWriter::handle()
 		try
 		{
 			jmsg["sample"] = m_num_stats;
-			if(m_extra != "")
-			{
-				jmsg["extra"] = m_extra;
-			}
 			jmsg["cur"]["events"] = cstats.n_evts;
 			jmsg["cur"]["drops"] = cstats.n_drops;
 			jmsg["cur"]["preemptions"] = cstats.n_preemptions;

--- a/userspace/falco/statsfilewriter.h
+++ b/userspace/falco/statsfilewriter.h
@@ -43,6 +43,5 @@ protected:
 	uint32_t m_num_stats;
 	std::shared_ptr<sinsp> m_inspector;
 	std::ofstream m_output;
-	std::string m_extra;
 	scap_stats m_last_stats;
 };


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Looking at this [PR]() from @shane-lawrence I thought that we need a little bit of cleanup here, and moreover, it could be useful to have the `drop_percentage` computed on the global statistics and not only on the delta. I used the `nlohmann json` library just to simplify the output :) Let me know what you think about that 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new: add a `drop_pct` referred to the global number of events
```
