### PR TITLE
fix(CI): codespell should ignore `ro` word

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,3 +1,4 @@
 aks
 creat
 chage
+ro

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -11,4 +11,4 @@ jobs:
         skip: .git
         ignore_words_file: .codespellignore
         check_filenames: true
-        check_hidden: true
+        check_hidden: false


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

The read-only acronym (`ro`)  is considered a typo by `codespell`, we now ignore it.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
