### PR TITLE
update(falco): add container-gvisor and kubernetes-gvisor print options

### DIFF
--- a/userspace/falco/app_actions/init_falco_engine.cpp
+++ b/userspace/falco/app_actions/init_falco_engine.cpp
@@ -29,9 +29,19 @@ void application::configure_output_format()
 		output_format = "container=%container.name (id=%container.id)";
 		replace_container_info = true;
 	}
+	else if(m_options.print_additional == "container-gvisor")
+	{
+		output_format = "container=%container.name (id=%container.id) vpid=%proc.vpid vtid=%thread.vtid";
+		replace_container_info = true;
+	}
 	else if(m_options.print_additional == "k" || m_options.print_additional == "kubernetes")
 	{
 		output_format = "k8s.ns=%k8s.ns.name k8s.pod=%k8s.pod.name container=%container.id";
+		replace_container_info = true;
+	}
+	else if(m_options.print_additional == "kubernetes-gvisor")
+	{
+		output_format = "k8s.ns=%k8s.ns.name k8s.pod=%k8s.pod.name container=%container.id vpid=%proc.vpid vtid=%thread.vtid";
 		replace_container_info = true;
 	}
 	else if(m_options.print_additional == "m" || m_options.print_additional == "mesos")
@@ -43,11 +53,6 @@ void application::configure_output_format()
 	{
 		output_format = m_options.print_additional;
 		replace_container_info = false;
-	}
-	else if(m_options.gvisor_config != "")
-	{
-		output_format = "container=%container.name (id=%container.id) vpid=%proc.vpid vtid=%thread.vtid";
-		replace_container_info = true;
 	}
 
 	if(!output_format.empty())

--- a/userspace/falco/app_actions/init_falco_engine.cpp
+++ b/userspace/falco/app_actions/init_falco_engine.cpp
@@ -29,7 +29,7 @@ void application::configure_output_format()
 		output_format = "container=%container.name (id=%container.id)";
 		replace_container_info = true;
 	}
-	else if(m_options.print_additional == "container-gvisor")
+	else if(m_options.print_additional == "cg" || m_options.print_additional == "container-gvisor")
 	{
 		output_format = "container=%container.name (id=%container.id) vpid=%proc.vpid vtid=%thread.vtid";
 		replace_container_info = true;
@@ -39,7 +39,7 @@ void application::configure_output_format()
 		output_format = "k8s.ns=%k8s.ns.name k8s.pod=%k8s.pod.name container=%container.id";
 		replace_container_info = true;
 	}
-	else if(m_options.print_additional == "kubernetes-gvisor")
+	else if(m_options.print_additional == "kg" || m_options.print_additional == "kubernetes-gvisor")
 	{
 		output_format = "k8s.ns=%k8s.ns.name k8s.pod=%k8s.pod.name container=%container.id vpid=%proc.vpid vtid=%thread.vtid";
 		replace_container_info = true;


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

When running with gVisor on a host with containers, you probably want to print details with `container-gvisor`, when using kubernetes `kubernetes-gvisor`, as they're equivalent to `container` and `kubernetes` but add information useful for gVisor (currently vtid and vpid, but could be more). These can easily be used by the helm chart as well.

Also, remove the previous `if` that was trying to set this automatically. It is cleaner to specifiy the print format explicitly like we currently do with k8s.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
update(falco): add container-gvisor and kubernetes-gvisor print options
```
