### PR TITLE
refactor(userspace/falco)!: make output rate limiter optional and output engine explicitly thread-safe

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -190,16 +190,14 @@ output_timeout: 2000
 # rate of falco notifications. This throttling is controlled by the following configuration
 # options:
 #  - rate: the number of tokens (i.e. right to send a notification)
-#    gained per second. Defaults to 1.
+#    gained per second. When 0, the throttling mechanism is disabled.
+#    Defaults to 0.
 #  - max_burst: the maximum number of tokens outstanding. Defaults to 1000.
 #
-# With these defaults, falco could send up to 1000 notifications after
-# an initial quiet period, and then up to 1 notification per second
-# afterward. It would gain the full burst back after 1000 seconds of
-# no activity.
+# With these defaults, the throttling mechanism is disabled.
 
 outputs:
-  rate: 1
+  rate: 0
   max_burst: 1000
 
 # Where security notifications should go.

--- a/falco.yaml
+++ b/falco.yaml
@@ -187,14 +187,19 @@ syscall_event_timeouts:
 output_timeout: 2000
 
 # A throttling mechanism implemented as a token bucket limits the
-# rate of falco notifications. This throttling is controlled by the following configuration
-# options:
+# rate of Falco notifications. One rate limiter is assigned to each event
+# source, so that alerts coming from one can't influence the throttling
+# mechanism of the others. This is controlled by the following options:
 #  - rate: the number of tokens (i.e. right to send a notification)
 #    gained per second. When 0, the throttling mechanism is disabled.
 #    Defaults to 0.
 #  - max_burst: the maximum number of tokens outstanding. Defaults to 1000.
 #
 # With these defaults, the throttling mechanism is disabled.
+# For example, by setting rate to 1 Falco could send up to 1000 notifications
+# after an initial quiet period, and then up to 1 notification per second
+# afterward. It would gain the full burst back after 1000 seconds of
+# no activity.
 
 outputs:
   rate: 0

--- a/userspace/falco/app_actions/init_outputs.cpp
+++ b/userspace/falco/app_actions/init_outputs.cpp
@@ -40,20 +40,17 @@ application::run_result application::init_outputs()
 		hostname = c_hostname;
 	}
 
-	m_state->outputs->init(m_state->engine,
-			      m_state->config->m_json_output,
-			      m_state->config->m_json_include_output_property,
-			      m_state->config->m_json_include_tags_property,
-			      m_state->config->m_output_timeout,
-			      m_state->config->m_notifications_rate, m_state->config->m_notifications_max_burst,
-			      m_state->config->m_buffered_outputs,
-			      m_state->config->m_time_format_iso_8601,
-			      hostname);
-
-	for(auto output : m_state->config->m_outputs)
-	{
-		m_state->outputs->add_output(output);
-	}
+	m_state->outputs.reset(new falco_outputs(
+		m_state->engine,
+		m_state->config->m_outputs,
+		m_state->config->m_json_output,
+		m_state->config->m_json_include_output_property,
+		m_state->config->m_json_include_tags_property,
+		m_state->config->m_output_timeout,
+		m_state->config->m_notifications_rate, m_state->config->m_notifications_max_burst,
+		m_state->config->m_buffered_outputs,
+		m_state->config->m_time_format_iso_8601,
+		hostname));
 
 	return run_result::ok();
 }

--- a/userspace/falco/app_actions/init_outputs.cpp
+++ b/userspace/falco/app_actions/init_outputs.cpp
@@ -47,7 +47,6 @@ application::run_result application::init_outputs()
 		m_state->config->m_json_include_output_property,
 		m_state->config->m_json_include_tags_property,
 		m_state->config->m_output_timeout,
-		m_state->config->m_notifications_rate, m_state->config->m_notifications_max_burst,
 		m_state->config->m_buffered_outputs,
 		m_state->config->m_time_format_iso_8601,
 		hostname));

