### PR TITLE
Remove Mesos support

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -511,7 +511,7 @@
 # %container.info, without any leading term (file=%fd.name
 # %container.info user=%user.name user_loginuid=%user.loginuid, and not file=%fd.name
 # container=%container.info user=%user.name user_loginuid=%user.loginuid). The output will change
-# based on the context and whether or not -pk/-pm/-pc was specified on
+# based on the context and whether or not -pk/-pc was specified on
 # the command line.
 - macro: container
   condition: (container.id != host)

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -145,7 +145,7 @@ public:
 	// of all output expressions. You can also choose to replace
 	// %container.info with the extra information or add it to the
 	// end of the expression. This is used in open source falco to
-	// add k8s/mesos/container information to outputs when
+	// add k8s/container information to outputs when
 	// available.
 	//
 	void set_extra(string &extra, bool replace_container_info);

--- a/userspace/falco/app_actions/init_clients.cpp
+++ b/userspace/falco/app_actions/init_clients.cpp
@@ -21,7 +21,7 @@ using namespace falco::app;
 application::run_result application::init_clients()
 {
 #ifndef MINIMAL_BUILD
-	// k8s and mesos clients are useful only if syscall source is enabled
+	// k8s clients is useful only if syscall source is enabled
 	if (!is_syscall_source_enabled())
 	{
 		return run_result::ok();
@@ -54,23 +54,6 @@ application::run_result application::init_clients()
 			}
 		}
 		m_state->inspector->init_k8s_client(k8s_api_ptr, k8s_api_cert_ptr, k8s_node_name_ptr, m_options.verbose);
-	}
-
-	//
-	// Run mesos, if required
-	//
-	if(!m_options.mesos_api.empty())
-	{
-		// Differs from init_k8s_client in that it
-		// passes a pointer but the inspector does
-		// *not* own it and does not use it after
-		// init_mesos_client() returns.
-		m_state->inspector->init_mesos_client(&(m_options.mesos_api), m_options.verbose);
-	}
-	else if(char* mesos_api_env = getenv("FALCO_MESOS_API"))
-	{
-		std::string mesos_api_copy = mesos_api_env;
-		m_state->inspector->init_mesos_client(&mesos_api_copy, m_options.verbose);
 	}
 #endif
 

