### PR TITLE
fix(rules): add falco no-driver images to k8s_containers macro

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2412,7 +2412,9 @@
      quay.io/prometheus-operator/prometheus-operator,
      k8s.gcr.io/ingress-nginx/kube-webhook-certgen, quay.io/spotahome/redis-operator,
      registry.opensource.zalan.do/acid/postgres-operator, registry.opensource.zalan.do/acid/postgres-operator-ui,
-     rabbitmqoperator/cluster-operator)
+     rabbitmqoperator/cluster-operator,
+     falcosecurity/falco-no-driver, docker.io/falcosecurity/falco-no-driver,
+     public.ecr.aws/falcosecurity/falco-no-driver)
      or (k8s.ns.name = "kube-system"))
 
 - macro: k8s_api_server


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

This adds the falco-no-driver images to the whitelist of the `k8s_containers` macro. Now that the official helm chart use the no-driver image as default, and considering the latest fixes the the libsinsp's k8s metadata client, Falco started alerting the `Contact K8S API Server From Container` rule noisy due to it detecting its own calls to the API server.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
rules(macro: k8s_containers): add falco no-driver images
```
