### PR TITLE
fix(userspace/falco): check plugin requirements when validating rule files

### DIFF
--- a/userspace/falco/app_actions/validate_rules_files.cpp
+++ b/userspace/falco/app_actions/validate_rules_files.cpp
@@ -70,6 +70,7 @@ application::run_result application::validate_rules_files()
 
 		// The json output encompasses all files so the
 		// validation result is a single json object.
+		std::string err = "";
 		nlohmann::json results = nlohmann::json::array();
 
 		for(auto &filename : m_options.validate_rules_filenames)
@@ -77,6 +78,10 @@ application::run_result application::validate_rules_files()
 			std::unique_ptr<falco::load_result> res;
 
 			res = m_state->engine->load_rules(rc.at(filename), filename);
+			if (!check_rules_plugin_requirements(err))
+			{
+				return run_result::fatal(err);
+			}
 
 			successful &= res->successful();
 

--- a/userspace/falco/application.h
+++ b/userspace/falco/application.h
@@ -284,6 +284,7 @@ private:
 	bool create_handler(int sig, void (*func)(int), run_result &ret);
 	void configure_output_format();
 	void check_for_ignored_events();
+	bool check_rules_plugin_requirements(std::string& err);
 	void format_plugin_info(std::shared_ptr<sinsp_plugin> p, std::ostream& os) const;
 	run_result open_offline_inspector();
 	run_result open_live_inspector(std::shared_ptr<sinsp> inspector, const std::string& source);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This fixes a regression. When validating rule files with the `-V` option, plugin requirements expressed by the ruleset where not checked.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
