### PR TITLE
fix(engine): save syscall source only when processing events

### DIFF
--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -346,6 +346,11 @@ unique_ptr<falco_engine::rule_result> falco_engine::process_event(std::size_t so
 
 	if(source_idx == m_syscall_source_idx)
 	{
+		if(m_syscall_source == NULL)
+		{
+			m_syscall_source = find_source(m_syscall_source_idx);
+		}
+
 		source = m_syscall_source;
 	}
 	else
@@ -387,7 +392,6 @@ std::size_t falco_engine::add_source(const std::string &source,
 	if(source == falco_common::syscall_source)
 	{
 		m_syscall_source_idx = idx;
-		m_syscall_source = find_source(m_syscall_source_idx);
 	}
 
 	return idx;


### PR DESCRIPTION
The optimization in https://github.com/falcosecurity/falco/pull/2210 had a bug when the engine uses multiple sources at the same time--m_syscall_source is a pointer to an entry in the indexed vector m_sources, but if add_source is called multiple times, the vector is resized, which copies the structs but invalidates any pointer to the vector entries.

So instead of caching m_syscall_source in add_source(), cache it in process_events(). m_sources won't change once processing events starts.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area rules

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Avoid crash related to caching syscall source when the falco engine uses multiple sources at the same time.
```
