### PR TITLE
update(userspace/falco): turn error into warning log when plugins are loaded but unused

### DIFF
--- a/test/falco_tests_plugins.yaml
+++ b/test/falco_tests_plugins.yaml
@@ -54,13 +54,6 @@ trace_files: !mux
       - 'Cloudtrail Create Instance': 1
     conf_file: BUILD_DIR/test/confs/plugins/cloudtrail_json_create_instances_bigevent.yaml
 
-  incompatible_extract_sources:
-    exit_status: 1
-    stderr_contains: "Plugin '.*' has field extraction capability but is not compatible with any known event source"
-    conf_file: BUILD_DIR/test/confs/plugins/incompatible_extract_sources.yaml
-    rules_file:
-      - rules/plugins/cloudtrail_create_instances.yaml
-
   overlap_extract_sources:
     exit_status: 1
     stderr_contains: "Plugin '.*' supports extraction of field 'test.field' that is overlapping for source 'test_source'"

--- a/userspace/falco/app_actions/init_inspectors.cpp
+++ b/userspace/falco/app_actions/init_inspectors.cpp
@@ -186,8 +186,9 @@ application::run_result application::init_inspectors()
 			&& p->caps() & CAP_EXTRACTION
 			&& !(p->caps() & CAP_SOURCING && p->is_source_compatible(p->event_source())))
 		{
-			return run_result::fatal("Plugin '" + p->name()
-				+ "' has field extraction capability but is not compatible with any known event source");
+			falco_logger::log(LOG_WARNING, 
+				"Plugin '" + p->name()
+				+ "' has field extraction capability but is not compatible with any known event source\n");
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind design

**Any specific area of the project related to this PR?**

/area engine

/area tests

**What this PR does / why we need it**:

The error `plugin XXX has field extraction capability but is not compatible with any loaded event source` has been troublesome for many users. Although it's semantically correct to prevent Falco from loading plugins that are not actually used, this causes the UX to be worse for users who are getting started with the plugin system. So, this PR proposes turning the error into a warning-level log message, so that Falco does not get blocked.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

This is a proposal open for discussion, with the goal to insert it in Falco 0.33.0 eventually given the small amount of changes involved.

/hold

/milestone 0.33.0

```release-note
update(userspace/falco): turn error into warning log when plugins are loaded but unused
```
