### PR TITLE
cleanup(scripts): cleanup systemd unit in DEB + RPM packages

### DIFF
--- a/scripts/debian/postinst.in
+++ b/scripts/debian/postinst.in
@@ -41,3 +41,34 @@ case "$1" in
 		fi
 	;;
 esac
+
+# Based off what debhelper dh_systemd_enable/13.3.4 would have added
+# ref: https://www.debian.org/doc/manuals/debmake-doc/ch05.en.html#debhelper
+
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+        # This will only remove masks created by d-s-h on package removal.
+        deb-systemd-helper unmask 'falco.service' >/dev/null || true
+
+        # was-enabled defaults to true, so new installations run enable.
+        if deb-systemd-helper --quiet was-enabled 'falco.service'; then
+                # Enables the unit on first installation, creates new
+                # symlinks on upgrades if the unit file has changed.
+                deb-systemd-helper enable 'falco.service' >/dev/null || true
+        else
+                # Update the statefile to add new symlinks (if any), which need to be
+                # cleaned up on purge. Also remove old symlinks.
+                deb-systemd-helper update-state 'falco.service' >/dev/null || true
+        fi
+fi
+
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+        if [ -d /run/systemd/system ]; then
+                systemctl --system daemon-reload >/dev/null || true
+                if [ -n "$2" ]; then
+                        _dh_action=restart
+                else
+                        _dh_action=start
+                fi
+                deb-systemd-invoke $_dh_action 'falco.service' >/dev/null || true
+        fi
+fi

--- a/scripts/debian/postrm.in
+++ b/scripts/debian/postrm.in
@@ -15,3 +15,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# Based off what debhelper dh_systemd_enable/13.3.4 would have added
+# ref: https://www.debian.org/doc/manuals/debmake-doc/ch05.en.html#debhelper
+
+set -e
+
+if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
+        systemctl --system daemon-reload >/dev/null || true
+fi
+
+if [ "$1" = "remove" ]; then
+        if [ -x "/usr/bin/deb-systemd-helper" ]; then
+                deb-systemd-helper mask 'falco.service' >/dev/null || true
+        fi
+fi
+
+if [ "$1" = "purge" ]; then
+        if [ -x "/usr/bin/deb-systemd-helper" ]; then
+                deb-systemd-helper purge 'falco.service' >/dev/null || true
+                deb-systemd-helper unmask 'falco.service' >/dev/null || true
+        fi
+fi

--- a/scripts/debian/prerm.in
+++ b/scripts/debian/prerm.in
@@ -17,6 +17,14 @@
 #
 set -e
 
+# Based off what debhelper dh_systemd_enable/13.3.4 would have added
+# ref: https://www.debian.org/doc/manuals/debmake-doc/ch05.en.html#debhelper
+# Currently running falco service uses the driver, so stop it before driver cleanup
+
+if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
+        deb-systemd-invoke stop 'falco.service' >/dev/null || true
+fi
+
 case "$1" in
 	remove|upgrade|deconfigure)
 		/usr/bin/falco-driver-loader --clean

--- a/scripts/rpm/postinstall.in
+++ b/scripts/rpm/postinstall.in
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+set -e
 
 mod_version="@DRIVER_VERSION@"
 dkms add -m falco -v $mod_version --rpm_safe_upgrade
@@ -28,4 +29,36 @@ else
 	echo -e ""
 	echo -e "Module build for the currently running kernel was skipped since the"
 	echo -e "kernel source for this kernel does not seem to be installed."
+fi
+
+# validate rpm macros by `rpm -qp --scripts <rpm>`
+# RPM scriptlets: https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_systemd
+#                 https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
+
+# systemd_post macro expands to
+# if postinst:
+#   `systemd-update-helper install-system-units <service>`
+%systemd_post 'falco.service'
+
+# post install mirrored from .deb
+if [ $1 -eq 1 ]; then
+        # This will only remove masks created on package removal.
+        /usr/bin/systemctl --system unmask 'falco.service' >/dev/null || true
+
+        # enable falco on installation
+        # note: DEB postinstall script checks for changed symlinks
+        /usr/bin/systemctl --system enable 'falco.service' >/dev/null || true
+
+        # start falco on installation
+        /usr/bin/systemctl --system start 'falco.service' >/dev/null || true
+fi
+
+# post upgrade mirrored from .deb
+if [ $1 -gt 1 ]; then
+    if [ -d /run/systemd/system ]; then
+        /usr/bin/systemctl --system daemon-reload >/dev/null || true
+
+        # restart falco on upgrade if service is already running
+        /usr/bin/systemctl --system condrestart 'falco.service' >/dev/null || true
+    fi
 fi

--- a/scripts/rpm/postuninstall.in
+++ b/scripts/rpm/postuninstall.in
@@ -14,3 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+set -e
+
+# post uninstall mirrored from .deb
+if [ -d /run/systemd/system ] && [ "$1" = 0 ]; then
+        /usr/bin/systemctl --system daemon-reload >/dev/null || true
+        /usr/bin/systemctl --system mask 'falco.service' >/dev/null || true
+fi
+
+# validate rpm macros by `rpm -qp --scripts <rpm>`
+# RPM scriptlets: https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_systemd
+#                 https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
+
+# systemd_postun_with_restart macro expands to
+# if package upgrade, not uninstall:
+#   `systemd-update-helper mark-restart-system-units <service>`
+%systemd_postun_with_restart 'falco.service'

--- a/scripts/rpm/preuninstall.in
+++ b/scripts/rpm/preuninstall.in
@@ -14,5 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+set -e
+
+# pre uninstall mirrored from .deb
+# Currently running falco service uses the driver, so stop it before driver cleanup
+if [ -d /run/systemd/system ] && [ $1 -eq 0 ]; then
+        # stop falco service before uninstall
+        /usr/bin/systemctl --system stop 'falco.service' >/dev/null || true
+fi
 
 /usr/bin/falco-driver-loader --clean
+
+# validate rpm macros by `rpm -qp --scripts <rpm>`
+# RPM scriptlets: https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_systemd
+#                 https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
+
+# systemd_preun macro expands to
+# if preuninstall:
+#  `systemd-update-helper remove-system-units <service>`
+%systemd_preun 'falco.service'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area build

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR builds off the work introduced in #1448, which converted Falco's initscripts to a systemd unit. 

Currently, when removing, reinstalling, and/or upgrading the Falco package via DEB or RPM, the systemd unit file can be left in an unhygienic state and the user needs to perform a `sudo systemctl daemon-reload`.

This change re-introduces the falco service cleanup that the DEB and RPM packages perform for it's systemd unit when (re)installing and removing the packages.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

* This change is in WIP at the moment, as the RPM-equivalent changes have not been committed

**Does this PR introduce a user-facing change?**: Yes

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
falco.service systemd unit is now cleaned-up during (re)install and removal via the DEB and RPM packages
```
