### PR TITLE
fix(falco_service): falco service needs to write under `/sys/module/falco`

### DIFF
--- a/cmake/cpack/CMakeCPackOptions.cmake
+++ b/cmake/cpack/CMakeCPackOptions.cmake
@@ -1,11 +1,13 @@
 if(CPACK_GENERATOR MATCHES "DEB")
 	list(APPEND CPACK_INSTALL_COMMANDS "mkdir -p _CPack_Packages/${CPACK_TOPLEVEL_TAG}/${CPACK_GENERATOR}/${CPACK_PACKAGE_FILE_NAME}/usr/lib/systemd/system")
 	list(APPEND CPACK_INSTALL_COMMANDS "cp scripts/debian/falco.service _CPack_Packages/${CPACK_TOPLEVEL_TAG}/${CPACK_GENERATOR}/${CPACK_PACKAGE_FILE_NAME}/usr/lib/systemd/system")
+	list(APPEND CPACK_INSTALL_COMMANDS "cp scripts/debian/falco_inject_kmod.service _CPack_Packages/${CPACK_TOPLEVEL_TAG}/${CPACK_GENERATOR}/${CPACK_PACKAGE_FILE_NAME}/usr/lib/systemd/system")
 endif()
 
 if(CPACK_GENERATOR MATCHES "RPM")
 	list(APPEND CPACK_INSTALL_COMMANDS "mkdir -p _CPack_Packages/${CPACK_TOPLEVEL_TAG}/${CPACK_GENERATOR}/${CPACK_PACKAGE_FILE_NAME}/usr/lib/systemd/system")
 	list(APPEND CPACK_INSTALL_COMMANDS "cp scripts/rpm/falco.service _CPack_Packages/${CPACK_TOPLEVEL_TAG}/${CPACK_GENERATOR}/${CPACK_PACKAGE_FILE_NAME}/usr/lib/systemd/system")
+	list(APPEND CPACK_INSTALL_COMMANDS "cp scripts/rpm/falco_inject_kmod.service _CPack_Packages/${CPACK_TOPLEVEL_TAG}/${CPACK_GENERATOR}/${CPACK_PACKAGE_FILE_NAME}/usr/lib/systemd/system")
 endif()
 
 if(CPACK_GENERATOR MATCHES "TGZ")

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -22,11 +22,17 @@ configure_file(debian/prerm.in debian/prerm)
 file(COPY "${PROJECT_SOURCE_DIR}/scripts/debian/falco.service"
 	DESTINATION "${PROJECT_BINARY_DIR}/scripts/debian")
 
+file(COPY "${PROJECT_SOURCE_DIR}/scripts/debian/falco_inject_kmod.service"
+	DESTINATION "${PROJECT_BINARY_DIR}/scripts/debian")
+
 configure_file(rpm/postinstall.in rpm/postinstall)
 configure_file(rpm/postuninstall.in rpm/postuninstall)
 configure_file(rpm/preuninstall.in rpm/preuninstall)
 
 file(COPY "${PROJECT_SOURCE_DIR}/scripts/rpm/falco.service"
+	DESTINATION "${PROJECT_BINARY_DIR}/scripts/rpm")
+
+file(COPY "${PROJECT_SOURCE_DIR}/scripts/rpm/falco_inject_kmod.service"
 	DESTINATION "${PROJECT_BINARY_DIR}/scripts/rpm")
 
 configure_file(falco-driver-loader falco-driver-loader @ONLY)

--- a/scripts/debian/falco.service
+++ b/scripts/debian/falco.service
@@ -17,6 +17,7 @@ NoNewPrivileges=yes
 ProtectHome=read-only
 ProtectSystem=full
 ProtectKernelTunables=true
+ReadWritePaths=/sys/module
 RestrictRealtime=true
 RestrictAddressFamilies=~AF_PACKET
 

--- a/scripts/debian/falco.service
+++ b/scripts/debian/falco.service
@@ -1,11 +1,12 @@
 [Unit]
 Description=Falco: Container Native Runtime Security
 Documentation=https://falco.org/docs/
+After=falco_inject_kmod.service
+Requires=falco_inject_kmod.service
 
 [Service]
 Type=simple
 User=root
-ExecStartPre=/sbin/modprobe falco
 ExecStart=/usr/bin/falco --pidfile=/var/run/falco.pid
 ExecStopPost=/sbin/rmmod falco
 UMask=0077
@@ -17,7 +18,7 @@ NoNewPrivileges=yes
 ProtectHome=read-only
 ProtectSystem=full
 ProtectKernelTunables=true
-ReadWritePaths=/sys/module
+ReadWritePaths=/sys/module/falco
 RestrictRealtime=true
 RestrictAddressFamilies=~AF_PACKET
 

--- a/scripts/debian/falco_inject_kmod.service
+++ b/scripts/debian/falco_inject_kmod.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Falco: Container Native Runtime Security
+Documentation=https://falco.org/docs/
+Before=falco.service
+Wants=falco.service
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/sbin/modprobe falco
+Restart=on-failure
+TimeoutSec=30s
+RestartSec=15s
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/rpm/falco.service
+++ b/scripts/rpm/falco.service
@@ -17,6 +17,7 @@ NoNewPrivileges=yes
 ProtectHome=read-only
 ProtectSystem=full
 ProtectKernelTunables=true
