### PR TITLE
rules: add OpenSSH private key to macro private_key_or_password

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -2548,6 +2548,7 @@
 - macro: private_key_or_password
   condition: >
     (proc.args icontains "BEGIN PRIVATE" or
+     proc.args icontains "BEGIN OPENSSH PRIVATE" or
      proc.args icontains "BEGIN RSA PRIVATE" or
      proc.args icontains "BEGIN DSA PRIVATE" or
      proc.args icontains "BEGIN EC PRIVATE" or


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

I noticed the rules macro `private_key_or_password` didn't check for OpenSSH private keys so I added it.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
rules(macro: private_key_or_password): now also check for OpenSSH private keys 
```
