### PR TITLE
fix(userspace/falco): verify engine fields only for syscalls

### DIFF
--- a/userspace/falco/verify_engine_fields.sh
+++ b/userspace/falco/verify_engine_fields.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SOURCE_DIR=$1
 
-NEW_CHECKSUM=$(./falco -c ${SOURCE_DIR}/falco.yaml --list -N | sha256sum | awk '{print $1}')
+NEW_CHECKSUM=$(./falco -c ${SOURCE_DIR}/falco.yaml --list=syscall -N | sha256sum | awk '{print $1}')
 CUR_CHECKSUM=$(grep FALCO_FIELDS_CHECKSUM "${SOURCE_DIR}/userspace/engine/falco_engine_version.h" | awk '{print $3}' | sed -e 's/"//g')
 
 if [ "$NEW_CHECKSUM" != "$CUR_CHECKSUM" ]; then


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This improves the `verify_engine_fields.sh` script (used when building Falco) to just check for syscall-related fields. This aims to make developers' life easier when dealing with plugins (e.g. Falco build always fails if you load a plugin in your local falco.yaml file), which should not affect the built-in fields anyway.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
