### PR TITLE
feat: Support for detecting outbound connection to c2 servers with FQ…

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -3052,10 +3052,39 @@
 - list: c2_server_ip_list
   items: []
 
+- list: c2_server_fqdn_list
+  items: []
+
+# For example, you can fetch a list of IP addresses and FQDN on this website:
+# https://feodotracker.abuse.ch/downloads/ipblocklist_recommended.json.
+# Use Falco HELM chart to update (append) the c2 server lists with your values.
+# See an example below.
+#
+#  ```yaml
+#  # values.yaml Falco HELM chart file
+#  [...]
+#  customRules:
+#    c2-servers-list.yaml: |-
+#      - list: c2_server_ip_list
+#        append: true
+#        items: 
+#        - "'51.178.161.32'"
+#        - "'46.101.90.205'"
+#        
+#      - list: c2_server_fqdn_list
+#        append: true
+#        items: 
+#        - "srv-web.ffconsulting.com"
+#        - "57.ip-142-44-247.net"
+#  ```
+
 - rule: Outbound Connection to C2 Servers
-  desc: Detect outbound connection to command & control servers
-  condition: outbound and fd.sip in (c2_server_ip_list)
-  output: Outbound connection to C2 server (command=%proc.cmdline pid=%proc.pid connection=%fd.name user=%user.name user_loginuid=%user.loginuid container_id=%container.id image=%container.image.repository)
+  desc: Detect outbound connection to command & control servers thanks to a list of IP addresses & a list of FQDN.
+  condition: >
+    outbound and 
+    ((fd.sip in (c2_server_ip_list)) or
+     (fd.sip.name in (c2_server_fqdn_list)))
+  output: Outbound connection to C2 server (c2_domain=%fd.sip.name c2_addr=%fd.sip command=%proc.cmdline connection=%fd.name user=%user.name user_loginuid=%user.loginuid container_id=%container.id image=%container.image.repository)
   priority: WARNING
   tags: [network]
 


### PR DESCRIPTION
…DN domains and IP addresses.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

/kind rule-update

/kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area rules


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This is a modification and enhancement of the [Falco rule](https://github.com/falcosecurity/falco/blob/79d875c28fdfb144ac8f417ee668fe2c4df175a0/rules/falco_rules.yaml#L3052-L3060) _outbound connection to c2 servers_. The rule was only considering IP addresses as a list of C2 servers. The rule was not considering Domain names (FQDN).

Now the rule both considers FQDN and IP address. This is espacially convenient for public list of C2 servers with both FQDN and IP addresses and that can be found on the internet, like this one:
https://feodotracker.abuse.ch/downloads/ipblocklist_recommended.json

The new  _outbound connection to c2 servers_ rules is inspired by other outbound rules like:
https://github.com/falcosecurity/falco/blob/master/rules/falco_rules.yaml#L392

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

No issue.

**Special notes for your reviewer**:

I am not sure that there is a user-facing change. Else I would say:
_Rule: Adding support for detecting outbound connection to c2 servers with both FQDN domains and IP addresses._


**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Update the "Outbound connection to C2 server" rule to match both FQDN and IP adresses. Prior to this change, the rule only matched IP adresses and not FQDN.
```