--- a/userspace/falco/application.cpp
+++ b/userspace/falco/application.cpp
@@ -45,9 +45,9 @@ application::state::state()
 	  enabled_sources({falco_common::syscall_source})
 {
 	config = std::make_shared<falco_configuration>();
-	outputs = std::make_shared<falco_outputs>();
 	engine = std::make_shared<falco_engine>();
 	inspector = std::make_shared<sinsp>();
+	outputs = nullptr;
 }
 
 application::state::~state()

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -191,7 +191,7 @@ void falco_configuration::init(string conf_filename, const vector<string> &cmdli
 
 	m_output_timeout = m_config->get_scalar<uint32_t>("output_timeout", 2000);
 
-	m_notifications_rate = m_config->get_scalar<uint32_t>("outputs.rate", 1);
+	m_notifications_rate = m_config->get_scalar<uint32_t>("outputs.rate", 0);
 	m_notifications_max_burst = m_config->get_scalar<uint32_t>("outputs.max_burst", 1000);
 
 	string priority = m_config->get_scalar<string>("priority", "debug");

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -39,6 +39,8 @@ limitations under the License.
 
 using namespace std;
 
+static const char* s_internal_source = "internal";
+
 falco_outputs::falco_outputs(
 	std::shared_ptr<falco_engine> engine,
 	const std::vector<falco::outputs::config>& outputs,
@@ -61,6 +63,8 @@ falco_outputs::falco_outputs(
 	m_buffered = buffered;
 	m_time_format_iso_8601 = time_format_iso_8601;
 	m_hostname = hostname;
+	m_token_bucket_rate = rate;
+	m_token_bucket_max_burst = max_burst;
 
 	for(const auto& output : outputs)
 	{
@@ -166,7 +170,7 @@ void falco_outputs::handle_msg(uint64_t ts,
 	falco_outputs::ctrl_msg cmsg = {};
 	cmsg.ts = ts;
 	cmsg.priority = priority;
-	cmsg.source = "internal";
+	cmsg.source = s_internal_source;
 	cmsg.rule = rule;
 	cmsg.fields = output_fields;
 
@@ -254,6 +258,27 @@ inline void falco_outputs::push(ctrl_msg_type cmt)
 	m_queue.push(cmsg);
 }
 
+bool falco_outputs::should_throttle(const ctrl_msg& msg)
+{
+	// note: "internal" alerts are not rate limited at this level
+	if (m_token_bucket_rate != 0 && strcmp(msg.source.c_str(), s_internal_source) != 0)
+	{
+		// note: there is one token bucket for each event source
+		auto it = m_token_buckets.find(msg.source);
+		if (it == m_token_buckets.end())
+		{
+			m_token_buckets.insert({msg.source, token_bucket()});
+			it = m_token_buckets.find(msg.source);
+			it->second.init(m_token_bucket_rate, m_token_bucket_max_burst);
+		}
+		if(!it->second.claim())
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
 // todo(leogr,leodido): this function is not supposed to throw exceptions, and with "noexcept",
 // the program is terminated if that occurs. Although that's the wanted behavior,
 // we still need to improve the error reporting since some inner functions can throw exceptions.
@@ -280,7 +305,14 @@ void falco_outputs::worker() noexcept
 				switch(cmsg.type)
 				{
 					case ctrl_msg_type::CTRL_MSG_OUTPUT:
-						o->output(&cmsg);
+						if(!should_throttle(cmsg))
+						{
+							o->output(&cmsg);
+						}
+						else
+						{
+							falco_logger::log(LOG_DEBUG, "Skipping rate-limited notification for rule " + cmsg.rule + "\n");
+						}
 						break;
 					case ctrl_msg_type::CTRL_MSG_CLEANUP:
 					case ctrl_msg_type::CTRL_MSG_STOP:

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -94,6 +94,9 @@ private:
 	bool m_time_format_iso_8601;
 	std::chrono::milliseconds m_timeout;
 	std::string m_hostname;
+	uint32_t m_token_bucket_rate;
+	uint32_t m_token_bucket_max_burst;
+	std::unordered_map<std::string, token_bucket> m_token_buckets;
 
 	enum ctrl_msg_type
 	{
@@ -117,4 +120,5 @@ private:
 	void worker() noexcept;
 	void stop_worker();
 	void add_output(falco::outputs::config oc);
+	bool should_throttle(const ctrl_msg& msg);
 };

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -21,7 +21,6 @@ limitations under the License.
 
 #include "gen_filter.h"
 #include "falco_common.h"
-#include "token_bucket.h"
 #include "falco_engine.h"
 #include "outputs.h"
 #include "formats.h"
@@ -46,8 +45,6 @@ public:
 		bool json_include_output_property,
 		bool json_include_tags_property,
 		uint32_t timeout,
-		uint32_t rate,
-		uint32_t max_burst, 
 		bool buffered,
 		bool time_format_iso_8601,
 		std::string hostname);
@@ -94,9 +91,6 @@ private:
 	bool m_time_format_iso_8601;
 	std::chrono::milliseconds m_timeout;
 	std::string m_hostname;
-	uint32_t m_token_bucket_rate;
-	uint32_t m_token_bucket_max_burst;
-	std::unordered_map<std::string, token_bucket> m_token_buckets;
 
 	enum ctrl_msg_type
 	{
@@ -120,5 +114,4 @@ private:
 	void worker() noexcept;
 	void stop_worker();
 	void add_output(falco::outputs::config oc);
-	bool should_throttle(const ctrl_msg& msg);
 };


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This is an alternative to https://github.com/falcosecurity/falco/pull/2080, that makes the token-bucket alert rate limiter optional by default. When enabled, the output framework now uses one token bucket for each inspector. Once we have multi-source support, alerts coming from one source won't influence the rate limiting of the others. At the same time, this will also be thread-safe because each thread will be own its own token bucket.

**Which issue(s) this PR fixes**:

Fixes #1333

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
refactor(userspace/falco): make output rate limiter optional and output engine explicitly thread-safe
update(falco.yaml)!: notification rate limiter disabled by default.
```
