### PR TITLE
update(userspace/engine): support alternative plugin version requirements in checks

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(
   engine/test_filter_macro_resolver.cpp
   engine/test_filter_evttype_resolver.cpp
   engine/test_filter_warning_resolver.cpp
+  engine/test_plugin_requirements.cpp
   falco/test_configuration.cpp
 )
 

--- a/tests/engine/test_plugin_requirements.cpp
+++ b/tests/engine/test_plugin_requirements.cpp
@@ -1,0 +1,269 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <memory>
+#include <catch.hpp>
+#include "falco_engine.h"
+
+static void check_requirements(
+        bool expect_success,
+        const std::vector<falco_engine::plugin_version_requirement>& plugins,
+        const std::string& ruleset_content)
+{
+    std::string err;
+    std::unique_ptr<falco_engine> e(new falco_engine());
+    falco::load_result::rules_contents_t c = {{"test", ruleset_content}};
+
+    auto res = e->load_rules(c.begin()->second, c.begin()->first);
+    if (!res->successful())
+    {
+        if (expect_success)
+        {
+            FAIL(res->as_string(false, c));
+        }
+        return;
+    }
+
+    if (!e->check_plugin_requirements(plugins, err))
+    {
+        if (expect_success)
+        {
+            FAIL(err);
+        }
+    }
+    else if (!expect_success)
+    {
+        FAIL("unexpected successful plugin requirements check");
+    }
+}
+
+TEST_CASE("check_plugin_requirements must accept", "[rule_loader]")
+{
+    SECTION("no requirement")
+    {
+        check_requirements(true, {{"k8saudit", "0.1.0"}}, "");
+    }
+
+    SECTION("single plugin")
+    {
+        check_requirements(true, {{"k8saudit", "0.1.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.1.0
+        )");
+    }
+
+    SECTION("single plugin newer version")
+    {
+        check_requirements(true, {{"k8saudit", "0.2.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.1.0
+        )");
+    }
+
+    SECTION("multiple plugins")
+    {
+        check_requirements(true, {{"k8saudit", "0.1.0"}, {"json", "0.3.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.1.0
+  - name: json
+    version: 0.3.0
+        )");
+    }
+
+    SECTION("single plugin multiple versions")
+    {
+        check_requirements(true, {{"k8saudit", "0.2.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.1.0
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.2.0
+        )");
+    }
+
+    SECTION("single plugin with alternatives")
+    {
+        check_requirements(true, {{"k8saudit-other", "0.5.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.1.0
+    alternatives:
+      - name: k8saudit-other
+        version: 0.4.0
+        )");
+    }
+
+    SECTION("multiple plugins with alternatives")
+    {
+        check_requirements(true, {{"k8saudit-other", "0.5.0"}, {"json2", "0.5.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.1.0
+    alternatives:
+      - name: k8saudit-other
+        version: 0.4.0
+  - name: json
+    version: 0.3.0
+    alternatives:
+      - name: json2
+        version: 0.1.0
+        )");
+    }
+
+    SECTION("multiple plugins with alternatives with multiple versions")
+    {
+        check_requirements(true, {{"k8saudit-other", "0.7.0"}, {"json2", "0.5.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.1.0
+    alternatives:
+      - name: k8saudit-other
+        version: 0.4.0
+  - name: json
+    version: 0.3.0
+    alternatives:
+      - name: json2
+        version: 0.1.0
+- required_plugin_versions:
+  - name: k8saudit
+    version: 1.0.0
+    alternatives:
+      - name: k8saudit-other
+        version: 0.7.0
+        )");
+    }
+}
+
+TEST_CASE("check_plugin_requirements must reject", "[rule_loader]")
+{
+    SECTION("no plugin loaded")
+    {
+        check_requirements(false, {}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.1.0
+        )");
+    }
+    
+    SECTION("single plugin wrong name")
+    {
+        check_requirements(false, {{"k8saudit", "0.1.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit2
+    version: 0.1.0
+        )");
+    }
+
+    SECTION("single plugin wrong version")
+    {
+        check_requirements(false, {{"k8saudit", "0.1.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.2.0
+        )");
+    }
+
+    SECTION("multiple plugins")
+    {
+        check_requirements(false, {{"k8saudit", "0.1.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.1.0
+  - name: json
+    version: 0.3.0
+        )");
+    }
+
+    SECTION("single plugin multiple versions")
+    {
+        check_requirements(false, {{"k8saudit", "0.1.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.1.0
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.2.0
+        )");
+    }
+
+    SECTION("single plugin with alternatives")
+    {
+        check_requirements(false, {{"k8saudit2", "0.5.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.1.0
+    alternatives:
+      - name: k8saudit-other
+        version: 0.4.0
+        )");
+    }
+
+    SECTION("single plugin with overlapping alternatives")
+    {
+        check_requirements(false, {{"k8saudit", "0.5.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.1.0
+    alternatives:
+      - name: k8saudit
+        version: 0.4.0
+        )");
+    }
+
+    SECTION("multiple plugins with alternatives")
+    {
+        check_requirements(false, {{"k8saudit-other", "0.5.0"}, {"json3", "0.5.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.1.0
+    alternatives:
+      - name: k8saudit-other
+        version: 0.4.0
+  - name: json
+    version: 0.3.0
+    alternatives:
+      - name: json2
+        version: 0.1.0
+        )");
+    }
+
+    SECTION("multiple plugins with alternatives with multiple versions")
+    {
+        check_requirements(false, {{"k8saudit", "0.7.0"}, {"json2", "0.5.0"}}, R"(
+- required_plugin_versions:
+  - name: k8saudit
+    version: 0.4.0
+    alternatives:
+      - name: k8saudit-other
+        version: 0.4.0
+  - name: json
+    version: 0.3.0
+    alternatives:
+      - name: json2
+        version: 0.1.0
+- required_plugin_versions:
+  - name: k8saudit
+    version: 1.0.0
+    alternatives:
+      - name: k8saudit-other
+        version: 0.7.0
+        )");
+    }
+}

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -234,7 +234,7 @@ public:
 							      const std::string &output) const;
 
 	// The rule loader definition is aliased as it is exactly what we need
-	typedef rule_loader::plugin_version_info plugin_version_requirement;
+	typedef rule_loader::plugin_version_info::requirement plugin_version_requirement;
 
 	//
 	// Returns true if the provided list of plugins satisfies all the

--- a/userspace/engine/falco_engine_version.h
+++ b/userspace/engine/falco_engine_version.h
@@ -16,7 +16,7 @@ limitations under the License.
 
 // The version of rules/filter fields/etc supported by this Falco
 // engine.
-#define FALCO_ENGINE_VERSION (14)
+#define FALCO_ENGINE_VERSION (15)
 
 // This is the result of running "falco --list -N | sha256sum" and
 // represents the fields supported by this version of Falco. It's used

--- a/userspace/engine/rule_loader.h
+++ b/userspace/engine/rule_loader.h
@@ -182,6 +182,18 @@ public:
 	*/
 	struct plugin_version_info
 	{
+		struct requirement
+		{
+			requirement() = default;
+			requirement(const std::string n, const std::string v):
+				name(n), version(v) { }
+
+			std::string name;
+			std::string version;
+		};
+
+		typedef std::vector<requirement> requirement_alternatives;
+
 		// This differs from the other _info structs by having
 		// a default constructor. This allows it to be used
 		// by falco_engine, which aliases the type.
@@ -190,8 +202,7 @@ public:
 		~plugin_version_info() = default;
 
 		context ctx;
-		std::string name;
-		std::string version;
+		requirement_alternatives alternatives;
 	};
 
 	/*!
@@ -303,7 +314,7 @@ public:
 		\brief Returns the set of all required versions for each plugin according
 		to the internal definitions.
 	*/
-	virtual const std::map<std::string, std::set<std::string>> required_plugin_versions() const;
+	virtual const std::vector<plugin_version_info::requirement_alternatives>& required_plugin_versions() const;
 
 	/*!
 		\brief Defines an info block. If a similar info block is found
@@ -348,5 +359,5 @@ private:
 	indexed_vector<rule_info> m_rule_infos;
 	indexed_vector<macro_info> m_macro_infos;
 	indexed_vector<list_info> m_list_infos;
-	std::map<std::string, std::set<std::string>> m_required_plugin_versions;
+	std::vector<plugin_version_info::requirement_alternatives> m_required_plugin_versions;
 };


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

/area tests

**What this PR does / why we need it**:

This PR updates the rule engine to support multiple alternatives plugin version requirements definitions in rulesets. The problem was first mentioned in https://github.com/falcosecurity/plugins/pull/134#discussion_r935806326, and documented in the #2150 issue.

Given that a new feature is added, the rule engine version has been bumped (to v15). Moreover, unit tests have been introduced to make sure that the plugin version checks work as expected.

**Which issue(s) this PR fixes**:

Fixes #2150

**Special notes for your reviewer**:

In this proposal, rulesets will be able to support the following syntax:
```yaml
- required_plugin_versions:
  - name: k8saudit
    version: 0.1.0
    alternatives:
      - name: k8saudit-other
        version: 0.4.0
```

Here, `alternatives` represents a list of alternative plugin name-version pairs to be checked as alternatives to the primary one. Maintaining a primary plugin requirement definition, and making `alternatives` optional, allow backward compatibile definitions such as:
```yaml
- required_plugin_versions:
  - name: k8saudit
    version: 0.1.0
```

Given so, `required_plugin_versions` now implicitly defines a CNF ([Conjunctive Normal Form](https://en.wikipedia.org/wiki/Conjunctive_normal_form). Rulesets are correctly loaded if **all** the `required_plugin_versions` definitions are satisfied. Each entry is satisfied if **at least one** of its alternatives is satisfied.

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/engine): support alternative plugin version requirements in checks
```
