### PR TITLE
fix mount detection in falco_rules.yaml

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3102,9 +3102,6 @@
   priority: WARNING
   tags: [container, cis, mitre_lateral_movement]
 
-- macro: mount_info
-  condition: (proc.args="" or proc.args intersects ("-V", "-l", "-h"))
-
 - macro: user_known_mount_in_privileged_containers
   condition: (never_true)
 
@@ -3113,8 +3110,7 @@
   condition: >
     spawned_process and container
     and container.privileged=true
-    and proc.name=mount
-    and not mount_info
+    and evt.type = mount
     and not user_known_mount_in_privileged_containers
   output: Mount was executed inside a privileged container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)
   priority: WARNING


### PR DESCRIPTION
Signed-off-by: Hi120ki <12624257+hi120ki@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

/kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area rules

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

In `Mount Launched in Privileged Container` rule, detect mount by `proc.name`.
But when some package is polluted, the attacker can mount without `mount` command.
And attackers also modify mount binary (`/usr/bin/mount`) to another name and bypass detection.

Then I update rule into detect `mount` syscall.

```yaml
- macro: user_known_mount_in_privileged_containers
  condition: (never_true)

- rule: Mount Launched in Privileged Container
  desc: Detect file system mount happened inside a privileged container which might lead to container escape.
  condition: >
    spawned_process and container
    and container.privileged=true
    and evt.type = mount
    and not user_known_mount_in_privileged_containers
  output: Mount was executed inside a privileged container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline %container.info image=%container.image.repository:%container.image.tag)
  priority: WARNING
  tags: [container, cis, mitre_lateral_movement]
```

This updated rule can detect mount command, and other way to mount, and modified name mount binary file.

Also, in the original rule ignores  when the process arg is none or `-V`, `-l`, `-h`.

```yaml
- macro: mount_info
  condition: (proc.args="" or proc.args intersects ("-V", "-l", "-h"))
```

I confirm no detection when running `mount` `mount -V` `mount -l` `mount -h` in updated rule.

I'm waiting for your comments on detecting `mount` syscall and my proposed changes.

Thank you.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix mount detection in falco_rules.yaml
```
