### PR TITLE
rules: add salt-call as a trusted process

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -220,7 +220,7 @@
   items: [probe_rpminfo, probe_rpmverify, probe_rpmverifyfile, probe_rpmverifypackage]
 
 - macro: rpm_procs
-  condition: (proc.name in (rpm_binaries, openscap_rpm_binaries) or proc.name in (salt-minion))
+  condition: (proc.name in (rpm_binaries, openscap_rpm_binaries) or proc.name in (salt-call, salt-minion))
 
 - list: deb_binaries
   items: [dpkg, dpkg-preconfigu, dpkg-reconfigur, dpkg-divert, apt, apt-get, aptitude,

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1441,7 +1441,7 @@
     and not proc.name in (user_mgmt_binaries, userexec_binaries, package_mgmt_binaries,
      cron_binaries, read_sensitive_file_binaries, shell_binaries, hids_binaries,
      vpn_binaries, mail_config_binaries, nomachine_binaries, sshkit_script_binaries,
-     in.proftpd, mandb, salt-minion, postgres_mgmt_binaries,
+     in.proftpd, mandb, salt-call, salt-minion, postgres_mgmt_binaries,
      google_oslogin_
      )
     and not cmp_cp_by_passwd


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind rule-update

**Any specific area of the project related to this PR?**

> /area rules

**What this PR does / why we need it**:

`salt-minion` was added as a trusted process in https://github.com/falcosecurity/falco/commit/85f51cf38c504772e00cc8918442ba6323ec9b89 and https://github.com/falcosecurity/falco/commit/1feae90c74943a7152972d94a39ed80965c26614, this however does not cover [salt-call](https://docs.saltproject.io/en/latest/ref/cli/salt-call.html) which is also a saltstack component and used on minions to apply changes from client-side. It should also be a trusted process along-with salt-minion as part of Saltstack.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
rule(Read sensitive file untrusted): let salt-call read sensitive files
rule(macro: rpm_procs): let salt-call write to rpm database
```

Thanks!