### PR TITLE
fix(userspace): cleanup output of ruleset validation result

### DIFF
--- a/test/falco_tests.yaml
+++ b/test/falco_tests.yaml
@@ -457,11 +457,6 @@ trace_files: !mux
         item_name: some macro
         code: LOAD_ERR_VALIDATE
         message: "Undefined macro 'foo' used in filter."
-    validate_warnings:
-      - item_type: macro
-        item_name: some macro
-        code: LOAD_UNUSED_MACRO
-        message: "Macro not referred to by any other rule/macro"
     validate_rules_file:
       - rules/invalid_overwrite_macro_multiple_docs.yaml
     trace_file: trace_files/cat_write.scap

--- a/userspace/engine/rule_loader_compiler.cpp
+++ b/userspace/engine/rule_loader_compiler.cpp
@@ -516,6 +516,7 @@ void rule_loader::compiler::compile(
 	catch(rule_load_exception &e)
 	{
 		cfg.res->add_error(e.ec, e.msg, e.ctx);
+		return;
 	}
 
 	// print info on any dangling lists or macros that were not used anywhere

--- a/userspace/falco/app_actions/validate_rules_files.cpp
+++ b/userspace/falco/app_actions/validate_rules_files.cpp
@@ -89,33 +89,30 @@ application::run_result application::validate_rules_files()
 			{
 				results.push_back(res->as_json(rc));
 			}
+			
+			if(summary != "")
+			{
+				summary += "\n";
+			}
+
+			// Add to the summary if not successful, or successful
+			// with no warnings.
+			if(!res->successful() || (res->successful() && !res->has_warnings()))
+			{
+				summary += res->as_string(true, rc);
+			}
 			else
 			{
-				if(summary != "")
-				{
-					summary += "\n";
-				}
+				// If here, there must be only warnings.
+				// Add a line to the summary noting that the
+				// file was ok with warnings, without actually
+				// printing the warnings.
+				summary += filename + ": Ok, with warnings";
 
-				// Add to the summary if not successful, or successful
-				// with no warnings.
-				if(!res->successful() ||
-				   (res->successful() && !res->has_warnings()))
+				// If verbose is true, print the warnings now.
+				if(m_options.verbose)
 				{
-					summary += res->as_string(true, rc);
-				}
-				else
-				{
-					// If here, there must be only warnings.
-					// Add a line to the summary noting that the
-					// file was ok with warnings, without actually
-					// printing the warnings.
-					summary += filename + ": Ok, with warnings";
-
-					// If verbose is true, print the warnings now.
-					if(m_options.verbose)
-					{
-						fprintf(stderr, "%s\n", res->as_string(true, rc).c_str());
-					}
+					fprintf(stderr, "%s\n", res->as_string(true, rc).c_str());
 				}
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This fixes two issues related to ruleset validation and error reporting:
1. Currently, when validating and loading rulesets we exit at the first error encountered. However, we didn't skip the "list/macro is unused" checks, which ended up flooding the loading result when encountering an error due to most/all macros and list being obviously unused. Plus, this was wrong logically because we can potentially encounter errors even before reaching the ruleset compilation step.
2. When printing validation result with json output enabled, we didn't fill-up the human-readable summary string. When encountering an error and making Falco terminate, this ended up in printing an empty string as a termination error.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace): cleanup output of ruleset validation result
```
