### PR TITLE
cleanup(docker): avoid linking /lib/modules to /host/lib/modules at docker image creation time

### DIFF
--- a/docker/driver-loader/docker-entrypoint.sh
+++ b/docker/driver-loader/docker-entrypoint.sh
@@ -25,4 +25,19 @@ do
     ln -s "$i" "/usr/src/$base"
 done
 
+if [ -n "$HOST_ROOT" ]; then
+    echo "* Setting up /lib/modules links from host"
+    ln -s /lib/modules $HOST_ROOT/lib/modules 
+    
+    # If HOST_ROOT is set, but HOST_ROOT/proc does not exist
+    # link real /proc to HOST_ROOT/proc, so that Falco can run gracefully.
+    # This is mostly useful when dealing with an hypervisor, like aws Fargate,
+    # where the container running Falco does not need to bind-mount the host proc volume,
+    # and its /proc already sees all task processes because it shares the same namespace.
+    if [ ! -d "$HOST_ROOT/proc" ]; then
+        echo "* Setting up /proc links from host"
+        ln -s "/proc" "$HOST_ROOT/proc"
+    fi
+fi
+
 /usr/bin/falco-driver-loader "$@"

--- a/docker/driver-loader/docker-entrypoint.sh
+++ b/docker/driver-loader/docker-entrypoint.sh
@@ -25,7 +25,7 @@ do
     ln -s "$i" "/usr/src/$base"
 done
 
-if [ -n "$HOST_ROOT" ]; then
+if [ -n "$HOST_ROOT" ] && [ "$HOST_ROOT" != "/" ]; then
     echo "* Setting up /lib/modules links from host"
     ln -s /lib/modules $HOST_ROOT/lib/modules 
     

--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -103,8 +103,7 @@ RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/fa
 # Some base images have an empty /lib/modules by default
 # If it's not empty, docker build will fail instead of
 # silently overwriting the existing directory
-RUN rm -df /lib/modules \
-	&& ln -s $HOST_ROOT/lib/modules /lib/modules
+RUN rm -df /lib/modules
 
 # debian:stable head contains binutils 2.31, which generates
 # binaries that are incompatible with kernels < 4.16. So manually

--- a/docker/falco/docker-entrypoint.sh
+++ b/docker/falco/docker-entrypoint.sh
@@ -30,4 +30,19 @@ if [[ -z "${SKIP_DRIVER_LOADER}" ]]; then
     /usr/bin/falco-driver-loader
 fi
 
+if [ -n "$HOST_ROOT" ]; then
+    echo "* Setting up /lib/modules links from host"
+    ln -s /lib/modules $HOST_ROOT/lib/modules
+    
+    # If HOST_ROOT is set, but HOST_ROOT/proc does not exist
+    # link real /proc to HOST_ROOT/proc, so that Falco can run gracefully.
+    # This is mostly useful when dealing with an hypervisor, like aws Fargate,
+    # where the container running Falco does not need to bind-mount the host proc volume,
+    # and its /proc already sees all task processes because it shares the same namespace.
+    if [ ! -d "$HOST_ROOT/proc" ]; then
+        echo "* Setting up /proc links from host"
+        ln -s "/proc" "$HOST_ROOT/proc"
+    fi
+fi
+
 exec "$@"

--- a/docker/falco/docker-entrypoint.sh
+++ b/docker/falco/docker-entrypoint.sh
@@ -30,7 +30,7 @@ if [[ -z "${SKIP_DRIVER_LOADER}" ]]; then
     /usr/bin/falco-driver-loader
 fi
 
-if [ -n "$HOST_ROOT" ]; then
+if [ -n "$HOST_ROOT" ] && [ "$HOST_ROOT" != "/" ]; then
     echo "* Setting up /lib/modules links from host"
     ln -s /lib/modules $HOST_ROOT/lib/modules
     

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -96,8 +96,7 @@ RUN rm -rf /usr/bin/clang \
 # Some base images have an empty /lib/modules by default
 # If it's not empty, docker build will fail instead of
 # silently overwriting the existing directory
-RUN rm -df /lib/modules \
-	&& ln -s $HOST_ROOT/lib/modules /lib/modules
+RUN rm -df /lib/modules
 
 ADD falco-${FALCO_VERSION}-*.deb /
 RUN dpkg -i /falco-${FALCO_VERSION}-$(uname -m).deb

--- a/docker/local/docker-entrypoint.sh
+++ b/docker/local/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [[ -z "${SKIP_DRIVER_LOADER}" ]]; then
     /usr/bin/falco-driver-loader
 fi
 
-if [ -n "$HOST_ROOT" ]; then
+if [ -n "$HOST_ROOT" ] && [ "$HOST_ROOT" != "/" ]; then
     echo "* Setting up /lib/modules links from host"
     ln -s /lib/modules $HOST_ROOT/lib/modules 
     

--- a/docker/local/docker-entrypoint.sh
+++ b/docker/local/docker-entrypoint.sh
@@ -31,4 +31,19 @@ if [[ -z "${SKIP_DRIVER_LOADER}" ]]; then
     /usr/bin/falco-driver-loader
 fi
 
+if [ -n "$HOST_ROOT" ]; then
+    echo "* Setting up /lib/modules links from host"
+    ln -s /lib/modules $HOST_ROOT/lib/modules 
+    
+    # If HOST_ROOT is set, but HOST_ROOT/proc does not exist
+    # link real /proc to HOST_ROOT/proc, so that Falco can run gracefully.
+    # This is mostly useful when dealing with an hypervisor, like aws Fargate,
+    # where the container running Falco does not need to bind-mount the host proc volume,
+    # and its /proc already sees all task processes because it shares the same namespace.
+    if [ ! -d "$HOST_ROOT/proc" ]; then
+        echo "* Setting up /proc links from host"
+        ln -s "/proc" "$HOST_ROOT/proc"
+    fi
+fi
+
 exec "$@"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

Avoid linking /lib/modules to /host/lib/modules at docker image creation time.
Instead, do it in docker-entrypoint scripts, so that even users using different HOST_ROOT than "/host", will still have a working image.

Moreover, if HOST_ROOT is set, but "$HOST_ROOT/proc" is not present, soft link "/proc" to "HOST_ROOT/proc", to allow Falco to run. Otherwise, scap_procs would exit with error and kill the istance.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
cleanup: allow users that use a different HOST_ROOT to still have a working falco-driver-loader driver compilation.
```
