### PR TITLE
rules: use list of Falco containers instead of repeating them

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1844,18 +1844,31 @@
           registry.access.redhat.com/sematext/agent,
           registry.access.redhat.com/sematext/logagent]
 
+# Falco containers
+- list: falco_containers
+  items:
+    - falcosecurity/falco
+    - docker.io/falcosecurity/falco
+    - public.ecr.aws/falcosecurity/falco
+
+# Falco no driver containers
+- list: falco_no_driver_containers
+  items:
+    - falcosecurity/falco-no-driver
+    - docker.io/falcosecurity/falco-no-driver
+    - public.ecr.aws/falcosecurity/falco-no-driver
+
 # These container images are allowed to run with --privileged and full set of capabilities
 - list: falco_privileged_images
   items: [
+    falco_containers,
     docker.io/calico/node,
     calico/node,
     docker.io/cloudnativelabs/kube-router,
     docker.io/docker/ucp-agent,
-    docker.io/falcosecurity/falco,
     docker.io/mesosphere/mesos-slave,
     docker.io/rook/toolbox,
     docker.io/sysdig/sysdig,
-    falcosecurity/falco,
     gcr.io/google_containers/kube-proxy,
     gcr.io/google-containers/startup-script,
     gcr.io/projectcalico-org/node,
@@ -1867,7 +1880,6 @@
     k8s.gcr.io/ip-masq-agent-amd64,
     k8s.gcr.io/kube-proxy,
     k8s.gcr.io/prometheus-to-sd,
-    public.ecr.aws/falcosecurity/falco,
     quay.io/calico/node,
     sysdig/sysdig,
     sematext_images,
@@ -1896,8 +1908,8 @@
 # host filesystem.
 - list: falco_sensitive_mount_images
   items: [
+    falco_containers,
     docker.io/sysdig/sysdig, sysdig/sysdig,
-    docker.io/falcosecurity/falco, falcosecurity/falco, public.ecr.aws/falcosecurity/falco,
     gcr.io/google_containers/hyperkube,
     gcr.io/google_containers/kube-proxy, docker.io/calico/node,
     docker.io/rook/toolbox, docker.io/cloudnativelabs/kube-router, docker.io/consul,
@@ -2409,18 +2421,17 @@
   condition: >
     (container.image.repository in (gcr.io/google_containers/hyperkube-amd64,
      gcr.io/google_containers/kube2sky,
-     docker.io/sysdig/sysdig, docker.io/falcosecurity/falco,
-     sysdig/sysdig, falcosecurity/falco,
+     docker.io/sysdig/sysdig, sysdig/sysdig,
      fluent/fluentd-kubernetes-daemonset, prom/prometheus,
+     falco_containers,
+     falco_no_driver_containers,
      ibm_cloud_containers,
-     public.ecr.aws/falcosecurity/falco, velero/velero,
+     velero/velero,
      quay.io/jetstack/cert-manager-cainjector, weaveworks/kured,
      quay.io/prometheus-operator/prometheus-operator,
      k8s.gcr.io/ingress-nginx/kube-webhook-certgen, quay.io/spotahome/redis-operator,
      registry.opensource.zalan.do/acid/postgres-operator, registry.opensource.zalan.do/acid/postgres-operator-ui,
-     rabbitmqoperator/cluster-operator,
-     falcosecurity/falco-no-driver, docker.io/falcosecurity/falco-no-driver,
-     public.ecr.aws/falcosecurity/falco-no-driver)
+     rabbitmqoperator/cluster-operator)
      or (k8s.ns.name = "kube-system"))
 
 - macro: k8s_api_server
@@ -2872,7 +2883,7 @@
   condition: (evt.type in (sendto, sendmsg, connect) and evt.dir=< and (fd.net != "127.0.0.0/8" and not fd.snet in (rfc_1918_addresses)) and ((minerpool_http) or (minerpool_https) or (minerpool_other)))
 
 - macro: trusted_images_query_miner_domain_dns
-  condition: (container.image.repository in (docker.io/falcosecurity/falco, falcosecurity/falco, public.ecr.aws/falcosecurity/falco))
+  condition: (container.image.repository in (falco_containers))
 
 # The rule is disabled by default.
 # Note: falco will send DNS request to resolve miner pool domain which may trigger alerts in your environment.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind rule-update

**Any specific area of the project related to this PR?**

/area rules

**What this PR does / why we need it**:

In the default rules I noticed the Falco containers where repeated in multiple rules. This creates a list and uses it instead which is similar to how the ibm_cloud_containers list is implemented and used.   

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
rules: add Falco container lists
```
