### PR TITLE
fix(userspace/falco): avoid using CPU when main thread waits for parallel event sources

### DIFF
--- a/userspace/falco/application.h
+++ b/userspace/falco/application.h
@@ -369,7 +369,7 @@ private:
 		std::shared_ptr<sinsp> inspector,
 		std::shared_ptr<stats_writer> statsw,
 		std::string source, // an empty source represents capture mode
-		std::atomic<bool>* finished,
+		application::source_sync_context* sync,
 		run_result* res) noexcept;
 
 	/* Returns true if we are in capture mode. */

--- a/userspace/falco/semaphore.h
+++ b/userspace/falco/semaphore.h
@@ -1,0 +1,62 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <mutex>
+#include <condition_variable>
+
+namespace falco
+{
+    /**
+     * @brief A simple semaphore implementation. Unfortunately, a standard
+     * semaphore is only available since C++20, which currently we don't target.
+     */
+    class semaphore
+    {
+    public:
+        /**
+         * @brief Creates a semaphore with the given initial counter value
+         */
+        semaphore(int c = 0): count(c) {}
+
+        /**
+         * @brief Increments the internal counter and unblocks acquirers
+         */
+        inline void release()
+        {
+            std::unique_lock<std::mutex> lock(mtx);
+            count++;
+            cv.notify_one();
+        }
+
+        /**
+         * @brief Decrements the internal counter or blocks until it can
+         */
+        inline void acquire()
+        {
+            std::unique_lock<std::mutex> lock(mtx);
+            while (count == 0)
+            {
+                cv.wait(lock);
+            }
+            count--;
+        }
+
+    private:
+        std::mutex mtx;
+        std::condition_variable cv;
+        int count;
+    };
+};


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

When synchronizing with parallel event sources running in their own thread, the main thread was not put to sleep and consumed CPU with no purpose. Using a semaphore, we're able to let it sync with the additional threads only when at least one signals termination.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
