### PR TITLE
new(cmdline): add development support for modern BPF probe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,14 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND CMAKE_SYSTEM_NAME MATCHES "Linux
   endif()
 endif()
 
+# Modern BPF is not supported on not Linux systems and in MINIMAL_BUILD
+if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT MINIMAL_BUILD)
+  option(BUILD_FALCO_MODERN_BPF "Build modern BPF support for Falco" OFF)
+  if(BUILD_FALCO_MODERN_BPF)
+    add_definitions(-DHAS_MODERN_BPF)
+  endif()
+endif()
+
 # We shouldn't need to set this, see https://gitlab.kitware.com/cmake/cmake/-/issues/16419
 option(EP_UPDATE_DISCONNECTED "ExternalProject update disconnected" OFF)
 if (${EP_UPDATE_DISCONNECTED})

--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -26,8 +26,8 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "fd46dd139a8e35692a7d40ab2f0ed2016df827cf")
-    set(DRIVER_CHECKSUM "SHA256=7c14a4b5f282c9e1e4496f5416d73c3132c72954d581e1a737f82ffa0e3a6bdd")
+    set(DRIVER_VERSION "0c280ca6847d7fbb616f152bb6cffd5b4d74452d")
+    set(DRIVER_CHECKSUM "SHA256=63577357e43cade45e76fb5f4522493195dcde1a6cfed3768ba5d51a67ab50ab")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -27,8 +27,8 @@ else()
   # In case you want to test against another falcosecurity/libs version (or branch, or commit) just pass the variable -
   # ie., `cmake -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "fd46dd139a8e35692a7d40ab2f0ed2016df827cf")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=7c14a4b5f282c9e1e4496f5416d73c3132c72954d581e1a737f82ffa0e3a6bdd")
+    set(FALCOSECURITY_LIBS_VERSION "0c280ca6847d7fbb616f152bb6cffd5b4d74452d")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=63577357e43cade45e76fb5f4522493195dcde1a6cfed3768ba5d51a67ab50ab")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -60,6 +60,9 @@ set(LIBSINSP_DIR "${FALCOSECURITY_LIBS_SOURCE_DIR}")
 # configure gVisor support
 set(BUILD_LIBSCAP_GVISOR ${BUILD_FALCO_GVISOR} CACHE BOOL "")
 
+# configure modern BPF support
+set(BUILD_LIBSCAP_MODERN_BPF ${BUILD_FALCO_MODERN_BPF} CACHE BOOL "")
+
 # explicitly disable the tests/examples of this dependency
 set(CREATE_TEST_TARGETS OFF CACHE BOOL "")
 set(BUILD_LIBSCAP_EXAMPLES OFF CACHE BOOL "")

--- a/userspace/falco/app_actions/open_inspector.cpp
+++ b/userspace/falco/app_actions/open_inspector.cpp
@@ -78,7 +78,7 @@ application::run_result application::open_live_inspector(
 		else if(m_options.modern_bpf) /* modern BPF engine. */
 		{
 			falco_logger::log(LOG_INFO, "Starting capture with modern BPF probe.");
-			inspector->open_modern_bpf(DEFAULT_DRIVER_BUFFER_BYTES_DIM, m_state->ppm_sc_of_interest, m_state->tp_of_interest);
+			inspector->open_modern_bpf(m_state->syscall_buffer_bytes_size, m_state->ppm_sc_of_interest, m_state->tp_of_interest);
 		}
 		else if(getenv(FALCO_BPF_ENV_VARIABLE) != NULL) /* BPF engine. */
 		{

--- a/userspace/falco/app_actions/open_inspector.cpp
+++ b/userspace/falco/app_actions/open_inspector.cpp
@@ -75,6 +75,11 @@ application::run_result application::open_live_inspector(
 			falco_logger::log(LOG_INFO, "Enabled event collection from gVisor. Configuration path: " + m_options.gvisor_config);
 			inspector->open_gvisor(m_options.gvisor_config, m_options.gvisor_root);
 		}
+		else if(m_options.modern_bpf) /* modern BPF engine. */
+		{
+			falco_logger::log(LOG_INFO, "Starting capture with modern BPF probe.");
+			inspector->open_modern_bpf(DEFAULT_DRIVER_BUFFER_BYTES_DIM, m_state->ppm_sc_of_interest, m_state->tp_of_interest);
+		}
 		else if(getenv(FALCO_BPF_ENV_VARIABLE) != NULL) /* BPF engine. */
 		{
 			const char *bpf_probe_path = std::getenv(FALCO_BPF_ENV_VARIABLE);

--- a/userspace/falco/app_cmdline_options.cpp
+++ b/userspace/falco/app_cmdline_options.cpp
@@ -31,6 +31,7 @@ cmdline_options::cmdline_options()
 	: event_buffer_format(sinsp_evt::PF_NORMAL),
 	  gvisor_config(""),	
 	  list_plugins(false),
+	  modern_bpf(false),
 	  m_cmdline_opts("falco", "Falco - Cloud Native Runtime Security")
 {
 	define();

--- a/userspace/falco/app_cmdline_options.cpp
+++ b/userspace/falco/app_cmdline_options.cpp
@@ -169,6 +169,9 @@ void cmdline_options::define()
 		("gvisor-generate-config",		  "Generate a configuration file that can be used for gVisor.", cxxopts::value<std::string>(gvisor_generate_config_with_socket)->implicit_value("/run/falco/gvisor.sock"), "<socket_path>")
 		("gvisor-root",					  "gVisor root directory for storage of container state. Equivalent to runsc --root flag.", cxxopts::value(gvisor_root), "<gvisor_root>")
 #endif
+#ifdef HAS_MODERN_BPF
+		("modern-bpf",				  "[EXPERIMENTAL] Use BPF modern probe to capture system events.", cxxopts::value(modern_bpf)->default_value("false"))
+#endif
 		("i",                             "Print all events that are ignored by default (i.e. without the -A flag) and exit.", cxxopts::value(print_ignored_events)->default_value("false"))
 #ifndef MINIMAL_BUILD
 		("k,k8s-api",                     "Enable Kubernetes support by connecting to the API server specified as argument. E.g. \"http://admin:password@127.0.0.1:8080\". The API server can also be specified via the environment variable FALCO_K8S_API.", cxxopts::value(k8s_api), "<url>")

--- a/userspace/falco/app_cmdline_options.h
+++ b/userspace/falco/app_cmdline_options.h
@@ -79,6 +79,7 @@ public:
 	bool verbose;
 	bool print_version_info;
 	bool print_page_size;
+	bool modern_bpf;
 
 	bool parse(int argc, char **argv, std::string &errstr);
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR adds the possibility to start Falco with the modern BPF probe. This cmd line option MUST be used only during development, it is not production ready! For this reason, it is compiled out unless we use the `-DBUILD_FALCO_MODERN_BPF=ON` CMake option

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new(cmdline): add development support for modern BPF probe
```
