### PR TITLE
new(userspace): support `SCAP_FILTERED_EVENT` return code

### DIFF
--- a/tests/engine/test_filter_evttype_resolver.cpp
+++ b/tests/engine/test_filter_evttype_resolver.cpp
@@ -75,8 +75,7 @@ TEST_CASE("Should find event types from filter", "[rule_loader]")
 	set<uint16_t> no_events;
     for(uint32_t i = 2; i < PPM_EVENT_MAX; i++)
     {
-        // Skip "old" event versions that have been replaced
-        // by newer event versions, or events that are unused.
+        // Skip events that are unused.
         if(g_infotables.m_event_info[i].flags & EF_UNUSED)
         {
             continue;

--- a/userspace/falco/app_actions/process_events.cpp
+++ b/userspace/falco/app_actions/process_events.cpp
@@ -123,6 +123,10 @@ application::run_result application::do_inspect(syscall_evt_drop_mgr &sdropmgr,
 
 			continue;
 		}
+		else if(rc == SCAP_FILTERED_EVENT)
+		{
+			continue;
+		}
 		else if(rc == SCAP_EOF)
 		{
 			break;


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

/area engine

**What this PR does / why we need it**:


As explained here https://github.com/falcosecurity/libs/pull/490 when the userspace chooses to filter an event now the libraries return `SCAP_FILTERED_EVENT`, so we need to manage it also in Falco.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