--- a/userspace/falco/app_actions/init_clients.cpp
+++ b/userspace/falco/app_actions/init_clients.cpp
@@ -21,7 +21,7 @@ using namespace falco::app;
 application::run_result application::init_clients()
 {
 #ifndef MINIMAL_BUILD
-	// k8s clients is useful only if syscall source is enabled
+	// k8s client is useful only if the syscall source is enabled
 	if (!is_syscall_source_enabled())
 	{
 		return run_result::ok();

--- a/userspace/falco/app_actions/init_falco_engine.cpp
+++ b/userspace/falco/app_actions/init_falco_engine.cpp
@@ -35,11 +35,6 @@ void application::configure_output_format()
 		output_format = "k8s.ns=%k8s.ns.name k8s.pod=%k8s.pod.name container=%container.id";
 		replace_container_info = true;
 	}
-	else if(m_options.print_additional == "m" || m_options.print_additional == "mesos")
-	{
-		output_format = "task=%mesos.task.name container=%container.id";
-		replace_container_info = true;
-	}
 	else if(!m_options.print_additional.empty())
 	{
 		output_format = m_options.print_additional;

--- a/userspace/falco/app_cmdline_options.cpp
+++ b/userspace/falco/app_cmdline_options.cpp
@@ -181,15 +181,12 @@ void cmdline_options::define()
 #ifndef MUSL_OPTIMIZED
 		("list-plugins",                  "Print info on all loaded plugins and exit.", cxxopts::value(list_plugins)->default_value("false"))
 #endif
-#ifndef MINIMAL_BUILD
-		("m,mesos-api",                   "Enable Mesos support by connecting to the API server specified as argument. E.g. \"http://admin:password@127.0.0.1:5050\". Marathon url is optional and defaults to Mesos address, port 8080. The API servers can also be specified via the environment variable FALCO_MESOS_API.", cxxopts::value(mesos_api), "<url[,marathon_url]>")
-#endif
 		("M",                             "Stop collecting after <num_seconds> reached.", cxxopts::value(duration_to_tot)->default_value("0"), "<num_seconds>")
 		("markdown",                      "When used with --list/--list-syscall-events, print the content in Markdown format", cxxopts::value<bool>(markdown))
 		("N",                             "When used with --list, only print field names.", cxxopts::value(names_only)->default_value("false"))
 		("o,option",                      "Set the value of option <opt> to <val>. Overrides values in configuration file. <opt> can be identified using its location in configuration file using dot notation. Elements which are entries of lists can be accessed via square brackets [].\n    E.g. base.id = val\n         base.subvalue.subvalue2 = val\n         base.list[1]=val", cxxopts::value(cmdline_config_options), "<opt>=<val>")
 		("plugin-info",                   "Print info for a single plugin and exit.\nThis includes all descriptivo info like name and author, along with the\nschema format for the init configuration and a list of suggested open parameters.\n<plugin_name> can be the name of the plugin or its configured library_path.", cxxopts::value(print_plugin_info), "<plugin_name>")
-		("p,print",                       "Add additional information to each falco notification's output.\nWith -pc or -pcontainer will use a container-friendly format.\nWith -pk or -pkubernetes will use a kubernetes-friendly format.\nWith -pm or -pmesos will use a mesos-friendly format.\nAdditionally, specifying -pc/-pk/-pm will change the interpretation of %container.info in rule output fields.", cxxopts::value(print_additional), "<output_format>")
+		("p,print",                       "Add additional information to each falco notification's output.\nWith -pc or -pcontainer will use a container-friendly format.\nWith -pk or -pkubernetes will use a kubernetes-friendly format.\nAdditionally, specifying -pc/-pk will change the interpretation of %container.info in rule output fields.", cxxopts::value(print_additional), "<output_format>")
 		("P,pidfile",                     "When run as a daemon, write pid to specified file", cxxopts::value(pidfilename)->default_value("/var/run/falco.pid"), "<pid_file>")
 		("r",                             "Rules file/directory (defaults to value set in configuration file, or /etc/falco_rules.yaml). Can be specified multiple times to read from multiple files/directories.", cxxopts::value<std::vector<std::string>>(), "<rules_file>")
 		("s",                             "If specified, append statistics related to Falco's reading/processing of events to this file (only useful in live mode).", cxxopts::value(stats_filename), "<stats_file>")

--- a/userspace/falco/app_cmdline_options.h
+++ b/userspace/falco/app_cmdline_options.h
@@ -58,7 +58,6 @@ public:
 	std::string print_plugin_info;
 	bool list_syscall_events;
 	bool markdown;
-	std::string mesos_api;
 	int duration_to_tot;
 	bool names_only;
 	std::vector<std::string> cmdline_config_options;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Mesos had been introduced in the initial stages of Falco development. Afterward, it was never maintained and was rarely used by Falco users. As of today, we are not aware of any users or adopters using the Mesos support.

Behind the proposal of removing it, there're also other important aspects:
- there has not been any recent activity on the Mesos code (either in [Falco](https://github.com/falcosecurity/falco/search?q=mesos&type=code) and [libs](https://github.com/falcosecurity/libs/search?q=mesos&type=code))
- there have not been reported [issues](https://github.com/falcosecurity/falco/issues?q=is%3Aissue+is%3Aopen+mesos)
- there have not been discussions on Slack (I actually could not find any discussion)
- the support is not tested
- we are not sure if it's still fully working


**Special notes for your reviewer**:

/milestone 0.33.0

/hold
We want to gather some feedback on dropping the Mesos support before merging it.

**Does this PR introduce a user-facing change?**:

```release-note
update!: remove Mesos support
```
