### PR TITLE
Falco driver loader enhancements

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -235,7 +235,7 @@ load_kernel_module_download() {
 	get_target_id
 
 	local FALCO_KERNEL_MODULE_FILENAME="${DRIVER_NAME}_${TARGET_ID}_${KERNEL_RELEASE}_${KERNEL_VERSION}.ko"
-	local URL=$(echo "${DRIVERS_REPO}/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" | sed s/+/%2B/g)
+	local URL=$(echo "${1}/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" | sed s/+/%2B/g)
 
 	echo "* Trying to download a prebuilt ${DRIVER_NAME} module from ${URL}"
 	if curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" "${URL}"; then
@@ -367,7 +367,10 @@ load_kernel_module() {
 	fi
 
 	if [ -n "$ENABLE_DOWNLOAD" ]; then
-		load_kernel_module_download
+		IFS=", " read -r -a urls <<< "${DRIVERS_REPO}"
+		for url in "${urls[@]}"; do
+			load_kernel_module_download $url
+		done
 	fi
 
 	if [ -n "$ENABLE_COMPILE" ]; then
@@ -502,14 +505,15 @@ load_bpf_probe_compile() {
 
 load_bpf_probe_download() {
 	local URL
-	URL=$(echo "${DRIVERS_REPO}/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}" | sed s/+/%2B/g)
+	URL=$(echo "${1}/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}" | sed s/+/%2B/g)
 
 	echo "* Trying to download a prebuilt eBPF probe from ${URL}"
 
 	if ! curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}" "${URL}"; then
 		>&2 echo "Unable to find a prebuilt ${DRIVER_NAME} eBPF probe"
-		return
+		return 1
 	fi
+	return 0
 }
 
 load_bpf_probe() {
@@ -529,7 +533,13 @@ load_bpf_probe() {
 		if [ -f "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}" ]; then
 			echo "* Skipping download, eBPF probe is already present in ${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}"
 		else
-			load_bpf_probe_download
+			IFS=", " read -r -a urls <<< "${DRIVERS_REPO}"
+			for url in "${urls[@]}"; do
+				load_bpf_probe_download $url
+				if [ $? -eq 0 ]; then
+                	break
+                fi
+			done
 		fi
 	fi
 
@@ -570,7 +580,7 @@ print_usage() {
 	echo "  --source-only  skip execution and allow sourcing in another script"
 	echo ""
 	echo "Environment variables:"
-	echo "  DRIVERS_REPO             specify a different URL where to look for prebuilt Falco drivers"
+	echo "  DRIVERS_REPO             specify different URL(s) where to look for prebuilt Falco drivers (comma separated)"
 	echo "  DRIVER_NAME              specify a different name for the driver"
 	echo "  DRIVER_INSECURE_DOWNLOAD whether you want to allow insecure downloads or not"
 	echo ""

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -238,10 +238,10 @@ load_kernel_module_download() {
 	local URL=$(echo "${DRIVERS_REPO}/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" | sed s/+/%2B/g)
 
 	echo "* Trying to download a prebuilt ${DRIVER_NAME} module from ${URL}"
-	if curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" "${URL}"; then
+	if curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" "${URL}"; then
 		echo "* Download succeeded"
-		chcon -t modules_object_t "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" > /dev/null 2>&1 || true
-		if insmod "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}"; then
+		chcon -t modules_object_t "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" > /dev/null 2>&1 || true
+		if insmod "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}"; then
 			echo "* Success: ${DRIVER_NAME} module found and inserted"
 			exit 0
 		else
@@ -359,10 +359,10 @@ load_kernel_module() {
 	echo "* Filename '${FALCO_KERNEL_MODULE_FILENAME}' is composed of:"
 	print_filename_components
 
-	if [ -f "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" ]; then
-		echo "* Found a prebuilt ${DRIVER_NAME} module at ${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}, loading it"
-		chcon -t modules_object_t "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" > /dev/null 2>&1 || true
-		insmod "${HOME}/.falco/${FALCO_KERNEL_MODULE_FILENAME}" && echo "* Success: ${DRIVER_NAME} module found and inserted"
+	if [ -f "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" ]; then
+		echo "* Found a prebuilt ${DRIVER_NAME} module at ${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}, loading it"
+		chcon -t modules_object_t "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" > /dev/null 2>&1 || true
+		insmod "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" && echo "* Success: ${DRIVER_NAME} module found and inserted"
 		exit $?
 	fi
 
@@ -491,8 +491,8 @@ load_bpf_probe_compile() {
 
 	make -C "/usr/src/${DRIVER_NAME}-${DRIVER_VERSION}/bpf" > /dev/null
 
-	mkdir -p "${HOME}/.falco"
-	mv "/usr/src/${DRIVER_NAME}-${DRIVER_VERSION}/bpf/probe.o" "${HOME}/.falco/${BPF_PROBE_FILENAME}"
+	mkdir -p "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}"
+	mv "/usr/src/${DRIVER_NAME}-${DRIVER_VERSION}/bpf/probe.o" "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}"
 
 	if [ -n "${BPF_KERNEL_SOURCES_URL}" ]; then
 		rm -r /tmp/kernel
@@ -506,7 +506,7 @@ load_bpf_probe_download() {
 
 	echo "* Trying to download a prebuilt eBPF probe from ${URL}"
 
-	if ! curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${BPF_PROBE_FILENAME}" "${URL}"; then
+	if ! curl -L --create-dirs "${FALCO_DRIVER_CURL_OPTIONS}" -o "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}" "${URL}"; then
 		>&2 echo "Unable to find a prebuilt ${DRIVER_NAME} eBPF probe"
 		return
 	fi
@@ -526,25 +526,25 @@ load_bpf_probe() {
 	print_filename_components
 
 	if [ -n "$ENABLE_DOWNLOAD" ]; then
-		if [ -f "${HOME}/.falco/${BPF_PROBE_FILENAME}" ]; then
-			echo "* Skipping download, eBPF probe is already present in ${HOME}/.falco/${BPF_PROBE_FILENAME}"
+		if [ -f "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}" ]; then
+			echo "* Skipping download, eBPF probe is already present in ${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}"
 		else
 			load_bpf_probe_download
 		fi
 	fi
 
 	if [ -n "$ENABLE_COMPILE" ]; then
-		if [ -f "${HOME}/.falco/${BPF_PROBE_FILENAME}" ]; then
-			echo "* Skipping compilation, eBPF probe is already present in ${HOME}/.falco/${BPF_PROBE_FILENAME}"
+		if [ -f "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}" ]; then
+			echo "* Skipping compilation, eBPF probe is already present in ${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}"
 		else
 			load_bpf_probe_compile
 		fi
 	fi
 
-	if [ -f "${HOME}/.falco/${BPF_PROBE_FILENAME}" ]; then
-		echo "* eBPF probe located in ${HOME}/.falco/${BPF_PROBE_FILENAME}"
+	if [ -f "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}" ]; then
+		echo "* eBPF probe located in ${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}"
 
-		ln -sf "${HOME}/.falco/${BPF_PROBE_FILENAME}" "${HOME}/.falco/${DRIVER_NAME}-bpf.o" \
+		ln -sf "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${BPF_PROBE_FILENAME}" "${HOME}/.falco/${DRIVER_NAME}-bpf.o" \
 			&& echo "* Success: eBPF probe symlinked to ${HOME}/.falco/${DRIVER_NAME}-bpf.o"
 		exit $?
 	else


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR introduces changes to the falco-driver-loader script.

 to support multiple download URLs in the DRIVERS_REPO environment variable, and to store downloaded drivers in a folder that mirrors the download directory.

The DRIVERS_REPO environment variable can now be used to specify multiple download URLs by separating individual URLs by a comma. URLs will be attempted in order from first to last as specified. Once a successful download has been performed (per a successful result code from curl), any remaining URLs will not be attempted. This will allow, for example, users to specify their own custom driver repo URL without having to duplicate those that are already available in the standard downloads.falco.org repo. 

Example: 

DRIVERS_REPO="https://myrepo.mycompany.com/mydrivers,https://download.falco.org/driver"

When storing downloaded drivers, falco-driver-loader previously stored these under /root/.falco/. However, falco-driver-loader could load a mismatched DRIVER_VERSION kernel module or eBPF probe as there was no identifying information relating to the locally-stored driver. These drivers will now be stored under /root/.falco/${DRIVER_VERSION}/${ARCH}/, which exactly mirrors the download URL that is constructed. Thus, there is parity between the locally-stored download location and the download path. While preventing mismatched driver versions with Falco, this also provides the advantage of allowing users to pre-load drivers by placing these kernel modules and eBPF probes directly on disk through a distribution mechanism other than DRIVERS_REPO. 

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(falco-driver-loader): `DRIVERS_REPO` now supports the use of multiple download URLs (comma separated)
```
