### PR TITLE
Support condition parse errors in rule loading results

### DIFF
--- a/test/falco_tests.yaml
+++ b/test/falco_tests.yaml
@@ -285,7 +285,7 @@ trace_files: !mux
   invalid_not_yaml:
     exit_status: 1
     validate_errors:
-      - item_type: file
+      - item_type: rules content
         item_name: ""
         code: LOAD_ERR_YAML_VALIDATE
         message: "Rules content is not yaml"
@@ -296,7 +296,7 @@ trace_files: !mux
   invalid_not_array:
     exit_status: 1
     validate_errors:
-      - item_type: file
+      - item_type: rules content
         item_name: ""
         code: LOAD_ERR_YAML_VALIDATE
         message: "Rules content is not yaml array of objects"
@@ -307,7 +307,7 @@ trace_files: !mux
   invalid_array_item_not_object:
     exit_status: 1
     validate_errors:
-      - item_type: item
+      - item_type: rules content item
         item_name: ""
         code: LOAD_ERR_YAML_VALIDATE
         message: "Unexpected element type. Each element should be a yaml associative array."
@@ -329,7 +329,7 @@ trace_files: !mux
   invalid_yaml_parse_error:
     exit_status: 1
     validate_errors:
-      - item_type: file
+      - item_type: rules content
         item_name: ""
         code: LOAD_ERR_YAML_PARSE
         message: "yaml-cpp: error at line 1, column 11: illegal map value"

--- a/userspace/engine/rule_loader.h
+++ b/userspace/engine/rule_loader.h
@@ -33,9 +33,40 @@ limitations under the License.
 class rule_loader
 {
 public:
+
 	class context
 	{
 	public:
+		// The kinds of items that can be in rules
+		// content. These generally map to yaml items but a
+		// few are more specific (e.g. "within condition
+		// expression", "value for yaml node", etc.)
+		enum item_type {
+			VALUE_FOR = 0,
+			EXCEPTIONS,
+			EXCEPTION,
+			EXCEPTION_VALUES,
+			EXCEPTION_VALUE,
+			RULES_CONTENT,
+			RULES_CONTENT_ITEM,
+			REQUIRED_ENGINE_VERSION,
+			REQUIRED_PLUGIN_VERSIONS,
+			REQUIRED_PLUGIN_VERSIONS_ENTRY,
+			REQUIRED_PLUGIN_VERSIONS_ALTERNATIVE,
+			LIST,
+			LIST_ITEM,
+			MACRO,
+			MACRO_CONDITION,
+			RULE,
+			RULE_CONDITION,
+			CONDITION_EXPRESSION,
+			RULE_OUTPUT,
+			RULE_OUTPUT_EXPRESSION,
+			RULE_PRIORITY
+		};
+
+		static const std::string& item_type_as_string(enum item_type it);
+
 		static const size_t default_snippet_width = 160;
 
 		struct position
@@ -61,7 +92,7 @@ public:
 
 			// The kind of item at this location
 			// (e.g. "list", "macro", "rule", "exception", etc)
-			std::string item_type;
+			context::item_type item_type;
 
 			// The name of this item (e.g. "Write Below Etc",
 			// etc).
@@ -70,7 +101,7 @@ public:
 
 		context(const std::string& name);
 		context(const YAML::Node& item,
-			const std::string item_type,
+			item_type item_type,
 			const std::string item_name,
 			const context& parent);
 
@@ -106,7 +137,7 @@ public:
 	private:
 		void init(const std::string& name,
 			  const position& pos,
-			  const std::string item_type,
+			  const item_type item_type,
 			  const std::string item_name,
 			  const context& parent);
 


### PR DESCRIPTION
In #2098, we reworked how rules loading errors/warnings were returned
to provide a richer set of information, including locations/context
for the errors/warnings.

That did *not* include locations within condition expressions,
though. When parsing a condition expression resulted in a
warning/error, the location simply pointed to the condition property
of the rule.

This commit improves this to handle parse errors:

- When libsinsp::filter::parser::parse() throws an exception, use
  get_pos() to get the position within the condition string.
- Add a new context() constructor that takes a filter pos_info instead
  of a YAML::Mark.

Doing this required some small changes to the context struct,
though. Previously, the name (e.g. yaml filename) was held separate
from the list of locations. However, condition strings don't directly
reflect any content in the yaml file. Yaml block scalars remove
whitespace/unwrap strings. Macro references/list references are
replaced with their contents.

To handle this, move the "name" (e.g. filename) from the context into
each location. This allows a chain of locations to start with file
positions but transition to offsets within a condition expression.

Also allow a context to contain an alternate content string which is
used to build the snippet. For contexts related to condition strings,
the content is the condition.

Finally, when printing snippets that contain very long lines (> a
static const 160 chars), instead of printing the entire line, print
the 160 chars surrounding the position.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Add better support for parse errors in rule conditions when displaying rule load errors.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
