### PR TITLE
add __STDC_FORMAT_MACROS

### DIFF
--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -44,6 +44,7 @@ set(LIBS_PACKAGE_NAME "falcosecurity")
 
 add_definitions(-D_GNU_SOURCE)
 add_definitions(-DHAS_CAPTURE)
+add_definitions(-D__STDC_FORMAT_MACROS)
 
 if(MUSL_OPTIMIZED_BUILD)
   add_definitions(-DMUSL_OPTIMIZED)

--- a/userspace/falco/app_actions/process_events.cpp
+++ b/userspace/falco/app_actions/process_events.cpp
@@ -13,8 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 
 #include <stdio.h>
 #include <sys/types.h>


### PR DESCRIPTION
avoid missing expected ‘)’ before ‘PRIu32‘ error

Signed-off-by: Skactor <sk4ct0r@gmail.com>

/kind bug
/area build


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```