### PR TITLE
new(userspace/falco): create grpc unix socket and gvisor endpoint path automatically

### DIFF
--- a/userspace/falco/CMakeLists.txt
+++ b/userspace/falco/CMakeLists.txt
@@ -41,6 +41,7 @@ set(
   app_actions/start_grpc_server.cpp
   app_actions/start_webserver.cpp
   app_actions/validate_rules_files.cpp
+  app_actions/create_requested_paths.cpp
   configuration.cpp
   logger.cpp
   falco_outputs.cpp

--- a/userspace/falco/app_actions/create_requested_paths.cpp
+++ b/userspace/falco/app_actions/create_requested_paths.cpp
@@ -18,6 +18,14 @@ limitations under the License.
 #include "falco_utils.h"
 #include <sys/stat.h>
 
+#ifndef CPPPATH_SEP
+#ifdef _MSC_VER
+#define CPPPATH_SEP "\\"
+#else
+#define CPPPATH_SEP "/"
+#endif
+#endif
+
 using namespace falco::app;
 
 application::run_result application::create_requested_paths()
@@ -91,8 +99,8 @@ int application::create_dir(const std::string &path)
 	// Examples:
 	// "/tmp/foo/bar" -> "", "tmp", "foo" -> mkdir("/") + mkdir("/tmp/") + midir("/tmp/foo/")
 	// "tmp/foo/bar" -> "tmp", "foo" -> mkdir("tmp/") + midir("tmp/foo/")
-	while (getline(f, s, '/') && !f.eof()) {
-		path_until_token += s + "/";
+	while (getline(f, s, *CPPPATH_SEP) && !f.eof()) {
+		path_until_token += s + CPPPATH_SEP;
 		int ret = mkdir(path_until_token.c_str(), 0600);
 		if (ret != 0 && errno != EEXIST)
 		{

--- a/userspace/falco/app_actions/create_requested_paths.cpp
+++ b/userspace/falco/app_actions/create_requested_paths.cpp
@@ -1,0 +1,103 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "application.h"
+#include "falco_utils.h"
+#include <sys/stat.h>
+
+using namespace falco::app;
+
+application::run_result application::create_requested_paths()
+{
+	if(!m_options.gvisor_config.empty())
+	{
+		// This is bad: parsing gvisor config to get endpoint
+		// to be able to auto-create the path to the file for the user.
+		std::ifstream reader(m_options.gvisor_config);
+		if (reader.fail())
+		{
+			return run_result::fatal(m_options.gvisor_config + ": cannot open file.");
+		}
+
+		nlohmann::json parsed_json;
+		std::string gvisor_socket;
+		try
+		{
+			parsed_json = nlohmann::json::parse(reader);
+		}
+		catch (const std::exception &e)
+		{
+			return run_result::fatal(m_options.gvisor_config + ": cannot parse JSON: " + e.what());
+		}
+
+		try
+		{
+			gvisor_socket = parsed_json["trace_session"]["sinks"][0]["config"]["endpoint"];
+		}
+		catch (const std::exception &e)
+		{
+			return run_result::fatal(m_options.gvisor_config + ": failed to fetch config.endpoint: " + e.what());
+		}
+
+		int ret = create_dir(gvisor_socket);
+		if (ret != 0)
+		{
+			return run_result::fatal(gvisor_socket + ": " + strerror(errno));
+		}
+	}
+
+	if (!m_state->config->m_grpc_bind_address.empty())
+	{
+		if(falco::utils::network::is_unix_scheme(m_state->config->m_grpc_bind_address))
+		{
+			auto server_path = m_state->config->m_grpc_bind_address.substr(
+				falco::utils::network::UNIX_SCHEME.length()
+			);
+			int ret = create_dir(server_path);
+			if(ret != 0)
+			{
+				return run_result::fatal(server_path + ": " + strerror(errno));
+			}
+		}
+	}
+
+	// TODO: eventually other files written by Falco whose destination is
+	// customizable by users, must be handled here.
+	return run_result::ok();
+}
+
+int application::create_dir(const std::string &path)
+{
+	// Properly reset errno
+	errno = 0;
+
+	istringstream f(path);
+	string path_until_token;
+	string s;
+	// Create all the subfolder stopping at last token (f.eof());
+	// Examples:
+	// "/tmp/foo/bar" -> "", "tmp", "foo" -> mkdir("/") + mkdir("/tmp/") + midir("/tmp/foo/")
+	// "tmp/foo/bar" -> "tmp", "foo" -> mkdir("tmp/") + midir("tmp/foo/")
+	while (getline(f, s, '/') && !f.eof()) {
+		path_until_token += s + "/";
+		int ret = mkdir(path_until_token.c_str(), 0600);
+		if (ret != 0 && errno != EEXIST)
+		{
+			return ret;
+		}
+	}
+	return 0;
+}

--- a/userspace/falco/application.cpp
+++ b/userspace/falco/application.cpp
@@ -132,6 +132,7 @@ bool application::run(std::string &errstr, bool &restart)
 		std::bind(&application::print_syscall_events, this),
 		std::bind(&application::create_signal_handlers, this),
 		std::bind(&application::load_config, this),
+		std::bind(&application::create_requested_paths, this),
 		std::bind(&application::print_plugin_info, this),
 		std::bind(&application::list_plugins, this),
 		std::bind(&application::init_inspector, this),

--- a/userspace/falco/application.h
+++ b/userspace/falco/application.h
@@ -193,6 +193,7 @@ private:
 	run_result load_config();
 	run_result load_plugins();
 	run_result load_rules_files();
+	run_result create_requested_paths();
 	run_result open_inspector();
 	run_result print_generated_gvisor_config();
 	run_result print_help();
@@ -219,6 +220,7 @@ private:
 #endif
 
 	// Methods called by the above methods
+	int create_dir(const std::string &path);
 	bool create_handler(int sig, void (*func)(int), run_result &ret);
 	void configure_output_format();
 	void check_for_ignored_events();


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

It is also able to handle multipart paths, like /run/falco/falco/falco/falco.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new(userspace/falco): automatically create paths for grpc unix socket and gvisor endpoint.
```
