### PR TITLE
Add GKE default pod into allowlist in Mount Launched of Privileged Container rule 

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3106,7 +3106,9 @@
   condition: (proc.args="" or proc.args intersects ("-V", "-l", "-h"))
 
 - macro: user_known_mount_in_privileged_containers
-  condition: (never_true)
+  condition:
+    (k8s.ns.name = kube-system
+    and container.image.repository = gke.gcr.io/gcp-compute-persistent-disk-csi-driver)
 
 - rule: Mount Launched in Privileged Container
   desc: Detect file system mount happened inside a privileged container which might lead to container escape.

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3105,10 +3105,13 @@
 - macro: mount_info
   condition: (proc.args="" or proc.args intersects ("-V", "-l", "-h"))
 
-- macro: user_known_mount_in_privileged_containers
+- macro: known_gke_mount_in_privileged_containers
   condition:
     (k8s.ns.name = kube-system
     and container.image.repository = gke.gcr.io/gcp-compute-persistent-disk-csi-driver)
+
+- macro: user_known_mount_in_privileged_containers
+  condition: (never_true)
 
 - rule: Mount Launched in Privileged Container
   desc: Detect file system mount happened inside a privileged container which might lead to container escape.
@@ -3117,6 +3120,7 @@
     and container.privileged=true
     and proc.name=mount
     and not mount_info
+    and not known_gke_mount_in_privileged_containers
     and not user_known_mount_in_privileged_containers
   output: Mount was executed inside a privileged container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)
   priority: WARNING


### PR DESCRIPTION
Signed-off-by: Hi120ki <12624257+hi120ki@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

/kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area rules

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

In GKE cluster, a system container `gce-pd-driver` that manages Persistent Disk is running.
But the rule `Mount Launched of Privileged Container` detects as false positive.

```
Process: mount -t ext4 -o defaults /dev/disk/by-id/google-pvc-<id> /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-<id>/globalmount
```

This container runs in `kube-system` namespace, and image is from `gke.gcr.io/gcp-compute-persistent-disk-csi-driver`.
I added it into allowlist(macro : `user_known_mount_in_privileged_containers `).

I'm waiting for your comments on adding it into allowlist and my proposed changes.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Add GKE default pod into allowlist in Mount Launched of Privileged Container rule 
```
