### PR TITLE
fix: print full rule load errors/warnings without verbose/-v

### DIFF
--- a/userspace/falco/app_actions/load_rules_files.cpp
+++ b/userspace/falco/app_actions/load_rules_files.cpp
@@ -100,9 +100,7 @@ application::run_result application::load_rules_files()
 
 		res = m_state->engine->load_rules_file(filename);
 
-		// Print the full output if verbose is true
-		if(m_options.verbose &&
-		   (!res->successful() || res->has_warnings()))
+		if((!res->successful() || (m_options.verbose && res->has_warnings())))
 		{
 			printf("%s\n",
 			       (m_state->config->m_json_output ?

--- a/userspace/falco/app_actions/validate_rules_files.cpp
+++ b/userspace/falco/app_actions/validate_rules_files.cpp
@@ -56,9 +56,7 @@ application::run_result application::validate_rules_files()
 			}
 			else
 			{
-				// Print the full output when verbose is true
-				if(m_options.verbose &&
-				   (!res->successful() || res->has_warnings()))
+				if(!res->successful() || (m_options.verbose && res->has_warnings()))
 				{
 					printf("%s\n", res->as_string(true).c_str());
 				}


### PR DESCRIPTION
The latest released falco always prints full details on errors when
used with -r (read rules)/-V (validate rules). However #2098 changed
this to only print full details when verbose is true.

Fix the regression by always printing full details regardless of
verbose/-v.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area rules

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
