### PR TITLE
fix(userspace/falco): make termination and signal handlers more stable

### DIFF
--- a/userspace/falco/app_actions/create_signal_handlers.cpp
+++ b/userspace/falco/app_actions/create_signal_handlers.cpp
@@ -75,7 +75,7 @@ application::run_result application::create_signal_handlers()
 	falco::app::g_terminate.store(APP_SIGNAL_NOT_SET, std::memory_order_seq_cst);
 	falco::app::g_restart.store(APP_SIGNAL_NOT_SET, std::memory_order_seq_cst);
 	falco::app::g_reopen_outputs.store(APP_SIGNAL_NOT_SET, std::memory_order_seq_cst);
-	
+
 	if (!g_terminate.is_lock_free()
 		|| !g_restart.is_lock_free()
 		|| !g_reopen_outputs.is_lock_free())
@@ -83,12 +83,15 @@ application::run_result application::create_signal_handlers()
 		falco_logger::log(LOG_WARNING, "Bundled atomics implementation is not lock-free, signal handlers may be unstable\n");
 	}
 
-	// we use the if just to make sure we return at the first failed statement
 	run_result ret;
 	if(! create_handler(SIGINT, ::terminate_signal_handler, ret) ||
 	   ! create_handler(SIGTERM, ::terminate_signal_handler, ret) ||
 	   ! create_handler(SIGUSR1, ::reopen_outputs_signal_handler, ret) ||
-	   ! create_handler(SIGHUP, ::restart_signal_handler, ret));
+	   ! create_handler(SIGHUP, ::restart_signal_handler, ret))
+	{
+		// we use the if just to make sure we return at the first failed statement
+	}
+
 	return ret;
 }
 

--- a/userspace/falco/app_actions/process_events.cpp
+++ b/userspace/falco/app_actions/process_events.cpp
@@ -374,6 +374,7 @@ application::run_result application::process_events()
 					// note: we don't return here because we need to reach
 					// the thread termination loop below to make sure all
 					// already-spawned threads get terminated gracefully
+					ctx.finished->store(true, std::memory_order_seq_cst);
 					break;
 				}
 
@@ -395,6 +396,7 @@ application::run_result application::process_events()
 				// the thread termination loop below to make sure all
 				// already-spawned threads get terminated gracefully
 				ctx.res = run_result::fatal(e.what());
+				ctx.finished->store(true, std::memory_order_seq_cst);
 				break;
 			}
 		}

--- a/userspace/falco/app_actions/process_events.cpp
+++ b/userspace/falco/app_actions/process_events.cpp
@@ -407,7 +407,7 @@ application::run_result application::process_events()
 		{
 			if (!res.success && !termination_forced)
 			{
-				falco_logger::log(LOG_INFO, "An error occurred in one event source, forcing termination...\n");
+				falco_logger::log(LOG_INFO, "An error occurred in an event source, forcing termination...\n");
 				terminate();
 				termination_forced = true;
 			}

--- a/userspace/falco/app_actions/process_events.cpp
+++ b/userspace/falco/app_actions/process_events.cpp
@@ -97,10 +97,19 @@ application::run_result application::do_inspect(
 	{
 		rc = inspector->next(&ev);
 
-		if(m_state->terminate.load(std::memory_order_seq_cst)
-			|| m_state->restart.load(std::memory_order_seq_cst))
+		if(should_terminate())
 		{
+			terminate();
 			break;
+		}
+		else if(should_restart())
+		{
+			restart();
+			break;
+		}
+		else if (should_reopen_outputs())
+		{
+			reopen_outputs();
 		}
 		else if(rc == SCAP_TIMEOUT)
 		{

--- a/userspace/falco/app_actions/process_events.cpp
+++ b/userspace/falco/app_actions/process_events.cpp
@@ -98,6 +98,11 @@ application::run_result application::do_inspect(
 	{
 		rc = inspector->next(&ev);
 
+		if (should_reopen_outputs())
+		{
+			reopen_outputs();
+		}
+
 		if(should_terminate())
 		{
 			terminate();
@@ -107,10 +112,6 @@ application::run_result application::do_inspect(
 		{
 			restart();
 			break;
-		}
-		else if (should_reopen_outputs())
-		{
-			reopen_outputs();
 		}
 		else if(rc == SCAP_TIMEOUT)
 		{

--- a/userspace/falco/application.cpp
+++ b/userspace/falco/application.cpp
@@ -115,6 +115,7 @@ void application::reopen_outputs()
 		{
 			m_state->outputs->reopen_outputs();
 		}
+		falco::app::g_reopen_outputs.store(APP_SIGNAL_NOT_SET);
 	}
 }
 

--- a/userspace/falco/application.h
+++ b/userspace/falco/application.h
@@ -304,6 +304,7 @@ private:
 		std::shared_ptr<sinsp> inspector,
 		std::shared_ptr<stats_writer> statsw,
 		std::string source, // an empty source represents capture mode
+		std::atomic<bool>* finished,
 		run_result* res) noexcept;
 
 	/* Returns true if we are in capture mode. */


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Signal handlers are used in Falco to force termination, hot reload, or output reloading. However, the current implementation is not stable for neither thread-safety and async-signal safety (more here: https://docs.oracle.com/cd/E19455-01/806-5257/gen-26/index.html). This PR refactors the way signals are handled to make sure it's safe both on single-threaded (e.g. capturing only syscalls) and multi-threaded use cases (e.g. multiple event sources in parallel).

Accordingly, the event source termination stage has been refactored to be more stable by using atomic values to check 1) that the event source has actually finished processing events, and 2) that the corresponding thread has already been joined. This is safer than simply relying on the `thread.joinable()` and `thread.join()` primitives.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
