### PR TITLE
update(userspace/falco): move on from deprecated libs API for printing event list

### DIFF
--- a/userspace/falco/app_actions/print_syscall_events.cpp
+++ b/userspace/falco/app_actions/print_syscall_events.cpp
@@ -16,17 +16,97 @@ limitations under the License.
 
 #include "application.h"
 
-#include <fields_info.h>
-
 using namespace falco::app;
+
+struct event_entry
+{
+	bool is_enter;
+	bool available;
+	std::string name;
+	struct ppm_event_info info;
+};
+
+static std::vector<event_entry> get_event_entries(bool include_generics, const std::unordered_set<uint32_t>& available)
+{
+	event_entry entry;
+	std::vector<event_entry> events;
+	std::unique_ptr<sinsp> inspector(new sinsp());
+	const struct ppm_event_info* etable = inspector->get_event_info_tables()->m_event_info;
+
+	// skip generic events
+	for(uint32_t evt = PPME_GENERIC_X + 1; evt < PPM_EVENT_MAX; evt++)
+	{
+		if (!sinsp::is_old_version_event(evt)
+				&& !sinsp::is_unused_event(evt)
+				&& !sinsp::is_unknown_event(evt))
+		{
+			entry.is_enter = PPME_IS_ENTER(evt);
+			entry.available = available.find(evt) != available.end();
+			entry.name = etable[evt].name;
+			entry.info = etable[evt];
+			events.push_back(entry);
+		}
+	}
+
+	if (include_generics)
+	{
+		// append generic events
+		const auto generic_syscalls = inspector->get_events_names({PPME_GENERIC_E});
+		for (const auto& name : generic_syscalls)
+		{
+			for(uint32_t evt = PPME_GENERIC_E; evt <= PPME_GENERIC_X; evt++)
+			{
+				entry.is_enter = PPME_IS_ENTER(evt);
+				entry.available = available.find(evt) != available.end();
+				entry.name = name;
+				entry.info = etable[evt];
+				events.push_back(entry);
+			}
+		}
+	}
+
+	return events;
+}
 
 application::run_result application::print_syscall_events()
 {
 	if(m_options.list_syscall_events)
 	{
-		// We know this function doesn't hold into the raw pointer value
-		std::unique_ptr<sinsp> inspector(new sinsp());
-		list_events(inspector.get(), m_options.markdown);
+		configure_interesting_sets();
+		const auto events = get_event_entries(false, m_state->ppm_event_info_of_interest);
+
+		if(m_options.markdown)
+		{
+			printf("Falco | Dir | Event\n");
+			printf(":-----|:----|:-----\n");
+		}
+
+		for (const auto& e : events)
+		{
+			char dir = e.is_enter ? '>' : '<';
+			if (m_options.markdown)
+			{
+				printf(e.available ? "Yes" : "No");
+				printf(" | %c | **%s**(", dir, e.name.c_str());
+			}
+			else
+			{
+				printf("%c %s(", dir, e.name.c_str());
+			}
+
+			for(uint32_t k = 0; k < e.info.nparams; k++)
+			{
+				if(k != 0)
+				{
+					printf(", ");
+				}
+
+				printf("%s %s", param_type_to_string(e.info.params[k].type),
+					e.info.params[k].name);
+			}
+			printf(")\n");
+		}
+
 		return run_result::exit();
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This fixes the `--list-syscall-events` option by making it print the right event list given the current new "interesting syscalls" model, and avoids using a deprecated libs api.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/falco): move on from deprecated libs API for printing event list
```
