### PR TITLE
fix(process_events): check the return value of `open_live_inspector`

### DIFF
--- a/userspace/falco/app_actions/process_events.cpp
+++ b/userspace/falco/app_actions/process_events.cpp
@@ -335,7 +335,12 @@ application::run_result application::process_events()
 			try
 			{
 				falco_logger::log(LOG_DEBUG, "Opening event source '" + source + "'\n");
-				open_live_inspector(src_info->inspector, source);
+				res = open_live_inspector(src_info->inspector, source);
+				if (!res.success)
+				{
+					return res;
+				}
+
 				if (m_state->enabled_sources.size() == 1)
 				{
 					// optimization: with only one source we don't spawn additional threads


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR checks the return value of the `open_live_inspector` method interrupting immediately the flow if the inspector is not opened

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
