### PR TITLE
chore(userspace/falco): make logging optional when terminating, restarting, and reopening outputs

### DIFF
--- a/userspace/falco/app_actions/process_events.cpp
+++ b/userspace/falco/app_actions/process_events.cpp
@@ -411,7 +411,7 @@ application::run_result application::process_events()
 			if (!res.success && !termination_forced)
 			{
 				falco_logger::log(LOG_INFO, "An error occurred in an event source, forcing termination...\n");
-				terminate();
+				terminate(false);
 				termination_forced = true;
 			}
 			for (auto &ctx : ctxs)

--- a/userspace/falco/application.cpp
+++ b/userspace/falco/application.cpp
@@ -98,19 +98,25 @@ application::~application()
 {
 }
 
-void application::terminate()
+void application::terminate(bool verbose)
 {
 	if (should_take_action_to_signal(falco::app::g_terminate))
 	{
-		falco_logger::log(LOG_INFO, "SIGINT received, exiting...\n");
+		if (verbose)
+		{
+			falco_logger::log(LOG_INFO, "SIGINT received, exiting...\n");
+		}
 	}
 }
 
-void application::reopen_outputs()
+void application::reopen_outputs(bool verbose)
 {
 	if (should_take_action_to_signal(falco::app::g_reopen_outputs))
 	{
-		falco_logger::log(LOG_INFO, "SIGUSR1 received, reopening outputs...\n");
+		if (verbose)
+		{
+			falco_logger::log(LOG_INFO, "SIGUSR1 received, reopening outputs...\n");
+		}
 		if(m_state != nullptr && m_state->outputs != nullptr)
 		{
 			m_state->outputs->reopen_outputs();
@@ -119,11 +125,14 @@ void application::reopen_outputs()
 	}
 }
 
-void application::restart()
+void application::restart(bool verbose)
 {
 	if (should_take_action_to_signal(falco::app::g_restart))
 	{
-		falco_logger::log(LOG_INFO, "SIGHUP received, restarting...\n");
+		if (verbose)
+		{
+			falco_logger::log(LOG_INFO, "SIGHUP received, restarting...\n");
+		}
 	}
 }
 

--- a/userspace/falco/application.h
+++ b/userspace/falco/application.h
@@ -319,9 +319,9 @@ private:
 	}
 
 	// used in signal handlers to control the flow of the application
-	void terminate();
-	void restart();
-	void reopen_outputs();
+	void terminate(bool verbose=true);
+	void restart(bool verbose=true);
+	void reopen_outputs(bool verbose=true);
 	inline bool should_terminate()
 	{
 		return g_terminate.load(std::memory_order_seq_cst) != APP_SIGNAL_NOT_SET;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This avoids logging the `SIGINT received...` message when Falco terminates due to internal reasons.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
