### PR TITLE
Add new rule that detect retrieving environment variables from /proc files

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3202,3 +3202,21 @@
 # Application rules have moved to application_rules.yaml. Please look
 # there if you want to enable them by adding to
 # falco_rules.local.yaml.
+
+- list: proc_environ_file_names
+  items: [/proc/self/environ, /proc/1/environ]
+
+- macro: proc_environ_files
+  condition: >
+    fd.name in (proc_environ_file_names)
+
+- rule: Read environment variable from /proc files
+  desc: An attempt to read process environment variables from /proc files
+  condition: >
+    container and open_read and proc_environ_files
+  enabled: true
+  output: >
+    Environment variables were retrieved from /proc files (user=%user.name user_loginuid=%user.loginuid program=%proc.name
+    command=%proc.cmdline file=%fd.name parent=%proc.pname gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] container_id=%container.id image=%container.image.repository)
+  priority: WARNING
+  tags: [filesystem, mitre_credential_access, mitre_discovery]

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3204,7 +3204,7 @@
 # falco_rules.local.yaml.
 
 - list: known_binaries_to_read_environment_variables_from_proc_files
-  items: [scsi_id]
+  items: [scsi_id, argoexec]
 
 - rule: Read environment variable from /proc files
   desc: An attempt to read process environment variables from /proc files

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3203,17 +3203,11 @@
 # there if you want to enable them by adding to
 # falco_rules.local.yaml.
 
-- list: proc_environ_file_names
-  items: [/proc/self/environ, /proc/1/environ]
-
-- macro: proc_environ_files
-  condition: >
-    fd.name in (proc_environ_file_names)
-
 - rule: Read environment variable from /proc files
   desc: An attempt to read process environment variables from /proc files
   condition: >
-    container and open_read and proc_environ_files
+    open_read and (fd.name glob /proc/*/environ)
+    and not proc.name in (systemctl, systemd-detect-, cloud-id)
   enabled: true
   output: >
     Environment variables were retrieved from /proc files (user=%user.name user_loginuid=%user.loginuid program=%proc.name

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3211,7 +3211,6 @@
   condition: >
     container and open_read and (fd.name glob /proc/*/environ)
     and not proc.name in (known_binaries_to_read_environment_variables_from_proc_files)
-  enabled: true
   output: >
     Environment variables were retrieved from /proc files (user=%user.name user_loginuid=%user.loginuid program=%proc.name
     command=%proc.cmdline file=%fd.name parent=%proc.pname gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] container_id=%container.id image=%container.image.repository)

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3209,7 +3209,7 @@
 - rule: Read environment variable from /proc files
   desc: An attempt to read process environment variables from /proc files
   condition: >
-    container and open_read and (fd.name glob /proc/*/environ)
+    open_read and container and (fd.name glob /proc/*/environ)
     and not proc.name in (known_binaries_to_read_environment_variables_from_proc_files)
   output: >
     Environment variables were retrieved from /proc files (user=%user.name user_loginuid=%user.loginuid program=%proc.name

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3207,7 +3207,7 @@
   desc: An attempt to read process environment variables from /proc files
   condition: >
     open_read and (fd.name glob /proc/*/environ)
-    and not proc.name in (systemctl, systemd-detect-, cloud-id)
+    and not proc.name in (systemctl, systemd-detect-, cloud-id, systemd-sysctl)
   enabled: true
   output: >
     Environment variables were retrieved from /proc files (user=%user.name user_loginuid=%user.loginuid program=%proc.name

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3206,8 +3206,7 @@
 - rule: Read environment variable from /proc files
   desc: An attempt to read process environment variables from /proc files
   condition: >
-    open_read and (fd.name glob /proc/*/environ)
-    and not proc.name in (systemctl, systemd-detect-, cloud-id, systemd-sysctl)
+    container and open_read and (fd.name glob /proc/*/environ)
   enabled: true
   output: >
     Environment variables were retrieved from /proc files (user=%user.name user_loginuid=%user.loginuid program=%proc.name

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3203,10 +3203,14 @@
 # there if you want to enable them by adding to
 # falco_rules.local.yaml.
 
+- list: known_binaries_to_read_environment_variables_from_proc_files
+  items: [scsi_id]
+
 - rule: Read environment variable from /proc files
   desc: An attempt to read process environment variables from /proc files
   condition: >
     container and open_read and (fd.name glob /proc/*/environ)
+    and not proc.name in (known_binaries_to_read_environment_variables_from_proc_files)
   enabled: true
   output: >
     Environment variables were retrieved from /proc files (user=%user.name user_loginuid=%user.loginuid program=%proc.name


### PR DESCRIPTION
Signed-off-by: Hi120ki <12624257+hi120ki@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

/kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area rules

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

These days, it's common to pass a secret to an application running on a container via an environment variable. Secrets store very sensitive information such as cloud credentials and JWT secretkeys, so it is important to detect when environment variables have been retrieved by an attack.

And if the application has SSRF or path traversal vulnerabilities, the attacker can steal the environment variables of the application process by reading `/proc/self/environ` and `/proc/1/environ` under the `/proc` directory.

<https://linux.die.net/man/5/proc>

For example, SSRF:

```
curl -X POST -d "url=file:///proc/self/environ" https://example.com/ssrf
curl -X POST -d "url=file:///proc/1/environ" https://example.com/ssrf
```

Path traversal:

```
curl --path-as-is https://example.com/path/../../proc/self/environ
curl --path-as-is https://example.com/path/../../proc/1/environ
```

In MITRE ATT&CK, this technique is categorised as [T1552 : Unsecured Credentials](https://attack.mitre.org/techniques/T1552/), and Sub-technique [T1552.001 : Unsecured Credentials: Credentials In Files](https://attack.mitre.org/techniques/T1552/001/), and Detection is [DS0022 - File - File Access](https://attack.mitre.org/datasources/DS0022/), and component is [T1003.007 OS Credential Dumping: Proc Filesystem](https://attack.mitre.org/techniques/T1003/007/).

I propose the following as a rule to detect environment variable reading from files under the `/proc` directory.

```yaml
- list: proc_environ_file_names
  items: [/proc/self/environ, /proc/1/environ]

- macro: proc_environ_files
  condition: >
    fd.name in (proc_environ_file_names)

- rule: Read environment variable from /proc files
  desc: An attempt to read process environment variables from /proc files
  condition: >
    container and open_read and proc_environ_files
  enabled: true
  output: >
    Environment variables were retrieved from /proc files (user=%user.name user_loginuid=%user.loginuid program=%proc.name
    command=%proc.cmdline file=%fd.name parent=%proc.pname gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] container_id=%container.id image=%container.image.repository)
  priority: WARNING
  tags: [filesystem, mitre_credential_access, mitre_discovery]
```

> Adding a host to the detection target causes false positives by `systemd`, so limited to container.

I'm waiting for your comments on detecting reading these files and my proposed rules.

Thank you.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Add rule to detect an attempt to read process environment variables from /proc files
```
