### PR TITLE
Rule: PTRACE attached to process

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3238,3 +3238,10 @@
     command=%proc.cmdline pid=%proc.pid file=%fd.name parent=%proc.pname gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] container_id=%container.id image=%container.image.repository)
   priority: WARNING
   tags: [filesystem, mitre_credential_access, mitre_discovery]
+
+- rule: PTRACE attached to process
+  desc: "This rule detects an attempt to inject code into a process using PTRACE."
+  condition: evt.type=ptrace and evt.dir=> and evt.arg.request=11 and proc_name_exists
+  output: Detected ptrace PTRACE_ATTACH attempt (proc.cmdline=%proc.cmdline container=%container.info evt.type=%evt.type evt.arg.request=%evt.arg.request proc.pid=%proc.pid proc.cwd=%proc.cwd proc.ppid=%proc.ppid proc.pcmdline=%proc.pcmdline proc.sid=%proc.sid proc.exepath=%proc.exepath user.uid=%user.uid user.loginuid=%user.loginuid user.loginname=%user.loginname user.name=%user.name group.gid=%group.gid group.name=%group.name container.id=%container.id container.name=%container.name image=%container.image.repository)
+  priority: WARNING
+  tags: [process]

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3239,9 +3239,15 @@
   priority: WARNING
   tags: [filesystem, mitre_credential_access, mitre_discovery]
 
+- list: known_ptrace_binaries
+  items: []
+
+- marco: known_ptrace_procs
+  condition: (proc.name in (known_ptrace_binaries))
+
 - rule: PTRACE attached to process
   desc: "This rule detects an attempt to inject code into a process using PTRACE."
-  condition: evt.type=ptrace and evt.dir=> and evt.arg.request=11 and proc_name_exists
+  condition: evt.type=ptrace and evt.dir=> and evt.arg.request in (5, 6, 11, 20, 27) and proc_name_exists and not known_ptrace_procs
   output: Detected ptrace PTRACE_ATTACH attempt (proc.cmdline=%proc.cmdline container=%container.info evt.type=%evt.type evt.arg.request=%evt.arg.request proc.pid=%proc.pid proc.cwd=%proc.cwd proc.ppid=%proc.ppid proc.pcmdline=%proc.pcmdline proc.sid=%proc.sid proc.exepath=%proc.exepath user.uid=%user.uid user.loginuid=%user.loginuid user.loginname=%user.loginname user.name=%user.name group.gid=%group.gid group.name=%group.name container.id=%container.id container.name=%container.name image=%container.image.repository)
   priority: WARNING
   tags: [process]

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3242,7 +3242,7 @@
 - list: known_ptrace_binaries
   items: []
 
-- marco: known_ptrace_procs
+- macro: known_ptrace_procs
   condition: (proc.name in (known_ptrace_binaries))
 
 - rule: PTRACE attached to process


### PR DESCRIPTION
Signed-off-by: Alessandro Brucato <alessandro.brucato@sysdig.com>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

/kind rule-create


**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area rules

> /area tests

> /area proposals

> /area CI


**What this PR does / why we need it**:
The ptrace system call can be used to alter a target's memory and execution which make it popular for injecting code. It is often used by malware for this purpose in order to be more stealthy, or steal information from the process. Legitimate tools, such as GDB or security software, may also leverage this method.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
New rule to detect attempts to inject code into a process using PTRACE
```
