### PR TITLE
fix(userspace): add explicit constructors and initializations

### DIFF
--- a/userspace/engine/falco_load_result.h
+++ b/userspace/engine/falco_load_result.h
@@ -56,6 +56,8 @@ public:
 		LOAD_UNKNOWN_ITEM
 	};
 
+	virtual ~load_result() = default;
+
 	// The warning code as a string
 	static const std::string& warning_code_str(warning_code ec);
 

--- a/userspace/engine/falco_rule.h
+++ b/userspace/engine/falco_rule.h
@@ -26,6 +26,12 @@ limitations under the License.
 */
 struct falco_rule
 {
+	falco_rule(): id(0), priority(falco_common::PRIORITY_DEBUG) {}
+	falco_rule(falco_rule&&) = default;
+	falco_rule& operator = (falco_rule&&) = default;
+	falco_rule(const falco_rule&) = default;
+	falco_rule& operator = (const falco_rule&) = default;
+
 	std::size_t id;
 	std::string source;
 	std::string name;

--- a/userspace/engine/falco_source.h
+++ b/userspace/engine/falco_source.h
@@ -26,6 +26,23 @@ limitations under the License.
 */
 struct falco_source
 {
+	falco_source() = default;
+	falco_source(falco_source&&) = default;
+	falco_source& operator = (falco_source&&) = default;
+	falco_source(const falco_source& s):
+		name(s.name),
+		ruleset_factory(s.ruleset_factory),
+		filter_factory(s.filter_factory),
+		formatter_factory(s.formatter_factory) { };
+	falco_source& operator = (const falco_source& s)
+	{
+		name = s.name;
+		ruleset_factory = s.ruleset_factory;
+		filter_factory = s.filter_factory;
+		formatter_factory = s.formatter_factory;
+		return *this;
+	};
+
 	std::string name;
 	std::shared_ptr<filter_ruleset> ruleset;
 	std::shared_ptr<filter_ruleset_factory> ruleset_factory;
@@ -36,7 +53,7 @@ struct falco_source
 	// matches an event.
 	mutable falco_rule m_rule;
 
-	inline bool is_field_defined(std::string field) const
+	inline bool is_field_defined(const std::string& field) const
 	{
 		auto *chk = filter_factory->new_filtercheck(field.c_str());
 		if (chk)

--- a/userspace/engine/filter_evttype_resolver.h
+++ b/userspace/engine/filter_evttype_resolver.h
@@ -188,6 +188,12 @@ public:
 private:
 	struct visitor : public libsinsp::filter::ast::expr_visitor
 	{
+		visitor(): m_expect_value(false) {}
+		visitor(visitor&&) = default;
+		visitor& operator = (visitor&&) = default;
+		visitor(const visitor&) = default;
+		visitor& operator = (const visitor&) = default;
+
 		bool m_expect_value;
 		falco_event_types m_last_node_evttypes;
 

--- a/userspace/engine/filter_macro_resolver.h
+++ b/userspace/engine/filter_macro_resolver.h
@@ -81,6 +81,12 @@ class filter_macro_resolver
 
 		struct visitor : public libsinsp::filter::ast::expr_visitor
 		{
+			visitor() = default;
+			visitor(visitor&&) = default;
+			visitor& operator = (visitor&&) = default;
+			visitor(const visitor&) = delete;
+			visitor& operator = (const visitor&) = delete;
+
 			std::unique_ptr<libsinsp::filter::ast::expr> m_node_substitute;
 			std::unordered_set<std::string>* m_unknown_macros;
 			std::unordered_set<std::string>* m_resolved_macros;

--- a/userspace/engine/filter_ruleset.h
+++ b/userspace/engine/filter_ruleset.h
@@ -151,5 +151,7 @@ public:
 class filter_ruleset_factory
 {
 public:
+	virtual ~filter_ruleset_factory() = default;
+
 	virtual std::shared_ptr<filter_ruleset> new_ruleset() = 0;
 };

--- a/userspace/engine/filter_warning_resolver.h
+++ b/userspace/engine/filter_warning_resolver.h
@@ -48,6 +48,12 @@ public:
 private:
 	struct visitor : public libsinsp::filter::ast::base_expr_visitor
 	{
+		visitor(): m_is_equality_check(false) {}
+		visitor(visitor&&) = default;
+		visitor& operator = (visitor&&) = default;
+		visitor(const visitor&) = delete;
+		visitor& operator = (const visitor&) = delete;
+
 		bool m_is_equality_check;
 		std::set<falco::load_result::warning_code>* m_warnings;
 

--- a/userspace/engine/indexed_vector.h
+++ b/userspace/engine/indexed_vector.h
@@ -28,7 +28,12 @@ template <typename T>
 class indexed_vector
 {
 public:
+	indexed_vector() = default;
 	virtual ~indexed_vector() = default;
+	indexed_vector(indexed_vector&&) = default;
+	indexed_vector& operator = (indexed_vector&&) = default;
+	indexed_vector(const indexed_vector&) = default;
+	indexed_vector& operator = (const indexed_vector&) = default;
 
 	/*!
 		\brief Returns the number of elements
@@ -68,7 +73,7 @@ public:
 		\param index String index of the element to be added in the vector
 		\return The numeric index assigned to the element
 	*/
-	virtual inline size_t insert(T& entry, const std::string& index)
+	virtual inline size_t insert(const T& entry, const std::string& index)
 	{
 		size_t id;
 		auto prev = m_index.find(index);
@@ -89,7 +94,7 @@ public:
 	*/
 	virtual inline T* at(size_t id) const
 	{
-		if (id <= m_entries.size())
+		if (id < m_entries.size())
 		{
 			return (T* const) &m_entries[id];
 		}

--- a/userspace/engine/rule_loader.cpp
+++ b/userspace/engine/rule_loader.cpp
@@ -504,7 +504,7 @@ const nlohmann::json& rule_loader::result::as_json(const rules_contents_t& conte
 }
 
 rule_loader::engine_version_info::engine_version_info(context &ctx)
-	: ctx(ctx)
+	: ctx(ctx), version(0)
 {
 }
 
@@ -519,12 +519,12 @@ rule_loader::plugin_version_info::plugin_version_info(context &ctx)
 }
 
 rule_loader::list_info::list_info(context &ctx)
-	: ctx(ctx)
+	: ctx(ctx), used(false), index(0), visibility(0)
 {
 }
 
 rule_loader::macro_info::macro_info(context &ctx)
-	: ctx(ctx), cond_ctx(ctx)
+	: ctx(ctx), cond_ctx(ctx), used(false), index(0), visibility(0)
 {
 }
 
@@ -534,7 +534,9 @@ rule_loader::rule_exception_info::rule_exception_info(context &ctx)
 }
 
 rule_loader::rule_info::rule_info(context &ctx)
-	: ctx(ctx), cond_ctx(ctx), output_ctx(ctx)
+	: ctx(ctx), cond_ctx(ctx), output_ctx(ctx), index(0), visibility(0),
+	  priority(falco_common::PRIORITY_DEBUG), enabled(true),
+	  warn_evttypes(true), skip_if_unknown_filter(false)
 {
 }
 

--- a/userspace/engine/rule_loader.h
+++ b/userspace/engine/rule_loader.h
@@ -66,6 +66,11 @@ namespace rule_loader
 			position() : pos(0), line(0), column(0) {};
 			position(const YAML::Mark& mark) : pos(mark.pos), line(mark.line), column(mark.column) {};
 			~position() = default;
+			position(position&&) = default;
+			position& operator = (position&&) = default;
+			position(const position&) = default;
+			position& operator = (const position&) = default;
+
 			int pos;
 			int line;
 			int column;
@@ -73,6 +78,18 @@ namespace rule_loader
 
 		struct location
 		{
+			location(): item_type(context::item_type::VALUE_FOR) {}
+			location(
+				const std::string n,
+				const position& p,
+				context::item_type i,
+				const std::string in):
+					name(n), pos(p), item_type(i), item_name(in) {}
+			location(location&&) = default;
+			location& operator = (location&&) = default;
+			location(const location&) = default;
+			location& operator = (const location&) = default;
+
 			// A name for the content this location refers
 			// to. Will generally be a filename, can also
 			// refer to a rule/macro condition when the
@@ -110,6 +127,11 @@ namespace rule_loader
 
 		virtual ~context() = default;
 
+		context(context&&) = default;
+		context& operator = (context&&) = default;
+		context(const context&) = default;
+		context& operator = (const context&) = default;
+
 		// Return the content name (generally filename) for
 		// this context
 		const std::string& name() const;
@@ -145,6 +167,16 @@ namespace rule_loader
 
 	struct warning
 	{
+		warning(): ctx("no-filename-given") {}
+		warning(
+			falco::load_result::warning_code w,
+			const std::string& m,
+			const context& c): wc(w), msg(m), ctx(c) {}
+		warning(warning&&) = default;
+		warning& operator = (warning&&) = default;
+		warning(const warning&) = default;
+		warning& operator = (const warning&) = default;
+
 		falco::load_result::warning_code wc;
 		std::string msg;
 		context ctx;
@@ -152,6 +184,16 @@ namespace rule_loader
 
 	struct error
 	{
+		error(): ctx("no-filename-given") {}
+		error(
+			falco::load_result::error_code e,
+			const std::string& m,
+			const context& c): ec(e), msg(m), ctx(c) {}
+		error(error&&) = default;
+		error& operator = (error&&) = default;
+		error(const error&) = default;
+		error& operator = (const error&) = default;
+
 		falco::load_result::error_code ec;
 		std::string msg;
 		context ctx;
@@ -162,6 +204,11 @@ namespace rule_loader
 	public:
 		rule_load_exception(falco::load_result::error_code ec, std::string msg, const context& ctx);
 		virtual ~rule_load_exception();
+		rule_load_exception(rule_load_exception&&) = default;
+		rule_load_exception& operator = (rule_load_exception&&) = default;
+		rule_load_exception(const rule_load_exception&) = default;
+		rule_load_exception& operator = (const rule_load_exception&) = default;
+
 		const char* what();
 
 		falco::load_result::error_code ec;
@@ -179,6 +226,10 @@ namespace rule_loader
 	public:
 		result(const std::string &name);
 		virtual ~result() = default;
+		result(result&&) = default;
+		result& operator = (result&&) = default;
+		result(const result&) = default;
+		result& operator = (const result&) = default;
 
 		virtual bool successful() override;
 		virtual bool has_warnings() override;
@@ -217,10 +268,16 @@ namespace rule_loader
 			const std::string& cont,
 			const indexed_vector<falco_source>& srcs,
 			std::string name)
-				: content(cont), sources(srcs), name(name)
+				: content(cont), sources(srcs), name(name),
+				  default_ruleset_id(0), replace_output_container_info(false),
+				  min_priority(falco_common::PRIORITY_DEBUG)
 			{
 				res.reset(new result(name));
 			}
+		configuration(configuration&&) = default;
+		configuration& operator = (configuration&&) = default;
+		configuration(const configuration&) = delete;
+		configuration& operator = (const configuration&) = delete;
 
 		const std::string& content;
 		const indexed_vector<falco_source>& sources;
@@ -239,6 +296,10 @@ namespace rule_loader
 	{
 		engine_version_info(context &ctx);
 		~engine_version_info() = default;
+		engine_version_info(engine_version_info&&) = default;
+		engine_version_info& operator = (engine_version_info&&) = default;
+		engine_version_info(const engine_version_info&) = default;
+		engine_version_info& operator = (const engine_version_info&) = default;
 
 		context ctx;
 		uint32_t version;
@@ -254,6 +315,10 @@ namespace rule_loader
 			requirement() = default;
 			requirement(const std::string n, const std::string v):
 				name(n), version(v) { }
+			requirement(requirement&&) = default;
+			requirement& operator = (requirement&&) = default;
+			requirement(const requirement&) = default;
+			requirement& operator = (const requirement&) = default;
 
 			std::string name;
 			std::string version;
@@ -267,6 +332,10 @@ namespace rule_loader
 		plugin_version_info();
 		plugin_version_info(context &ctx);
 		~plugin_version_info() = default;
+		plugin_version_info(plugin_version_info&&) = default;
+		plugin_version_info& operator = (plugin_version_info&&) = default;
+		plugin_version_info(const plugin_version_info&) = default;
+		plugin_version_info& operator = (const plugin_version_info&) = default;
 
 		context ctx;
 		requirement_alternatives alternatives;
@@ -279,6 +348,10 @@ namespace rule_loader
 	{
 		list_info(context &ctx);
 		~list_info() = default;
+		list_info(list_info&&) = default;
+		list_info& operator = (list_info&&) = default;
+		list_info(const list_info&) = default;
+		list_info& operator = (const list_info&) = default;
 
 		context ctx;
 		bool used;
@@ -295,6 +368,10 @@ namespace rule_loader
 	{
 		macro_info(context &ctx);
 		~macro_info() = default;
+		macro_info(macro_info&&) = default;
+		macro_info& operator = (macro_info&&) = default;
+		macro_info(const macro_info&) = default;
+		macro_info& operator = (const macro_info&) = default;
 
 		context ctx;
 		context cond_ctx;
@@ -313,6 +390,10 @@ namespace rule_loader
 	{
 		rule_exception_info(context &ctx);
 		~rule_exception_info() = default;
+		rule_exception_info(rule_exception_info&&) = default;
+		rule_exception_info& operator = (rule_exception_info&&) = default;
+		rule_exception_info(const rule_exception_info&) = default;
+		rule_exception_info& operator = (const rule_exception_info&) = default;
 
 		/*!
 			\brief This is necessary due to the dynamic-typed nature of
@@ -321,6 +402,14 @@ namespace rule_loader
 			this easier to implement in C++, that is not non-dynamic-typed.
 		*/
 		struct entry {
+			entry(): is_list(false) {}
+			explicit entry(const std::string& i): is_list(false), item(i) {}
+			explicit entry(const std::vector<entry>& v): is_list(true), items(v) {}
+			entry(entry&&) = default;
+			entry& operator = (entry&&) = default;
+			entry(const entry&) = default;
+			entry& operator = (const entry&) = default;
+
 			bool is_list;
 			std::string item;
 			std::vector<entry> items;
@@ -346,6 +435,10 @@ namespace rule_loader
 	{
 		rule_info(context &ctx);
 		~rule_info() = default;
+		rule_info(rule_info&&) = default;
+		rule_info& operator = (rule_info&&) = default;
+		rule_info(const rule_info&) = default;
+		rule_info& operator = (const rule_info&) = default;
 
 		context ctx;
 		context cond_ctx;

--- a/userspace/engine/rule_loader_collector.cpp
+++ b/userspace/engine/rule_loader_collector.cpp
@@ -64,7 +64,7 @@ static void validate_exception_info(
 			ex.comps.is_list = true;
 			for (size_t i = 0; i < ex.fields.items.size(); i++)
 			{
-				ex.comps.items.push_back({false, "="});
+				ex.comps.items.push_back(rule_loader::rule_exception_info::entry("="));
 			}
 		}
 		THROW(ex.fields.items.size() != ex.comps.items.size(),

--- a/userspace/engine/rule_loader_collector.h
+++ b/userspace/engine/rule_loader_collector.h
@@ -29,7 +29,12 @@ namespace rule_loader
 class collector
 {
 public:
+	collector(): m_cur_index(0) { }
 	virtual ~collector() = default;
+	collector(collector&&) = default;
+	collector& operator = (collector&&) = default;
+	collector(const collector&) = delete;
+	collector& operator = (const collector&) = delete;
 
 	/*!
 		\brief Erases all the internal state and definitions

--- a/userspace/engine/rule_loader_compiler.h
+++ b/userspace/engine/rule_loader_compiler.h
@@ -30,7 +30,12 @@ namespace rule_loader
 class compiler
 {
 public:
+	compiler() = default;
 	virtual ~compiler() = default;
+	compiler(compiler&&) = default;
+	compiler& operator = (compiler&&) = default;
+	compiler(const compiler&) = default;
+	compiler& operator = (const compiler&) = default;
 
 	/*!
 		\brief Compiles a list of falco rules

--- a/userspace/engine/rule_loader_reader.h
+++ b/userspace/engine/rule_loader_reader.h
@@ -28,7 +28,12 @@ namespace rule_loader
 class reader
 {
 public:
+    reader() = default;
     virtual ~reader() = default;
+    reader(reader&&) = default;
+	reader& operator = (reader&&) = default;
+	reader(const reader&) = default;
+	reader& operator = (const reader&) = default;
 
     /*!
 		\brief Reads the contents of a ruleset and uses a collector to store

--- a/userspace/engine/stats_manager.h
+++ b/userspace/engine/stats_manager.h
@@ -34,6 +34,10 @@ class stats_manager
 public:
 	stats_manager();
 	virtual ~stats_manager();
+	stats_manager(stats_manager&&) = default;
+	stats_manager& operator = (stats_manager&&) = default;
+	stats_manager(const stats_manager&) = default;
+	stats_manager& operator = (const stats_manager&) = default;
 
 	/*!
 		\brief Erases the internal state and statistics data

--- a/userspace/falco/application.cpp
+++ b/userspace/falco/application.cpp
@@ -46,7 +46,8 @@ application::state::state()
 	  source_infos(),
 	  plugin_configs(),
 	  ppm_sc_of_interest(),
-	  tp_of_interest()
+	  tp_of_interest(),
+	  syscall_buffer_bytes_size(DEFAULT_DRIVER_BUFFER_BYTES_DIM)
 {
 	config = std::make_shared<falco_configuration>();
 	engine = std::make_shared<falco_engine>();

--- a/userspace/falco/application.h
+++ b/userspace/falco/application.h
@@ -36,6 +36,10 @@ class application {
 public:
 	application();
 	virtual ~application();
+	application(application&&) = default;
+	application& operator = (application&&) = default;
+	application(const application&) = delete;
+	application& operator = (const application&) = delete;
 
 	// These are only used in signal handlers. Other than there,
 	// the control flow of the application should not be changed
@@ -174,6 +178,11 @@ private:
 
 		run_result();
 		virtual ~run_result();
+		run_result(run_result&&) = default;
+		run_result& operator = (run_result&&) = default;
+		run_result(const run_result&) = default;
+		run_result& operator = (const run_result&) = default;
+
 
 		// If true, the method completed successfully.
 		bool success;

--- a/userspace/falco/stats_writer.h
+++ b/userspace/falco/stats_writer.h
@@ -67,11 +67,11 @@ public:
 
 	stats_writer(const stats_writer&) = delete;
 
-	stats_writer(stats_writer&&) = delete;
+	stats_writer(stats_writer&&) = default;
 
 	stats_writer& operator=(const stats_writer&) = delete;
 
-	stats_writer& operator=(stats_writer&&) = delete;
+	stats_writer& operator=(stats_writer&&) = default;
 
 	~stats_writer();
 
@@ -109,6 +109,12 @@ public:
 private:
 	struct msg
 	{
+		msg(): stop(false) {}
+		msg(msg&&) = default;
+		msg& operator = (msg&&) = default;
+		msg(const msg&) = default;
+		msg& operator = (const msg&) = default;
+
 		bool stop;
 		scap_stats delta;
 		scap_stats stats;


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This cleans up the codebase by adding explicit constructors and initialization, and makes the copy/move semantics explicit  where missing. This should solve some tedious bugs and non-predictable behaviors (and make cppcheck happier).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