+ReadWritePaths=/sys/module
 RestrictRealtime=true
 RestrictAddressFamilies=~AF_PACKET
 StandardOutput=null

--- a/scripts/rpm/falco.service
+++ b/scripts/rpm/falco.service
@@ -1,11 +1,12 @@
 [Unit]
 Description=Falco: Container Native Runtime Security
 Documentation=https://falco.org/docs/
+After=falco_inject_kmod.service
+Requires=falco_inject_kmod.service
 
 [Service]
 Type=simple
 User=root
-ExecStartPre=/sbin/modprobe falco
 ExecStart=/usr/bin/falco --pidfile=/var/run/falco.pid
 ExecStopPost=/sbin/rmmod falco
 UMask=0077
@@ -17,7 +18,7 @@ NoNewPrivileges=yes
 ProtectHome=read-only
 ProtectSystem=full
 ProtectKernelTunables=true
-ReadWritePaths=/sys/module
+ReadWritePaths=/sys/module/falco
 RestrictRealtime=true
 RestrictAddressFamilies=~AF_PACKET
 StandardOutput=null

--- a/scripts/rpm/falco_inject_kmod.service
+++ b/scripts/rpm/falco_inject_kmod.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Falco: Container Native Runtime Security
+Documentation=https://falco.org/docs/
+Before=falco.service
+Wants=falco.service
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/sbin/modprobe falco
+Restart=on-failure
+TimeoutSec=30s
+RestartSec=15s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Trying to run the latest Falco deb/rpm package there is an issue:

Since this PR https://github.com/falcosecurity/falco/pull/2214, Falco service needs to write under `/sys/module/falco/parameters/g_buffer_bytes_dim`  the variable buffer dimension. The problem is that right now the path `/sys/module` is mounted read-only so Falco will fail with `Errno 30` in the attempt to write `/sys/module/falco/parameters/g_buffer_bytes_dim`:

```
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Falco version: 0.32.1-241+251b4d5 (x86_64)
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Fri Oct  7 23:41:26 2022: Falco version: 0.32.1-241+251b4d5 (x86_64)
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Fri Oct  7 23:41:26 2022: Falco initialized with configuration file: /etc/falco/falco.yaml
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Falco initialized with configuration file: /etc/falco/falco.yaml
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Loading rules from file /etc/falco/falco_rules.yaml
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Fri Oct  7 23:41:26 2022: Loading rules from file /etc/falco/falco_rules.yaml
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Loading rules from file /etc/falco/falco_rules.local.yaml
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Fri Oct  7 23:41:26 2022: Loading rules from file /etc/falco/falco_rules.local.yaml
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: The chosen syscall buffer dimension is: 8388608 bytes (8 MBs)
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Fri Oct  7 23:41:26 2022: The chosen syscall buffer dimension is: 8388608 bytes (8 MBs)
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Fri Oct  7 23:41:26 2022: Starting health webserver with threadiness 6, listening on port 8765
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Starting health webserver with threadiness 6, listening on port 8765
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Fri Oct  7 23:41:26 2022: Enabled event sources: syscall
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Fri Oct  7 23:41:26 2022: Opening capture with Kernel module
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Enabled event sources: syscall
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Opening capture with Kernel module
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Trying to inject the Kernel module and opening the capture again...
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Fri Oct  7 23:41:26 2022: Trying to inject the Kernel module and opening the capture again...
Oct 07 23:41:26 ubuntu2204.localdomain falco[34605]: Error: unable to open '/sys/module/falco/parameters/g_buffer_bytes_dim': Errno 30. Please ensure the kernel module is already loaded.
```

Considering the falco service config:

```
[Unit]
Description=Falco: Container Native Runtime Security
Documentation=https://falco.org/docs/

[Service]
Type=simple
User=root
ExecStartPre=/sbin/modprobe falco
ExecStart=/usr/bin/falco --pidfile=/var/run/falco.pid
ExecStopPost=/sbin/rmmod falco
UMask=0077
TimeoutSec=30
RestartSec=15s
Restart=on-failure
PrivateTmp=true
NoNewPrivileges=yes
ProtectHome=read-only
ProtectSystem=full
ProtectKernelTunables=true
RestrictRealtime=true
RestrictAddressFamilies=~AF_PACKET

[Install]
WantedBy=multi-user.target

```

there are some solutions to this problem:
1. The most aggressive one is to put `ProtectKernelTunables` to `false`
2. [PROPOSED ONE] The cleanest one should be to inject the kmod in a separate unit and call the falco unit only when the path `/sys/module/falco` is already there, in this way the falco unit could set `ReadWritePaths` to only `/sys/module/falco`
3. The third solution sets `ReadWritePaths` to  `/sys/module` because the falco subfolder is not yet created at startup-time and we cannot `mkdir` this directory into another unit because we cannot create folders under `sys/module` only the kernel can do that. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
