### PR TITLE
Rule: detecting executions from /dev/shm

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3307,6 +3307,21 @@
   priority: WARNING
   tags: [mitre_credential_access, process, aws]
 
+- rule: Execution from /dev/shm
+  desc: This rule detects file execution from the /dev/shm directory, a common tactic for threat actors to stash their readable+writable+(sometimes)executable files.
+  condition: >
+    spawned_process and 
+    (proc.exe startswith "/dev/shm/" or 
+    (proc.cwd startswith "/dev/shm/" and proc.exe startswith "./" ) or 
+    (shell_procs and proc.args startswith "-c /dev/shm") or 
+    (shell_procs and proc.args startswith "-i /dev/shm") or 
+    (shell_procs and proc.args startswith "/dev/shm") or 
+    (proc.cwd startswith "/dev/shm/" and proc.args startswith "./" )) and 
+    not container.image.repository in (falco_privileged_images, trusted_images)
+  output: "File execution detected from /dev/shm (proc.cmdline=%proc.cmdline connection=%fd.name user.name=%user.name user.loginuid=%user.loginuid container.id=%container.id evt.type=%evt.type evt.res=%evt.res proc.pid=%proc.pid proc.cwd=%proc.cwd proc.ppid=%proc.ppid proc.pcmdline=%proc.pcmdline proc.sid=%proc.sid proc.exepath=%proc.exepath user.uid=%user.uid user.loginname=%user.loginname group.gid=%group.gid group.name=%group.name container.name=%container.name image=%container.image.repository)"
+  priority: WARNING
+  tags: [mitre_execution]
+
 # Application rules have moved to application_rules.yaml. Please look
 # there if you want to enable them by adding to
 # falco_rules.local.yaml.


### PR DESCRIPTION
Signed-off-by: Alberto Pellitteri <albertopellitteri96@gmail.com>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

/kind rule-create

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area rules

> /area tests

> /area proposals

> /area CI

**What this PR does / why we need it**:
The execution from /dev/shm rule detects file execution from the /dev/shm directory, which is a common location for threat actors to store their files. The shm device is backed by RAM, so any files written here will not be written to disk. Many threat actors in the wild write and execute scripts and malicious binaries from /dev/shm. It is not common for legitimate binaries to be stored and executed from the /dev/shm directory.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
rule(Execution from /dev/shm): new rule to detect execution from /dev/shm
```
