### PR TITLE
fix(userspace/engine): avoid reading duplicate exception values

### DIFF
--- a/userspace/engine/rule_reader.cpp
+++ b/userspace/engine/rule_reader.cpp
@@ -139,9 +139,9 @@ static void decode_exception_info_entry(
 	if (val.IsSequence())
 	{
 		out.is_list = true;
-		rule_loader::rule_exception_info::entry tmp;
 		for(const YAML::Node& v : val)
 		{
+			rule_loader::rule_exception_info::entry tmp;
 			rule_loader::context lctx(v, rule_loader::context::EXCEPTION, "", valctx);
 
 			// Optional is always false once you get past the outer values


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

The recursive function that reads rule exception values does not clear out the value list, so consecutive list-type exception values may end up containing in duplicate items.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

The regression seems to be introduced in https://github.com/falcosecurity/falco/pull/2098

A minimum example to reproduce the issue is reported below:
```yaml
- rule: Sample Rule
  desc: A sample rule
  output: Sample output (type=%evt.type)
  priority: ERROR
  condition: >
    evt.dir = <
  exceptions:
    - name: sample_exception
      fields: [evt.type, proc.name]
      comps: [in, in]
      values:
        - [[openat], [ls]]
```
This rule and its exceptions will be compiled into the following condition (note the rolled-over duplication of `openat`):
```
(evt.dir = < and not (evt.type in (openat) and proc.name in (openat, ls)))
```
With this fix, the rule is correctly compiled as:
```
(evt.dir = < and not (evt.type in (openat) and proc.name in (ls)))
```

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/engine): avoid reading duplicate exception values
```
