### PR TITLE
Add rule to detect bypass by symlink files

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3244,8 +3244,8 @@
 - rule: Detection bypass by symlinked files
   desc: An attempt to bypass fd.name based rules by existing symlink files
   condition: >
-    (fd.nameraw glob '*/proc*/root/*')
-    or (fd.nameraw glob '*/proc*/cwd/*')
+    (fd.nameraw glob '*/proc/*/root/*')
+    or (fd.nameraw glob '*/proc/*/cwd/*')
     or (fd.nameraw glob '*/dev*/fd/*..*')
     or (fd.nameraw glob '*/var*/spool*/cron*/crontabs/*..*')
   enabled: true

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3240,3 +3240,17 @@
     command=%proc.cmdline pid=%proc.pid file=%fd.name parent=%proc.pname gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] container_id=%container.id image=%container.image.repository)
   priority: WARNING
   tags: [filesystem, mitre_credential_access, mitre_discovery]
+
+- rule: Detection bypass by symlinked files
+  desc: An attempt to bypass fd.name based rules by existing symlink files
+  condition: >
+    (fd.nameraw glob '*/proc*/root/*')
+    or (fd.nameraw glob '*/proc*/cwd/*')
+    or (fd.nameraw glob '*/dev*/fd/*..*')
+    or (fd.nameraw glob '*/var*/spool*/cron*/crontabs/*..*')
+  enabled: true
+  output: >
+    Detection bypass by symlinked files (user=%user.name user_loginuid=%user.loginuid program=%proc.name
+    command=%proc.cmdline file=%fd.name parent=%proc.pname gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] container_id=%container.id image=%container.image.repository)
+  priority: Alert
+  tags: [filesystem]


### PR DESCRIPTION
Signed-off-by: Hi120ki <12624257+hi120ki@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

/kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area rules

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

In some falco rules, such as detecting specific file access, are using `fd.name`.

For exameple, the rule `Read sensitive file trusted after startup` detects to access sensitive files, like `/etc/shadow`, `/etc/pam.conf`, by `fd.name in (sensitive_file_names)`.

But in linux filesystem, there are some already defined symlink files, such as `/var/spool/cron/crontabs`, this is linked into `/etc/crontabs` directory.

Then using these symlink files, it is posssible to bypass falco detection.

```
$ docker run --rm -itd --name alpine alpine:latest
$ docker exec -it alpine ash
/ # cat /etc/shadow
root:*::0:::::
...
```

It cause `Warning Sensitive file opened for reading by non-trusted program`.

But running this command, there is no detection, successfully bypassed!

```
/ # cat /var/spool/cron/crontabs/../shadow
root:*::0:::::
...
```

How this symlink file based bypass method works:

```
/var/spool/cron/crontabs/ = /etc/crontabs
/var/spool/cron/crontabs/../ = /etc/
/var/spool/cron/crontabs/../shadow = /etc/shadow
```

Then, using other defined symlink file `/dev/fd`, is linked into `/proc/self/fd`, can bypass the rule `Read environment variable from /proc files` (in PR #2193, approved and waiting merge) like this command

```
/ # cat /dev/fd/../environ
HOSTNAME=...
```

Then, a more general method is using `/proc/self/root -> /`, is pointed out by [@mrtc0](https://twitter.com/mrtc0) in [How to Bypass Falco](https://blog.ssrf.in/post/how-to-bypass-falco/), can be used like this

```
/ # cat /proc/self/root/etc/shadow
root:*::0:::::
...
```

Related to `/proc/self/root`, there is `/proc/self/cwd -> (proccess dir)`.

```
/ # cat /proc/self/cwd/etc/shadow
root:*::0:::::
...
/ # cat /proc/self/cwd/../etc/shadow
/ # cat /proc/self/cwd/../../etc/shadow
```

To detect these bypass method, I propose this rule.

```yaml
- rule: Detection bypass by symlinked files
  desc: An attempt to bypass fd.name based rules by existing symlink files
  condition: >
    (fd.nameraw glob '*/proc*/root/*')
    or (fd.nameraw glob '*/proc*/cwd/*')
    or (fd.nameraw glob '*/dev*/fd/*..*')
    or (fd.nameraw glob '*/var*/spool*/cron*/crontabs/*..*')
  enabled: true
  output: >
    Detection bypass by symlinked files (user=%user.name user_loginuid=%user.loginuid program=%proc.name
    command=%proc.cmdline file=%fd.name parent=%proc.pname gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] container_id=%container.id image=%container.image.repository)
  priority: Alert
  tags: [filesystem]
```

> `/dev/fd` and `/var/spool/cron/crontabs` are used by ordinary process, add `*..*` to the end of glob match text for reducing false positive.

> Memo: why my proposed rule is created `fd.nameraw` insted of `fd.name`
>
> If we run command `cat /proc/self/root/../etc/shadow`, falco probe record `openat` syscall with argument `/proc/self/root/../etc/shadow`
>
> and falco normalize argument path by `falco-lib` and generate `fd.name = /proc/self/etc/shadow` (`root` is disappear). So, it is impossible to detect by `fd.name`.

I tested this rule by these commands on alpine and ubuntu latest image, if you find corner cases, please tell me.

```
cat /proc/self/root/etc/shadow
cat /proc/self/./root/etc/shadow
cat /proc/self/root/../etc/shadow
cat ../proc/self/root/etc/shadow
cat /proc/self/cwd/../../etc/shadow
cat /dev/fd/../environ
cat /dev/./fd/../environ
cat ../dev/fd/../environ
cat /var/spool/cron/crontabs/../shadow
cat /var/spool/./cron/crontabs/../shadow
cat ../var/spool/cron/crontabs/../shadow
```

This bypass technique has huge impact to falco detection. The above, I only show bypassing `Sensitive file opened for reading by non-trusted program` and `Read environment variable from /proc files`, but there are more rules that can bypass.

I'm now looking for other symlink files that can bypass falco rules, I will create another PR to add that after this PR is merged.

I'm waiting for your comments on this bypass technique and my proposed rules.

Thank you.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Add rule to detect bypass by symlink files
```
