### PR TITLE
fix(engine): fix warning about redundant std::move

### DIFF
--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -237,7 +237,7 @@ std::unique_ptr<load_result> falco_engine::load_rules_file(const string &rules_f
 
 		res->add_error(load_result::LOAD_ERR_FILE_READ, e.what(), ctx);
 
-		return std::move(res);
+		return res;
 	}
 
 	return load_rules(rules_content, rules_filename);


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fixes the following:

```
falco/userspace/engine/falco_engine.cpp: In member function ‘std::unique_ptr<falco::load_result> falco_engine::load_rules_file(const string&)’:                                                                
falco/userspace/engine/falco_engine.cpp:240:19: error: redundant move in return statement [-Werror=redundant-move]                                                                                             
  240 |   return std::move(res);                                                                                                                                                                                                              
      |          ~~~~~~~~~^~~~~                                                                                                                                                                                                               
falco/userspace/engine/falco_engine.cpp:240:19: note: remove ‘std::move’ call                                                                                                                                  
```

Necessary when compiling with warnings as errors.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

I could've sworn that I saw this fix already in another PR but I can't find it and it's not in master, so if there is already another PR open please tell me and I'll close this one.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
