### PR TITLE
Rule: detecting executions looking for AWS credentials

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3262,10 +3262,6 @@
   priority: WARNING
   tags: [container, filesystem, mitre_initial_access, T1611]
 
-# Application rules have moved to application_rules.yaml. Please look
-# there if you want to enable them by adding to
-# falco_rules.local.yaml.
-
 - list: known_binaries_to_read_environment_variables_from_proc_files
   items: [scsi_id, argoexec]
 
@@ -3292,3 +3288,25 @@
   output: Detected ptrace PTRACE_ATTACH attempt (proc.cmdline=%proc.cmdline container=%container.info evt.type=%evt.type evt.arg.request=%evt.arg.request proc.pid=%proc.pid proc.cwd=%proc.cwd proc.ppid=%proc.ppid proc.pcmdline=%proc.pcmdline proc.sid=%proc.sid proc.exepath=%proc.exepath user.uid=%user.uid user.loginuid=%user.loginuid user.loginname=%user.loginname user.name=%user.name group.gid=%group.gid group.name=%group.name container.id=%container.id container.name=%container.name image=%container.image.repository)
   priority: WARNING
   tags: [process]
+  
+- macro: private_aws_credentials
+  condition: >
+    (proc.args icontains "aws_access_key_id" or
+    proc.args icontains "aws_secret_access_key" or
+    proc.args icontains "aws_session_token" or
+    proc.args icontains "accesskeyid" or
+    proc.args icontains "secretaccesskey")
+
+- rule: Find AWS Credentials
+  desc: Find or grep AWS credentials
+  condition: >
+    spawned_process and
+    ((grep_commands and private_aws_credentials) or
+    (proc.name = "find" and proc.args endswith ".aws/credentials"))
+  output: Detected AWS credentials search activity (user.name=%user.name user.loginuid=%user.loginuid proc.cmdline=%proc.cmdline container.id=%container.id container_name=%container.name evt.type=%evt.type evt.res=%evt.res proc.pid=%proc.pid proc.cwd=%proc.cwd proc.ppid=%proc.ppid proc.pcmdline=%proc.pcmdline proc.sid=%proc.sid proc.exepath=%proc.exepath user.uid=%user.uid user.loginname=%user.loginname group.gid=%group.gid group.name=%group.name container.name=%container.name image=%container.image.repository:%container.image.tag)
+  priority: WARNING
+  tags: [mitre_credential_access, process, aws]
+
+# Application rules have moved to application_rules.yaml. Please look
+# there if you want to enable them by adding to
+# falco_rules.local.yaml.


### PR DESCRIPTION
Signed-off-by: Alberto Pellitteri <albertopellitteri96@gmail.com>
Co-authored-by: Alessandro Brucato <alessandro.brucato@sysdig.com>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

/kind rule-create

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area rules

> /area tests

> /area proposals

> /area CI


**What this PR does / why we need it**:
Nowadays many attacks are interested in stealing credentials. Most of the researched credentials are related to cloud platforms and can used by attackers to attempt lateral movement attacks. TeamTNT, for example, is a well-known threat actor that continuously conducts campaigns to steal AWS related credentials.
For this reason we created the ```Find AWS credentials``` rule, able to detect whenever a process searches the AWS credential file or keywords related to AWS secret key or access key.   

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
rule(Find AWS Credentials): new rule to detect executions looking for AWS credentials
```
