### PR TITLE
new: print some info about eBPF and enabled sources when Falco starts

### DIFF
--- a/userspace/falco/app_actions/init_falco_engine.cpp
+++ b/userspace/falco/app_actions/init_falco_engine.cpp
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <sstream>
+
 #include "application.h"
 
 using namespace falco::app;
@@ -88,6 +90,13 @@ application::run_result application::init_falco_engine()
 	{
 		return run_result::fatal("At least one event source needs to be enabled");
 	}
+
+	/* Print all enabled sources. */
+	std::ostringstream os;
+	std::copy(m_state->enabled_sources.begin(), m_state->enabled_sources.end(), std::ostream_iterator<std::string>(os, ","));
+	std::string result = os.str();
+	result.pop_back();
+	falco_logger::log(LOG_INFO, "Enabled sources: " + result + "\n");
 
 	m_state->engine->set_min_priority(m_state->config->m_min_priority);
 

--- a/userspace/falco/app_actions/open_inspector.cpp
+++ b/userspace/falco/app_actions/open_inspector.cpp
@@ -83,6 +83,14 @@ application::run_result application::open_inspector()
 		}
 	}
 
+	/// TODO: we can add a method to the inspector that tells us what 
+	/// is the underline engine used. Right now we print something only 
+	/// in case of BPF engine
+	if(m_state->inspector->is_bpf_enabled())
+	{
+		falco_logger::log(LOG_INFO, "Falco is using the BPF probe\n");	
+	}
+
 	// This must be done after the open
 	if(!m_options.all_events)
 	{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR allows Falco to print some info when it starts:

* Which are the event sources enabled (maybe more than one in the next future)
* If Falco is using the BPF probe (as I wrote in the TODO we can extend this to every `scap` engine)

This is a possible output:

```
Sat Jul 16 10:23:11 2022: Falco version 0.32.1-14+ac9cd6d
Sat Jul 16 10:23:11 2022: Falco initialized with configuration file ../falco.yaml
Sat Jul 16 10:23:11 2022: Enabled sources: syscall
Sat Jul 16 10:23:11 2022: Loading rules from file ../rules/falco_rules.yaml
Sat Jul 16 10:23:11 2022: Starting internal webserver, listening on port 8765
Sat Jul 16 10:23:11 2022: Falco is using the BPF probe
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new: print some info about eBPF and enabled sources when Falco starts
```
