### PR TITLE
fix(plugins): trim whitespace in `open_params`

### DIFF
--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -400,7 +400,8 @@ namespace YAML {
 
 			if(node["open_params"] && !node["open_params"].IsNull())
 			{
-				rhs.m_open_params = node["open_params"].as<std::string>();
+				string open_params = node["open_params"].as<std::string>();
+				rhs.m_open_params = trim(open_params);
 			}
 
 			return true;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

`open_params` is read from the falco YAML configuration file and parsed using Go's URL.

For example:
https://github.com/falcosecurity/plugins/blob/c349be6e84d2230698b5ca5d51ddadcda42c5e21/plugins/k8saudit/pkg/k8saudit/source.go#L41-L42

Go's URL parser does not handle whitespace, so if a user defines the `open_params` in the falco configuration file as follows

```yaml
open_params: >
/file/path
```

the parser returns an error. To avoid this, we now trim this parameter so no whitespace will be left for Go's URL parser to error out on.

**Which issue(s) this PR fixes**:

It doesn't fix it but it started from falcosecurity/plugins#182.

**Special notes for your reviewer**:

Read falcosecurity/plugins#182.

**Does this PR introduce a user-facing change?**:

```release-note
update(falco.yaml): `open_params` under plugins configuration is now trimmed from surrounding whitespace
```

/cc @jasondellaluce
/assign @yardenshoham