### PR TITLE
Set Default Driver Download Location

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -602,6 +602,8 @@ print_usage() {
 	echo ""
 	echo "Environment variables:"
 	echo "  DRIVERS_REPO             specify different URL(s) where to look for prebuilt Falco drivers (comma separated)"
+	echo "                           The default value is https://download.falco.org/driver - the public distribution"
+	echo "                           point of downloadable falco kernel drivers"
 	echo "  DRIVER_NAME              specify a different name for the driver"
 	echo "  DRIVER_INSECURE_DOWNLOAD whether you want to allow insecure downloads or not"
 	echo ""
@@ -621,7 +623,7 @@ if ! hash sed > /dev/null 2>&1; then
 fi
 KERNEL_VERSION=$(uname -v | sed 's/#\([[:digit:]]\+\).*/\1/')
 
-DRIVERS_REPO=${DRIVERS_REPO:-"@DRIVERS_REPO@"}
+DRIVERS_REPO=${DRIVERS_REPO:-"https://download.falco.org/driver"}
 
 if [ -n "$DRIVER_INSECURE_DOWNLOAD" ]
 then


### PR DESCRIPTION
TL;DR: Set a default driver download location to
https://download.falco.org/driver to facilitate a more download-and-go user experience for the driver-loader script.

Every few months or so I come back to the falco project and need to get reacquainted with the structure of where things are. How do I install the kernel modules? Where should I download the kernel modules from? Where are the eBPF probes? It's pretty consistently 20 minutes to an hour of work that needs to be repeated two or more times per year.

One of the things that promised to help with this was the falco-driver-loader script. It's really good! As soon as you know all the inputs to the script. So instead of relying on future me to reverse engineer the inputs from a lack of knowledge, present me is going to update the script to include the public distribution point of eBPF probes and kernel modules.

Signed-off-by: Tom Kelley <distortedsignal@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area scripts

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Provide a good default for the download URL for eBPF probes and kernel modules. This helps users to get up and running with Falco faster.

**Which issue(s) this PR fixes**:

N/A - it's easier to open a PR than to open an issue.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note

The `falco-driver-loader` script now uses the `download.falco.org/driver` distribution point as the default driver distribution point.

```
