### PR TITLE
update(userspace): avoid using and relying on std namespace in headers

### DIFF
--- a/tests/engine/test_filter_evttype_resolver.cpp
+++ b/tests/engine/test_filter_evttype_resolver.cpp
@@ -20,24 +20,23 @@ limitations under the License.
 #include <sinsp.h>
 #include <filter/parser.h>
 
-using namespace std;
 using namespace libsinsp::filter;
 
-string to_string(set<uint16_t> s)
+std::string to_string(std::set<uint16_t> s)
 {
-	string out = "[";
+	std::string out = "[";
 	for(auto &val : s)
 	{
         out += out.size() == 1 ? "" : ", ";
-		out += to_string(val);
+		out += std::to_string(val);
 	}
 	out += "]";
 	return out;
 }
 
-void compare_evttypes(std::unique_ptr<ast::expr> f, set<uint16_t> &expected)
+void compare_evttypes(std::unique_ptr<ast::expr> f, std::set<uint16_t> &expected)
 {
-    set<uint16_t> actual;
+    std::set<uint16_t> actual;
     filter_evttype_resolver().evttypes(f.get(), actual);
     for(auto &etype : expected)
     {
@@ -49,30 +48,30 @@ void compare_evttypes(std::unique_ptr<ast::expr> f, set<uint16_t> &expected)
     }
 }
 
-std::unique_ptr<ast::expr> compile(const string &fltstr)
+std::unique_ptr<ast::expr> compile(const std::string &fltstr)
 {
     return libsinsp::filter::parser(fltstr).parse();
 }
 
 TEST_CASE("Should find event types from filter", "[rule_loader]")
 {
-    set<uint16_t> openat_only{
+    std::set<uint16_t> openat_only{
         PPME_SYSCALL_OPENAT_E, PPME_SYSCALL_OPENAT_X,
 		PPME_SYSCALL_OPENAT_2_E, PPME_SYSCALL_OPENAT_2_X };
 
-	set<uint16_t> close_only{
+	std::set<uint16_t> close_only{
 		PPME_SYSCALL_CLOSE_E, PPME_SYSCALL_CLOSE_X };
 
-	set<uint16_t> openat_close{
+	std::set<uint16_t> openat_close{
         PPME_SYSCALL_OPENAT_E, PPME_SYSCALL_OPENAT_X,
         PPME_SYSCALL_OPENAT_2_E, PPME_SYSCALL_OPENAT_2_X,
         PPME_SYSCALL_CLOSE_E, PPME_SYSCALL_CLOSE_X };
 
-	set<uint16_t> not_openat;
-	set<uint16_t> not_openat_close;
-	set<uint16_t> not_close;
-	set<uint16_t> all_events;
-	set<uint16_t> no_events;
+	std::set<uint16_t> not_openat;
+	std::set<uint16_t> not_openat_close;
+	std::set<uint16_t> not_close;
+	std::set<uint16_t> all_events;
+	std::set<uint16_t> no_events;
 
     for(uint32_t i = 2; i < PPM_EVENT_MAX; i++)
     {

--- a/tests/engine/test_filter_macro_resolver.cpp
+++ b/tests/engine/test_filter_macro_resolver.cpp
@@ -17,7 +17,6 @@ limitations under the License.
 #include "filter_macro_resolver.h"
 #include <catch.hpp>
 
-using namespace std;
 using namespace libsinsp::filter::ast;
 
 static pos_info create_pos(uint32_t idx, uint32_t line, uint32_t col)
@@ -39,7 +38,7 @@ static bool operator==(const pos_info& p1, const pos_info& p2)
 
 TEST_CASE("Should resolve macros on a filter AST", "[rule_loader]")
 {
-	string macro_name = "test_macro";
+	std::string macro_name = "test_macro";
 	pos_info macro_pos = create_pos(12, 85, 27);
 
 	SECTION("in the general case")
@@ -106,8 +105,8 @@ TEST_CASE("Should resolve macros on a filter AST", "[rule_loader]")
 
 	SECTION("with multiple macros")
 	{
-		string a_macro_name = macro_name + "_1";
-		string b_macro_name = macro_name + "_2";
+		std::string a_macro_name = macro_name + "_1";
+		std::string b_macro_name = macro_name + "_2";
 
 		pos_info a_macro_pos = create_pos(11, 75, 43);
 		pos_info b_macro_pos = create_pos(91, 21, 9);
@@ -155,8 +154,8 @@ TEST_CASE("Should resolve macros on a filter AST", "[rule_loader]")
 
 	SECTION("with nested macros")
 	{
-		string a_macro_name = macro_name + "_1";
-		string b_macro_name = macro_name + "_2";
+		std::string a_macro_name = macro_name + "_1";
+		std::string b_macro_name = macro_name + "_2";
 
 		pos_info a_macro_pos = create_pos(47, 1, 76);
 		pos_info b_macro_pos = create_pos(111, 65, 2);
@@ -207,7 +206,7 @@ TEST_CASE("Should resolve macros on a filter AST", "[rule_loader]")
 
 TEST_CASE("Should find unknown macros", "[rule_loader]")
 {
-	string macro_name = "test_macro";
+	std::string macro_name = "test_macro";
 	pos_info macro_pos = create_pos(9, 4, 2);
 
 	SECTION("in the general case")
@@ -227,8 +226,8 @@ TEST_CASE("Should find unknown macros", "[rule_loader]")
 
 	SECTION("with nested macros")
 	{
-		string a_macro_name = macro_name + "_1";
-		string b_macro_name = macro_name + "_2";
+		std::string a_macro_name = macro_name + "_1";
+		std::string b_macro_name = macro_name + "_2";
 
 		pos_info a_macro_pos = create_pos(32, 84, 9);
 		pos_info b_macro_pos = create_pos(1, 0, 5);
@@ -258,7 +257,7 @@ TEST_CASE("Should find unknown macros", "[rule_loader]")
 
 TEST_CASE("Should undefine macro", "[rule_loader]")
 {
-	string macro_name = "test_macro";
+	std::string macro_name = "test_macro";
 	pos_info macro_pos_1 = create_pos(12, 9, 3);
 	pos_info macro_pos_2 = create_pos(9, 6, 3);
 
@@ -286,7 +285,7 @@ TEST_CASE("Should undefine macro", "[rule_loader]")
 // checks that the macro AST is cloned and not shared across resolved filters
 TEST_CASE("Should clone macro AST", "[rule_loader]")
 {
-	string macro_name = "test_macro";
+	std::string macro_name = "test_macro";
 	pos_info macro_pos = create_pos(5, 2, 8888);
 	std::shared_ptr<unary_check_expr> macro = std::move(unary_check_expr::create("test.field", "", "exists"));
 	std::shared_ptr<expr> filter = std::move(value_expr::create(macro_name, macro_pos));

--- a/tests/falco/test_configuration.cpp
+++ b/tests/falco/test_configuration.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 #include "configuration.h"
 #include <catch.hpp>
 
-string sample_yaml = 
+std::string sample_yaml = 
     "base_value:\n"
     "    id: 1\n"
     "    name: 'sample_name'\n"
@@ -36,7 +36,7 @@ TEST_CASE("configuration must load YAML data", "[configuration]")
 
     SECTION("broken YAML")
     {
-        string sample_broken_yaml = sample_yaml + " /  bad_symbol";
+        std::string sample_broken_yaml = sample_yaml + " /  bad_symbol";
         REQUIRE_THROWS(conf.load_from_string(sample_broken_yaml));
     }
 
@@ -71,20 +71,20 @@ TEST_CASE("configuration must read YAML fields", "[configuration]")
     SECTION("arbitrary depth nesting")
     {
         REQUIRE(conf.get_scalar<int>("base_value.id", -1) == 1);
-        REQUIRE(conf.get_scalar<string>("base_value.name", "none") == "sample_name");
+        REQUIRE(conf.get_scalar<std::string>("base_value.name", "none") == "sample_name");
         REQUIRE(conf.get_scalar<bool>("base_value.subvalue.subvalue2.boolean", false) == true);
     }
     
     SECTION("list field elements")
     {
-        REQUIRE(conf.get_scalar<string>("base_value_2.sample_list[0]", "none") == "elem1");
-        REQUIRE(conf.get_scalar<string>("base_value_2.sample_list[1]", "none") == "elem2");
-        REQUIRE(conf.get_scalar<string>("base_value_2.sample_list[2]", "none") == "elem3");
+        REQUIRE(conf.get_scalar<std::string>("base_value_2.sample_list[0]", "none") == "elem1");
+        REQUIRE(conf.get_scalar<std::string>("base_value_2.sample_list[1]", "none") == "elem2");
+        REQUIRE(conf.get_scalar<std::string>("base_value_2.sample_list[2]", "none") == "elem3");
     }
 
     SECTION("sequence")
     {
-        vector<string> seq;
+        std::vector<std::string> seq;
         conf.get_sequence(seq, "base_value_2.sample_list");
         REQUIRE(seq.size() == 3);
         REQUIRE(seq[0] == "elem1");
@@ -95,7 +95,7 @@ TEST_CASE("configuration must read YAML fields", "[configuration]")
 
 TEST_CASE("configuration must modify YAML fields", "[configuration]")
 {
-    string key = "base_value.subvalue.subvalue2.boolean";
+    std::string key = "base_value.subvalue.subvalue2.boolean";
 	yaml_configuration conf;
     conf.load_from_string(sample_yaml);
     REQUIRE(conf.get_scalar<bool>(key, false) == true);

--- a/userspace/engine/evttype_index_ruleset.cpp
+++ b/userspace/engine/evttype_index_ruleset.cpp
@@ -20,8 +20,6 @@ limitations under the License.
 
 #include <algorithm>
 
-using namespace std;
-
 evttype_index_ruleset::evttype_index_ruleset(
 	std::shared_ptr<gen_event_filter_factory> f): m_filter_factory(f)
 {
@@ -174,7 +172,7 @@ void evttype_index_ruleset::add(
 	}
 	catch (const sinsp_exception& e)
 	{
-		throw falco_exception(string(e.what()));
+		throw falco_exception(std::string(e.what()));
 	}
 }
 
@@ -193,17 +191,17 @@ void evttype_index_ruleset::clear()
 	m_filters.clear();
 }
 
-void evttype_index_ruleset::enable(const string &substring, bool match_exact, uint16_t ruleset_id)
+void evttype_index_ruleset::enable(const std::string &substring, bool match_exact, uint16_t ruleset_id)
 {
 	enable_disable(substring, match_exact, true, ruleset_id);
 }
 
-void evttype_index_ruleset::disable(const string &substring, bool match_exact, uint16_t ruleset_id)
+void evttype_index_ruleset::disable(const std::string &substring, bool match_exact, uint16_t ruleset_id)
 {
 	enable_disable(substring, match_exact, false, ruleset_id);
 }
 
-void evttype_index_ruleset::enable_disable(const string &substring, bool match_exact, bool enabled, uint16_t ruleset_id)
+void evttype_index_ruleset::enable_disable(const std::string &substring, bool match_exact, bool enabled, uint16_t ruleset_id)
 {
 	while(m_rulesets.size() < (size_t)ruleset_id + 1)
 	{
@@ -223,7 +221,7 @@ void evttype_index_ruleset::enable_disable(const string &substring, bool match_e
 		}
 		else
 		{
-			matches = (substring == "" || (wrap->rule.name.find(substring) != string::npos));
+			matches = (substring == "" || (wrap->rule.name.find(substring) != std::string::npos));
 		}
 
 		if(matches)
@@ -240,17 +238,17 @@ void evttype_index_ruleset::enable_disable(const string &substring, bool match_e
 	}
 }
 
-void evttype_index_ruleset::enable_tags(const set<string> &tags, uint16_t ruleset_id)
+void evttype_index_ruleset::enable_tags(const std::set<std::string> &tags, uint16_t ruleset_id)
 {
 	enable_disable_tags(tags, true, ruleset_id);
 }
 
-void evttype_index_ruleset::disable_tags(const set<string> &tags, uint16_t ruleset_id)
+void evttype_index_ruleset::disable_tags(const std::set<std::string> &tags, uint16_t ruleset_id)
 {
 	enable_disable_tags(tags, false, ruleset_id);
 }
 
-void evttype_index_ruleset::enable_disable_tags(const set<string> &tags, bool enabled, uint16_t ruleset_id)
+void evttype_index_ruleset::enable_disable_tags(const std::set<std::string> &tags, bool enabled, uint16_t ruleset_id)
 {
 	while(m_rulesets.size() < (size_t)ruleset_id + 1)
 	{
@@ -259,7 +257,7 @@ void evttype_index_ruleset::enable_disable_tags(const set<string> &tags, bool en
 
 	for(const auto &wrap : m_filters)
 	{
-		std::set<string> intersect;
+		std::set<std::string> intersect;
 
 		set_intersection(tags.begin(), tags.end(),
 				 wrap->rule.tags.begin(), wrap->rule.tags.end(),
@@ -299,7 +297,7 @@ bool evttype_index_ruleset::run(gen_event *evt, falco_rule& match, uint16_t rule
 	return m_rulesets[ruleset_id]->run(evt, match);
 }
 
-void evttype_index_ruleset::enabled_evttypes(set<uint16_t> &evttypes, uint16_t ruleset_id)
+void evttype_index_ruleset::enabled_evttypes(std::set<uint16_t> &evttypes, uint16_t ruleset_id)
 {
 	if(m_rulesets.size() < (size_t)ruleset_id + 1)
 	{

--- a/userspace/engine/falco_common.cpp
+++ b/userspace/engine/falco_common.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "falco_common.h"
 
-static vector<string> priority_names = {
+static std::vector<std::string> priority_names = {
 	"Emergency",
 	"Alert",
 	"Critical",
@@ -27,7 +27,7 @@ static vector<string> priority_names = {
 	"Debug"
 };
 
-bool falco_common::parse_priority(string v, priority_type& out)
+bool falco_common::parse_priority(std::string v, priority_type& out)
 {
 	for (size_t i = 0; i < priority_names.size(); i++)
 	{
@@ -44,7 +44,7 @@ bool falco_common::parse_priority(string v, priority_type& out)
 	return false;
 }
 
-falco_common::priority_type falco_common::parse_priority(string v)
+falco_common::priority_type falco_common::parse_priority(std::string v)
 {
 	falco_common::priority_type out;
 	if (!parse_priority(v, out))
@@ -54,7 +54,7 @@ falco_common::priority_type falco_common::parse_priority(string v)
 	return out;
 }
 
-bool falco_common::format_priority(priority_type v, string& out, bool shortfmt)
+bool falco_common::format_priority(priority_type v, std::string& out, bool shortfmt)
 {
 	if ((size_t) v < priority_names.size())
 	{
@@ -71,12 +71,12 @@ bool falco_common::format_priority(priority_type v, string& out, bool shortfmt)
 	return false;
 }
 
-string falco_common::format_priority(priority_type v, bool shortfmt)
+std::string falco_common::format_priority(priority_type v, bool shortfmt)
 {
-	string out;
+	std::string out;
 	if(!format_priority(v, out, shortfmt))
 	{
-		throw falco_exception("Unknown priority enum value: " + to_string(v));
+		throw falco_exception("Unknown priority enum value: " + std::to_string(v));
 	}
 	return out;
 }

--- a/userspace/engine/falco_common.h
+++ b/userspace/engine/falco_common.h
@@ -52,7 +52,7 @@ struct falco_exception : std::exception
 
 namespace falco_common
 {
-	const string syscall_source = "syscall";
+	const std::string syscall_source = "syscall";
 
 	// Same as numbers/indices into the above vector
 	enum priority_type

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -38,7 +38,6 @@ limitations under the License.
 
 const std::string falco_engine::s_default_ruleset = "falco-default-ruleset";
 
-using namespace std;
 using namespace falco;
 
 falco_engine::falco_engine(bool seed_rng)
@@ -85,7 +84,7 @@ const falco_source* falco_engine::find_source(std::size_t index) const
 	auto ret = m_sources.at(index);
 	if(!ret)
 	{
-		throw falco_exception("Unknown event source index " + to_string(index));
+		throw falco_exception("Unknown event source index " + std::to_string(index));
 	}
 	return ret;
 }
@@ -169,7 +168,7 @@ void falco_engine::list_fields(std::string &source, bool verbose, bool names_onl
 	}
 }
 
-void falco_engine::load_rules(const string &rules_content, bool verbose, bool all_events)
+void falco_engine::load_rules(const std::string &rules_content, bool verbose, bool all_events)
 {
 	static const std::string no_name = "N/A";
 
@@ -222,7 +221,7 @@ void falco_engine::load_rules_file(const std::string &rules_filename, bool verbo
 	interpret_load_result(res, rules_filename, rules_content, verbose);
 }
 
-std::unique_ptr<load_result> falco_engine::load_rules_file(const string &rules_filename)
+std::unique_ptr<load_result> falco_engine::load_rules_file(const std::string &rules_filename)
 {
 	std::string rules_content;
 
@@ -243,7 +242,7 @@ std::unique_ptr<load_result> falco_engine::load_rules_file(const string &rules_f
 	return load_rules(rules_content, rules_filename);
 }
 
-void falco_engine::enable_rule(const string &substring, bool enabled, const string &ruleset)
+void falco_engine::enable_rule(const std::string &substring, bool enabled, const std::string &ruleset)
 {
 	uint16_t ruleset_id = find_ruleset_id(ruleset);
 	bool match_exact = false;
@@ -261,7 +260,7 @@ void falco_engine::enable_rule(const string &substring, bool enabled, const stri
 	}
 }
 
-void falco_engine::enable_rule_exact(const string &rule_name, bool enabled, const string &ruleset)
+void falco_engine::enable_rule_exact(const std::string &rule_name, bool enabled, const std::string &ruleset)
 {
 	uint16_t ruleset_id = find_ruleset_id(ruleset);
 	bool match_exact = true;
@@ -279,7 +278,7 @@ void falco_engine::enable_rule_exact(const string &rule_name, bool enabled, cons
 	}
 }
 
-void falco_engine::enable_rule_by_tag(const set<string> &tags, bool enabled, const string &ruleset)
+void falco_engine::enable_rule_by_tag(const std::set<std::string> &tags, bool enabled, const std::string &ruleset)
 {
 	uint16_t ruleset_id = find_ruleset_id(ruleset);
 
@@ -334,7 +333,7 @@ std::shared_ptr<gen_event_formatter> falco_engine::create_formatter(const std::s
 	return find_source(source)->formatter_factory->create_formatter(output);
 }
 
-unique_ptr<falco_engine::rule_result> falco_engine::process_event(std::size_t source_idx, gen_event *ev, uint16_t ruleset_id)
+std::unique_ptr<falco_engine::rule_result> falco_engine::process_event(std::size_t source_idx, gen_event *ev, uint16_t ruleset_id)
 {
 	// note: there are no thread-safety guarantees on the filter_ruleset::run()
 	// method, but the thread-safety assumptions of falco_engine::process_event()
@@ -360,10 +359,10 @@ unique_ptr<falco_engine::rule_result> falco_engine::process_event(std::size_t so
 
 	if(should_drop_evt() || !source || !source->ruleset->run(ev, source->m_rule, ruleset_id))
 	{
-		return unique_ptr<struct rule_result>();
+		return std::unique_ptr<struct rule_result>();
 	}
 
-	unique_ptr<struct rule_result> res(new rule_result());
+	std::unique_ptr<struct rule_result> res(new rule_result());
 	res->evt = ev;
 	res->rule = source->m_rule.name;
 	res->source = source->m_rule.source;
@@ -375,7 +374,7 @@ unique_ptr<falco_engine::rule_result> falco_engine::process_event(std::size_t so
 	return res;
 }
 
-unique_ptr<falco_engine::rule_result> falco_engine::process_event(std::size_t source_idx, gen_event *ev)
+std::unique_ptr<falco_engine::rule_result> falco_engine::process_event(std::size_t source_idx, gen_event *ev)
 {
 	return process_event(source_idx, ev, m_default_ruleset_id);
 }
@@ -411,7 +410,7 @@ std::size_t falco_engine::add_source(const std::string &source,
 	return m_sources.insert(src, source);
 }
 
-void falco_engine::describe_rule(string *rule) const
+void falco_engine::describe_rule(std::string *rule) const
 {
 	static const char* rule_fmt = "%-50s %s\n";
 	fprintf(stdout, rule_fmt, "Rule", "Description");
@@ -434,7 +433,7 @@ void falco_engine::describe_rule(string *rule) const
 
 void falco_engine::print_stats() const
 {
-	string out;
+	std::string out;
 	m_rule_stats_manager.format(m_rules, out);
 	// todo(jasondellaluce): introduce a logging callback in Falco
 	fprintf(stdout, "%s", out.c_str());
@@ -447,7 +446,7 @@ bool falco_engine::is_source_valid(const std::string &source) const
 
 void falco_engine::read_file(const std::string& filename, std::string& contents)
 {
-	ifstream is;
+	std::ifstream is;
 
 	is.open(filename);
 	if (!is.is_open())
@@ -455,8 +454,8 @@ void falco_engine::read_file(const std::string& filename, std::string& contents)
 		throw falco_exception("Could not open " + filename + " for reading");
 	}
 
-	contents.assign(istreambuf_iterator<char>(is),
-			istreambuf_iterator<char>());
+	contents.assign(std::istreambuf_iterator<char>(is),
+			std::istreambuf_iterator<char>());
 }
 
 void falco_engine::interpret_load_result(std::unique_ptr<load_result>& res,
@@ -559,7 +558,7 @@ void falco_engine::set_sampling_multiplier(double sampling_multiplier)
 	m_sampling_multiplier = sampling_multiplier;
 }
 
-void falco_engine::set_extra(string &extra, bool replace_container_info)
+void falco_engine::set_extra(std::string &extra, bool replace_container_info)
 {
 	m_extra = extra;
 	m_replace_container_info = replace_container_info;

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -150,7 +150,7 @@ public:
 	// add k8s/mesos/container information to outputs when
 	// available.
 	//
-	void set_extra(string &extra, bool replace_container_info);
+	void set_extra(std::string &extra, bool replace_container_info);
 
 	// Represents the result of matching an event against a set of
 	// rules.
@@ -284,7 +284,7 @@ private:
 	stats_manager m_rule_stats_manager;
 
 	uint16_t m_next_ruleset_id;
-	std::map<string, uint16_t> m_known_rulesets;
+	std::map<std::string, uint16_t> m_known_rulesets;
 	falco_common::priority_type m_min_priority;
 
 	//

--- a/userspace/engine/filter_evttype_resolver.cpp
+++ b/userspace/engine/filter_evttype_resolver.cpp
@@ -69,7 +69,7 @@ void filter_evttype_resolver::evttypes(
 }
 
 void filter_evttype_resolver::evttypes(
-	shared_ptr<ast::expr> filter,
+	std::shared_ptr<ast::expr> filter,
 	std::set<uint16_t>& out) const
 {
 	visitor v;

--- a/userspace/engine/filter_macro_resolver.cpp
+++ b/userspace/engine/filter_macro_resolver.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 
 #include "filter_macro_resolver.h"
 
-using namespace std;
 using namespace libsinsp::filter;
 
 bool filter_macro_resolver::run(libsinsp::filter::ast::expr*& filter)
@@ -51,8 +50,8 @@ bool filter_macro_resolver::run(std::shared_ptr<libsinsp::filter::ast::expr>& fi
 }
 
 void filter_macro_resolver::set_macro(
-		string name,
-		shared_ptr<libsinsp::filter::ast::expr> macro)
+		std::string name,
+		std::shared_ptr<libsinsp::filter::ast::expr> macro)
 {
 	m_macros[name] = macro;
 }

--- a/userspace/engine/filter_warning_resolver.cpp
+++ b/userspace/engine/filter_warning_resolver.cpp
@@ -21,13 +21,13 @@ using namespace falco;
 
 static const char* no_value = "<NA>";
 
-static inline bool is_unsafe_field(const string& f)
+static inline bool is_unsafe_field(const std::string& f)
 {
 	return !strncmp(f.c_str(), "ka.", strlen("ka."))
 		|| !strncmp(f.c_str(), "jevt.", strlen("jevt."));
 }
 
-static inline bool is_equality_operator(const string& op)
+static inline bool is_equality_operator(const std::string& op)
 {
 	return op == "==" || op == "=" || op == "!="
 		|| op == "in" || op == "intersects" || op == "pmatch";

--- a/userspace/engine/formats.cpp
+++ b/userspace/engine/formats.cpp
@@ -33,11 +33,11 @@ falco_formats::~falco_formats()
 {
 }
 
-string falco_formats::format_event(gen_event *evt, const std::string &rule, const std::string &source,
+std::string falco_formats::format_event(gen_event *evt, const std::string &rule, const std::string &source,
 				   const std::string &level, const std::string &format, std::set<std::string> &tags,
 				   const std::string &hostname) const
 {
-	string line;
+	std::string line;
 
 	std::shared_ptr<gen_event_formatter> formatter;
 
@@ -48,7 +48,7 @@ string falco_formats::format_event(gen_event *evt, const std::string &rule, cons
 
 	if(formatter->get_output_format() == gen_event_formatter::OF_JSON)
 	{
-		string json_line;
+		std::string json_line;
 
 		// Format the event into a json object with all fields resolved
 		formatter->tostring(evt, json_line);
@@ -67,14 +67,14 @@ string falco_formats::format_event(gen_event *evt, const std::string &rule, cons
 		Json::Value event;
 		Json::Value rule_tags;
 		Json::FastWriter writer;
-		string full_line;
+		std::string full_line;
 		unsigned int rule_tags_idx = 0;
 
 		// Convert the time-as-nanoseconds to a more json-friendly ISO8601.
 		time_t evttime = evt->get_ts() / 1000000000;
 		char time_sec[20]; // sizeof "YYYY-MM-DDTHH:MM:SS"
 		char time_ns[12];  // sizeof ".sssssssssZ"
-		string iso8601evttime;
+		std::string iso8601evttime;
 
 		strftime(time_sec, sizeof(time_sec), "%FT%T", gmtime(&evttime));
 		snprintf(time_ns, sizeof(time_ns), ".%09luZ", evt->get_ts() % 1000000000);
@@ -131,14 +131,14 @@ string falco_formats::format_event(gen_event *evt, const std::string &rule, cons
 	return line.c_str();
 }
 
-map<string, string> falco_formats::get_field_values(gen_event *evt, const std::string &source,
+std::map<std::string, std::string> falco_formats::get_field_values(gen_event *evt, const std::string &source,
 						    const std::string &format) const
 {
 	std::shared_ptr<gen_event_formatter> formatter;
 
 	formatter = m_falco_engine->create_formatter(source, format);
 
-	map<string, string> ret;
+	std::map<std::string, std::string> ret;
 
 	if (! formatter->get_field_values(evt, ret))
 	{

--- a/userspace/engine/formats.h
+++ b/userspace/engine/formats.h
@@ -33,7 +33,7 @@ public:
 				 const std::string &level, const std::string &format, std::set<std::string> &tags,
 				 const std::string &hostname) const;
 
-	map<string, string> get_field_values(gen_event *evt, const std::string &source,
+	std::map<std::string, std::string> get_field_values(gen_event *evt, const std::string &source,
 					     const std::string &format) const ;
 
 protected:

--- a/userspace/engine/rule_loader_compiler.cpp
+++ b/userspace/engine/rule_loader_compiler.cpp
@@ -70,7 +70,7 @@ static bool is_format_valid(const falco_source& source, std::string fmt, std::st
 		formatter = source.formatter_factory->create_formatter(fmt);
 		return true;
 	}
-	catch(exception &e)
+	catch(std::exception &e)
 	{
 		err = e.what();
 		return false;
@@ -454,7 +454,7 @@ void rule_loader::compiler::compile_rule_infos(
 		// failure.
 		sinsp_filter_compiler compiler(cfg.sources.at(r.source)->filter_factory, ast.get());
 		try {
-			shared_ptr<gen_event_filter> filter(compiler.compile());
+			std::shared_ptr<gen_event_filter> filter(compiler.compile());
 			source->ruleset->add(*out.at(rule_id), filter, ast);
 		}
 		catch (const sinsp_exception& e)

--- a/userspace/engine/rule_loader_reader.cpp
+++ b/userspace/engine/rule_loader_reader.cpp
@@ -21,7 +21,6 @@ limitations under the License.
 
 #define THROW(cond, err, ctx)    { if ((cond)) { throw rule_loader::rule_load_exception(falco::load_result::LOAD_ERR_YAML_VALIDATE, (err), (ctx)); } }
 
-
 // Don't call this directly, call decode_val/decode_optional_val instead.
 template <typename T>
 static void decode_val_generic(const YAML::Node& item, const char *key, T& out, const rule_loader::context& ctx, bool optional)
@@ -88,7 +87,7 @@ static void decode_seq(const YAML::Node& item, const char *key,
 }
 
 template <typename T>
-static void decode_items(const YAML::Node& item, vector<T>& out,
+static void decode_items(const YAML::Node& item, std::vector<T>& out,
 		       const rule_loader::context& ctx)
 {
 	bool optional = false;
@@ -101,7 +100,7 @@ static void decode_items(const YAML::Node& item, vector<T>& out,
 }
 
 template <typename T>
-static void decode_tags(const YAML::Node& item, set<T>& out,
+static void decode_tags(const YAML::Node& item, std::set<T>& out,
 		       const rule_loader::context& ctx)
 {
 	bool optional = true;
@@ -136,7 +135,7 @@ static void decode_exception_info_entry(
 	{
 		THROW(val.Scalar().empty(), "Value must be non-empty", valctx);
 		out.is_list = false;
-		THROW(!YAML::convert<string>::decode(val, out.item), "Could not decode scalar value", valctx);
+		THROW(!YAML::convert<std::string>::decode(val, out.item), "Could not decode scalar value", valctx);
 	}
 	if (val.IsSequence())
 	{
@@ -400,7 +399,7 @@ static void read_item(
 			}
 			else
 			{
-				string priority;
+				std::string priority;
 
 				// All of these are required
 				decode_val(item, "condition", v.cond, ctx);
@@ -441,7 +440,7 @@ bool rule_loader::reader::read(rule_loader::configuration& cfg, collector& colle
 	{
 		docs = YAML::LoadAll(cfg.content);
 	}
-	catch(const exception& e)
+	catch(const std::exception& e)
 	{
 		rule_loader::context ctx(cfg.name);
 		cfg.res->add_error(falco::load_result::LOAD_ERR_YAML_PARSE, e.what(), ctx);

--- a/userspace/engine/stats_manager.cpp
+++ b/userspace/engine/stats_manager.cpp
@@ -17,8 +17,6 @@ limitations under the License.
 #include "stats_manager.h"
 #include "falco_common.h"
 
-using namespace std;
-
 stats_manager::stats_manager()
 	: m_total(0)
 {
@@ -38,9 +36,9 @@ void stats_manager::clear()
 
 void stats_manager::format(
 	const indexed_vector<falco_rule>& rules,
-	string& out) const
+	std::string& out) const
 {
-	string fmt;
+	std::string fmt;
 	out = "Events detected: " + to_string(m_total) + "\n";
 	out += "Rule counts by severity:\n";
 	for (size_t i = 0; i < m_by_priority.size(); i++)
@@ -51,7 +49,7 @@ void stats_manager::format(
 			falco_common::format_priority(
 				(falco_common::priority_type) i, fmt, true);
 			transform(fmt.begin(), fmt.end(), fmt.begin(), ::toupper);
-			out += "   " + fmt + ": " + to_string(val) + "\n";
+			out += "   " + fmt + ": " + std::to_string(val) + "\n";
 		}
 	}
 	out += "Triggered rules by rule name:\n";
@@ -60,7 +58,7 @@ void stats_manager::format(
 		auto val = m_by_rule_id[i].get()->load();
 		if (val > 0)
 		{
-			out += "   " + rules.at(i)->name + ": " + to_string(val) + "\n";
+			out += "   " + rules.at(i)->name + ": " + std::to_string(val) + "\n";
 		}
 	}
 }
@@ -70,12 +68,12 @@ void stats_manager::on_rule_loaded(const falco_rule& rule)
 	while (m_by_rule_id.size() <= rule.id)
 	{
 		m_by_rule_id.emplace_back();
-		m_by_rule_id[m_by_rule_id.size() - 1].reset(new atomic<uint64_t>(0));
+		m_by_rule_id[m_by_rule_id.size() - 1].reset(new std::atomic<uint64_t>(0));
 	}
 	while (m_by_priority.size() <= (size_t) rule.priority)
 	{
 		m_by_priority.emplace_back();
-		m_by_priority[m_by_priority.size() - 1].reset(new atomic<uint64_t>(0));
+		m_by_priority[m_by_priority.size() - 1].reset(new std::atomic<uint64_t>(0));
 	}
 }
 

--- a/userspace/engine/stats_manager.h
+++ b/userspace/engine/stats_manager.h
@@ -67,7 +67,7 @@ public:
 		std::string& out) const;
 
 private:
-	atomic<uint64_t> m_total;
-	std::vector<std::unique_ptr<atomic<uint64_t>>> m_by_priority;
-	std::vector<std::unique_ptr<atomic<uint64_t>>> m_by_rule_id;
+	std::atomic<uint64_t> m_total;
+	std::vector<std::unique_ptr<std::atomic<uint64_t>>> m_by_priority;
+	std::vector<std::unique_ptr<std::atomic<uint64_t>>> m_by_rule_id;
 };

--- a/userspace/falco/app_actions/create_requested_paths.cpp
+++ b/userspace/falco/app_actions/create_requested_paths.cpp
@@ -92,9 +92,9 @@ int application::create_dir(const std::string &path)
 	// Properly reset errno
 	errno = 0;
 
-	istringstream f(path);
-	string path_until_token;
-	string s;
+	std::istringstream f(path);
+	std::string path_until_token;
+	std::string s;
 	// Create all the subfolder stopping at last token (f.eof());
 	// Examples:
 	// "/tmp/foo/bar" -> "", "tmp", "foo" -> mkdir("/") + mkdir("/tmp/") + midir("/tmp/foo/")

--- a/userspace/falco/app_actions/init_clients.cpp
+++ b/userspace/falco/app_actions/init_clients.cpp
@@ -29,9 +29,9 @@ application::run_result application::init_clients()
 
 	auto inspector = m_state->source_infos.at(falco_common::syscall_source)->inspector;
 
-	falco_logger::log(LOG_DEBUG, "Setting metadata download max size to " + to_string(m_state->config->m_metadata_download_max_mb) + " MB\n");
-	falco_logger::log(LOG_DEBUG, "Setting metadata download chunk wait time to " + to_string(m_state->config->m_metadata_download_chunk_wait_us) + " μs\n");
-	falco_logger::log(LOG_DEBUG, "Setting metadata download watch frequency to " + to_string(m_state->config->m_metadata_download_watch_freq_sec) + " seconds\n");
+	falco_logger::log(LOG_DEBUG, "Setting metadata download max size to " + std::to_string(m_state->config->m_metadata_download_max_mb) + " MB\n");
+	falco_logger::log(LOG_DEBUG, "Setting metadata download chunk wait time to " + std::to_string(m_state->config->m_metadata_download_chunk_wait_us) + " μs\n");
+	falco_logger::log(LOG_DEBUG, "Setting metadata download watch frequency to " + std::to_string(m_state->config->m_metadata_download_watch_freq_sec) + " seconds\n");
 	inspector->set_metadata_download_params(m_state->config->m_metadata_download_max_mb * 1024 * 1024, m_state->config->m_metadata_download_chunk_wait_us, m_state->config->m_metadata_download_watch_freq_sec);
 
 	//
@@ -44,9 +44,9 @@ application::run_result application::init_clients()
 		// Create string pointers for some config vars
 		// and pass to inspector. The inspector then
 		// owns the pointers.
-		std::string *k8s_api_ptr = new string((!m_options.k8s_api.empty() ? m_options.k8s_api : k8s_api_env));
-		std::string *k8s_api_cert_ptr = new string(m_options.k8s_api_cert);
-		std::string *k8s_node_name_ptr = new string(m_options.k8s_node_name);
+		std::string *k8s_api_ptr = new std::string((!m_options.k8s_api.empty() ? m_options.k8s_api : k8s_api_env));
+		std::string *k8s_api_cert_ptr = new std::string(m_options.k8s_api_cert);
+		std::string *k8s_node_name_ptr = new std::string(m_options.k8s_node_name);
 
 		if(k8s_api_cert_ptr->empty())
 		{

--- a/userspace/falco/app_actions/load_rules_files.cpp
+++ b/userspace/falco/app_actions/load_rules_files.cpp
@@ -72,7 +72,7 @@ void application::check_for_ignored_events()
 
 application::run_result application::load_rules_files()
 {
-	string all_rules;
+	std::string all_rules;
 
 	if (!m_options.rules_filenames.empty())
 	{
@@ -87,7 +87,7 @@ application::run_result application::load_rules_files()
 	falco_logger::log(LOG_DEBUG, "Configured rules filenames:\n");
 	for (const auto& path : m_state->config->m_rules_filenames)
 	{
-		falco_logger::log(LOG_DEBUG, string("   ") + path + "\n");
+		falco_logger::log(LOG_DEBUG, std::string("   ") + path + "\n");
 	}
 
 	for (const auto &path : m_state->config->m_rules_filenames)

--- a/userspace/falco/app_actions/print_support.cpp
+++ b/userspace/falco/app_actions/print_support.cpp
@@ -40,7 +40,7 @@ application::run_result application::print_support()
 
 		if(uname(&sysinfo) != 0)
 		{
-			return run_result::fatal(string("Could not uname() to find system info: ") + strerror(errno));
+			return run_result::fatal(std::string("Could not uname() to find system info: ") + strerror(errno));
 		}
 
 		support["version"] = FALCO_VERSION;

--- a/userspace/falco/app_actions/process_events.cpp
+++ b/userspace/falco/app_actions/process_events.cpp
@@ -205,7 +205,7 @@ application::run_result application::do_inspect(
 		// engine, which will match the event against the set
 		// of rules. If a match is found, pass the event to
 		// the outputs.
-		unique_ptr<falco_engine::rule_result> res = m_state->engine->process_event(source_engine_idx, ev);
+		std::unique_ptr<falco_engine::rule_result> res = m_state->engine->process_event(source_engine_idx, ev);
 		if(res)
 		{
 			if (!rate_limiter_enabled || rate_limiter.claim())

--- a/userspace/falco/app_actions/start_grpc_server.cpp
+++ b/userspace/falco/app_actions/start_grpc_server.cpp
@@ -27,7 +27,7 @@ application::run_result application::start_grpc_server()
 	// gRPC server
 	if(m_state->config->m_grpc_enabled)
 	{
-		falco_logger::log(LOG_INFO, "gRPC server threadiness equals to " + to_string(m_state->config->m_grpc_threadiness) + "\n");
+		falco_logger::log(LOG_INFO, "gRPC server threadiness equals to " + std::to_string(m_state->config->m_grpc_threadiness) + "\n");
 		// TODO(fntlnz,leodido): when we want to spawn multiple threads we need to have a queue per thread, or implement
 		// different queuing mechanisms, round robin, fanout? What we want to achieve?
 		m_state->grpc_server.init(

--- a/userspace/falco/app_actions/start_webserver.cpp
+++ b/userspace/falco/app_actions/start_webserver.cpp
@@ -28,9 +28,9 @@ application::run_result application::start_webserver()
 	{
 		std::string ssl_option = (m_state->config->m_webserver_ssl_enabled ? " (SSL)" : "");
 		falco_logger::log(LOG_INFO, "Starting health webserver with threadiness "
-			+ to_string(m_state->config->m_webserver_threadiness)
+			+ std::to_string(m_state->config->m_webserver_threadiness)
 			+ ", listening on port "
-			+ to_string(m_state->config->m_webserver_listen_port)
+			+ std::to_string(m_state->config->m_webserver_listen_port)
 			+ ssl_option + "\n");
 
 		m_state->webserver.start(

--- a/userspace/falco/application.cpp
+++ b/userspace/falco/application.cpp
@@ -24,8 +24,6 @@ limitations under the License.
 #include "application.h"
 #include "falco_common.h"
 
-using namespace std::placeholders;
-
 static inline bool should_take_action_to_signal(std::atomic<int>& v)
 {
 	// we expected the signal to be received, and we try to set action-taken flag
@@ -204,10 +202,10 @@ bool application::run(std::string &errstr, bool &restart)
 	};
 
 	std::list<std::function<bool(std::string &)>> teardown_steps = {
-		std::bind(&application::unregister_signal_handlers, this, _1),
+		std::bind(&application::unregister_signal_handlers, this, std::placeholders::_1),
 #ifndef MINIMAL_BUILD
-		std::bind(&application::stop_grpc_server, this, _1),
-		std::bind(&application::stop_webserver, this, _1)
+		std::bind(&application::stop_grpc_server, this, std::placeholders::_1),
+		std::bind(&application::stop_webserver, this, std::placeholders::_1)
 #endif
 	};
 

--- a/userspace/falco/application.h
+++ b/userspace/falco/application.h
@@ -281,8 +281,8 @@ private:
 				throw falco_exception("Could not open file " + filename + " for reading");
 			}
 
-			std::string rules_content((istreambuf_iterator<char>(is)),
-						  istreambuf_iterator<char>());
+			std::string rules_content((std::istreambuf_iterator<char>(is)),
+						  std::istreambuf_iterator<char>());
 			rules_contents.emplace_back(std::move(rules_content));
 		}
 

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -29,8 +29,6 @@ limitations under the License.
 #include "logger.h"
 #include "banned.h" // This raises a compilation error when certain functions are used
 
-using namespace std;
-
 falco_configuration::falco_configuration():
 	m_json_output(false),
 	m_json_include_output_property(true),
@@ -69,9 +67,9 @@ falco_configuration::~falco_configuration()
 	}
 }
 
-void falco_configuration::init(const string& conf_filename, const vector<string> &cmdline_options)
+void falco_configuration::init(const std::string& conf_filename, const std::vector<std::string> &cmdline_options)
 {
-	string m_config_file = conf_filename;
+	std::string m_config_file = conf_filename;
 	m_config = new yaml_configuration();
 	try
 	{
@@ -85,9 +83,9 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 
 	init_cmdline_options(cmdline_options);
 
-	list<string> rules_files;
+	std::list<std::string> rules_files;
 
-	m_config->get_sequence<list<string>>(rules_files, string("rules_file"));
+	m_config->get_sequence<std::list<std::string>>(rules_files, std::string("rules_file"));
 
 	for(auto &file : rules_files)
 	{
@@ -107,15 +105,15 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 	file_output.name = "file";
 	if(m_config->get_scalar<bool>("file_output.enabled", false))
 	{
-		string filename, keep_alive;
-		filename = m_config->get_scalar<string>("file_output.filename", "");
-		if(filename == string(""))
+		std::string filename, keep_alive;
+		filename = m_config->get_scalar<std::string>("file_output.filename", "");
+		if(filename == std::string(""))
 		{
-			throw logic_error("Error reading config file (" + m_config_file + "): file output enabled but no filename in configuration block");
+			throw std::logic_error("Error reading config file (" + m_config_file + "): file output enabled but no filename in configuration block");
 		}
 		file_output.options["filename"] = filename;
 
-		keep_alive = m_config->get_scalar<string>("file_output.keep_alive", "");
+		keep_alive = m_config->get_scalar<std::string>("file_output.keep_alive", "");
 		file_output.options["keep_alive"] = keep_alive;
 
 		m_outputs.push_back(file_output);
@@ -139,15 +137,15 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 	program_output.name = "program";
 	if(m_config->get_scalar<bool>("program_output.enabled", false))
 	{
-		string program, keep_alive;
-		program = m_config->get_scalar<string>("program_output.program", "");
-		if(program == string(""))
+		std::string program, keep_alive;
+		program = m_config->get_scalar<std::string>("program_output.program", "");
+		if(program == std::string(""))
 		{
-			throw logic_error("Error reading config file (" + m_config_file + "): program output enabled but no program in configuration block");
+			throw std::logic_error("Error reading config file (" + m_config_file + "): program output enabled but no program in configuration block");
 		}
 		program_output.options["program"] = program;
 
-		keep_alive = m_config->get_scalar<string>("program_output.keep_alive", "");
+		keep_alive = m_config->get_scalar<std::string>("program_output.keep_alive", "");
 		program_output.options["keep_alive"] = keep_alive;
 
 		m_outputs.push_back(program_output);
@@ -157,33 +155,33 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 	http_output.name = "http";
 	if(m_config->get_scalar<bool>("http_output.enabled", false))
 	{
-		string url;
-		url = m_config->get_scalar<string>("http_output.url", "");
+		std::string url;
+		url = m_config->get_scalar<std::string>("http_output.url", "");
 
-		if(url == string(""))
+		if(url == std::string(""))
 		{
-			throw logic_error("Error reading config file (" + m_config_file + "): http output enabled but no url in configuration block");
+			throw std::logic_error("Error reading config file (" + m_config_file + "): http output enabled but no url in configuration block");
 		}
 		http_output.options["url"] = url;
 
-		string user_agent;
-		user_agent = m_config->get_scalar<string>("http_output.user_agent","falcosecurity/falco");
+		std::string user_agent;
+		user_agent = m_config->get_scalar<std::string>("http_output.user_agent","falcosecurity/falco");
 		http_output.options["user_agent"] = user_agent;
 
 		m_outputs.push_back(http_output);
 	}
 
 	m_grpc_enabled = m_config->get_scalar<bool>("grpc.enabled", false);
-	m_grpc_bind_address = m_config->get_scalar<string>("grpc.bind_address", "0.0.0.0:5060");
+	m_grpc_bind_address = m_config->get_scalar<std::string>("grpc.bind_address", "0.0.0.0:5060");
 	m_grpc_threadiness = m_config->get_scalar<uint32_t>("grpc.threadiness", 0);
 	if(m_grpc_threadiness == 0)
 	{
 		m_grpc_threadiness = falco::utils::hardware_concurrency();
 	}
 	// todo > else limit threadiness to avoid oversubscription?
-	m_grpc_private_key = m_config->get_scalar<string>("grpc.private_key", "/etc/falco/certs/server.key");
-	m_grpc_cert_chain = m_config->get_scalar<string>("grpc.cert_chain", "/etc/falco/certs/server.crt");
-	m_grpc_root_certs = m_config->get_scalar<string>("grpc.root_certs", "/etc/falco/certs/ca.crt");
+	m_grpc_private_key = m_config->get_scalar<std::string>("grpc.private_key", "/etc/falco/certs/server.key");
+	m_grpc_cert_chain = m_config->get_scalar<std::string>("grpc.cert_chain", "/etc/falco/certs/server.crt");
+	m_grpc_root_certs = m_config->get_scalar<std::string>("grpc.root_certs", "/etc/falco/certs/ca.crt");
 
 	falco::outputs::config grpc_output;
 	grpc_output.name = "grpc";
@@ -195,10 +193,10 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 
 	if(m_outputs.size() == 0)
 	{
-		throw logic_error("Error reading config file (" + m_config_file + "): No outputs configured. Please configure at least one output file output enabled but no filename in configuration block");
+		throw std::logic_error("Error reading config file (" + m_config_file + "): No outputs configured. Please configure at least one output file output enabled but no filename in configuration block");
 	}
 
-	m_log_level = m_config->get_scalar<string>("log_level", "info");
+	m_log_level = m_config->get_scalar<std::string>("log_level", "info");
 
 	falco_logger::set_level(m_log_level);
 
@@ -213,10 +211,10 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 	m_notifications_rate = m_config->get_scalar<uint32_t>("outputs.rate", 0);
 	m_notifications_max_burst = m_config->get_scalar<uint32_t>("outputs.max_burst", 1000);
 
-	string priority = m_config->get_scalar<string>("priority", "debug");
+	std::string priority = m_config->get_scalar<std::string>("priority", "debug");
 	if (!falco_common::parse_priority(priority, m_min_priority))
 	{
-		throw logic_error("Unknown priority \"" + priority + "\"--must be one of emergency, alert, critical, error, warning, notice, informational, debug");
+		throw std::logic_error("Unknown priority \"" + priority + "\"--must be one of emergency, alert, critical, error, warning, notice, informational, debug");
 	}
 
 	m_buffered_outputs = m_config->get_scalar<bool>("buffered_outputs", false);
@@ -228,15 +226,15 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 	m_webserver_enabled = m_config->get_scalar<bool>("webserver.enabled", false);
 	m_webserver_threadiness = m_config->get_scalar<uint32_t>("webserver.threadiness", 0);
 	m_webserver_listen_port = m_config->get_scalar<uint32_t>("webserver.listen_port", 8765);
-	m_webserver_k8s_healthz_endpoint = m_config->get_scalar<string>("webserver.k8s_healthz_endpoint", "/healthz");
+	m_webserver_k8s_healthz_endpoint = m_config->get_scalar<std::string>("webserver.k8s_healthz_endpoint", "/healthz");
 	m_webserver_ssl_enabled = m_config->get_scalar<bool>("webserver.ssl_enabled", false);
-	m_webserver_ssl_certificate = m_config->get_scalar<string>("webserver.ssl_certificate", "/etc/falco/falco.pem");
+	m_webserver_ssl_certificate = m_config->get_scalar<std::string>("webserver.ssl_certificate", "/etc/falco/falco.pem");
 	if(m_webserver_threadiness == 0)
 	{
 		m_webserver_threadiness = falco::utils::hardware_concurrency();
 	}
 
-	std::list<string> syscall_event_drop_acts;
+	std::list<std::string> syscall_event_drop_acts;
 	m_config->get_sequence(syscall_event_drop_acts, "syscall_event_drops.actions");
 
 	for(std::string &act : syscall_event_drop_acts)
@@ -249,7 +247,7 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 		{
 			if(m_syscall_evt_drop_actions.count(syscall_evt_drop_action::IGNORE))
 			{
-				throw logic_error("Error reading config file (" + m_config_file + "): syscall event drop action \"" + act + "\" does not make sense with the \"ignore\" action");
+				throw std::logic_error("Error reading config file (" + m_config_file + "): syscall event drop action \"" + act + "\" does not make sense with the \"ignore\" action");
 			}
 			m_syscall_evt_drop_actions.insert(syscall_evt_drop_action::LOG);
 		}
@@ -257,7 +255,7 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 		{
 			if(m_syscall_evt_drop_actions.count(syscall_evt_drop_action::IGNORE))
 			{
-				throw logic_error("Error reading config file (" + m_config_file + "): syscall event drop action \"" + act + "\" does not make sense with the \"ignore\" action");
+				throw std::logic_error("Error reading config file (" + m_config_file + "): syscall event drop action \"" + act + "\" does not make sense with the \"ignore\" action");
 			}
 			m_syscall_evt_drop_actions.insert(syscall_evt_drop_action::ALERT);
 		}
@@ -267,7 +265,7 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 		}
 		else
 		{
-			throw logic_error("Error reading config file (" + m_config_file + "): available actions for syscall event drops are \"ignore\", \"log\", \"alert\", and \"exit\"");
+			throw std::logic_error("Error reading config file (" + m_config_file + "): available actions for syscall event drops are \"ignore\", \"log\", \"alert\", and \"exit\"");
 		}
 	}
 
@@ -279,7 +277,7 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 	m_syscall_evt_drop_threshold = m_config->get_scalar<double>("syscall_event_drops.threshold", .1);
 	if(m_syscall_evt_drop_threshold < 0 || m_syscall_evt_drop_threshold > 1)
 	{
-		throw logic_error("Error reading config file (" + m_config_file + "): syscall event drops threshold must be a double in the range [0, 1]");
+		throw std::logic_error("Error reading config file (" + m_config_file + "): syscall event drops threshold must be a double in the range [0, 1]");
 	}
 	m_syscall_evt_drop_rate = m_config->get_scalar<double>("syscall_event_drops.rate", .03333);
 	m_syscall_evt_drop_max_burst = m_config->get_scalar<double>("syscall_event_drops.max_burst", 1);
@@ -288,19 +286,19 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 	m_syscall_evt_timeout_max_consecutives = m_config->get_scalar<uint32_t>("syscall_event_timeouts.max_consecutives", 1000);
 	if(m_syscall_evt_timeout_max_consecutives == 0)
 	{
-		throw logic_error("Error reading config file(" + m_config_file + "): the maximum consecutive timeouts without an event must be an unsigned integer > 0");
+		throw std::logic_error("Error reading config file(" + m_config_file + "): the maximum consecutive timeouts without an event must be an unsigned integer > 0");
 	}
 
 	m_metadata_download_max_mb = m_config->get_scalar<uint32_t>("metadata_download.max_mb", 100);
 	if(m_metadata_download_max_mb > 1024)
 	{
-		throw logic_error("Error reading config file(" + m_config_file + "): metadata download maximum size should be < 1024 Mb");
+		throw std::logic_error("Error reading config file(" + m_config_file + "): metadata download maximum size should be < 1024 Mb");
 	}
 	m_metadata_download_chunk_wait_us = m_config->get_scalar<uint32_t>("metadata_download.chunk_wait_us", 1000);
 	m_metadata_download_watch_freq_sec = m_config->get_scalar<uint32_t>("metadata_download.watch_freq_sec", 1);
 	if(m_metadata_download_watch_freq_sec == 0)
 	{
-		throw logic_error("Error reading config file(" + m_config_file + "): metadata download watch frequency seconds must be an unsigned integer > 0");
+		throw std::logic_error("Error reading config file(" + m_config_file + "): metadata download watch frequency seconds must be an unsigned integer > 0");
 	}
 
 	/* We put this value in the configuration file because in this way we can change the dimension at every reload.
@@ -312,17 +310,17 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 
 	bool load_plugins_node_defined = m_config->is_defined("load_plugins");
 
-	m_config->get_sequence<set<string>>(load_plugins, "load_plugins");
+	m_config->get_sequence<std::set<std::string>>(load_plugins, "load_plugins");
 
 	std::list<falco_configuration::plugin_config> plugins;
 	try
 	{
-		m_config->get_sequence<std::list<falco_configuration::plugin_config>>(plugins, string("plugins"));
+		m_config->get_sequence<std::list<falco_configuration::plugin_config>>(plugins, std::string("plugins"));
 	}
-	catch (exception &e)
+	catch (std::exception &e)
 	{
 		// Might be thrown due to not being able to open files
-		throw logic_error("Error reading config file(" + m_config_file + "): could not load plugins config: " + e.what());
+		throw std::logic_error("Error reading config file(" + m_config_file + "): could not load plugins config: " + e.what());
 	}
 
 	// If load_plugins was specified, only save plugins matching those in values
@@ -340,7 +338,7 @@ void falco_configuration::init(const string& conf_filename, const vector<string>
 	m_watch_config_files = m_config->get_scalar<bool>("watch_config_files", true);
 }
 
-void falco_configuration::read_rules_file_directory(const string &path, list<string> &rules_filenames, list<string> &rules_folders)
+void falco_configuration::read_rules_file_directory(const std::string &path, std::list<std::string> &rules_filenames, std::list<std::string> &rules_folders)
 {
 	struct stat st;
 
@@ -359,7 +357,7 @@ void falco_configuration::read_rules_file_directory(const string &path, list<str
 		// It's a directory. Read the contents, sort
 		// alphabetically, and add every path to
 		// rules_filenames
-		vector<string> dir_filenames;
+		std::vector<std::string> dir_filenames;
 
 		DIR *dir = opendir(path.c_str());
 
@@ -371,7 +369,7 @@ void falco_configuration::read_rules_file_directory(const string &path, list<str
 
 		for(struct dirent *ent = readdir(dir); ent; ent = readdir(dir))
 		{
-			string efile = path + "/" + ent->d_name;
+			std::string efile = path + "/" + ent->d_name;
 
 			rc = stat(efile.c_str(), &st);
 
@@ -392,7 +390,7 @@ void falco_configuration::read_rules_file_directory(const string &path, list<str
 		std::sort(dir_filenames.begin(),
 			  dir_filenames.end());
 
-		for(string &ent : dir_filenames)
+		for(std::string &ent : dir_filenames)
 		{
 			rules_filenames.push_back(ent);
 		}
@@ -406,11 +404,11 @@ void falco_configuration::read_rules_file_directory(const string &path, list<str
 	}
 }
 
-static bool split(const string &str, char delim, pair<string, string> &parts)
+static bool split(const std::string &str, char delim, std::pair<std::string, std::string> &parts)
 {
 	size_t pos;
 
-	if((pos = str.find_first_of(delim)) == string::npos)
+	if((pos = str.find_first_of(delim)) == std::string::npos)
 	{
 		return false;
 	}
@@ -420,21 +418,21 @@ static bool split(const string &str, char delim, pair<string, string> &parts)
 	return true;
 }
 
-void falco_configuration::init_cmdline_options(const vector<string> &cmdline_options)
+void falco_configuration::init_cmdline_options(const std::vector<std::string> &cmdline_options)
 {
-	for(const string &option : cmdline_options)
+	for(const std::string &option : cmdline_options)
 	{
 		set_cmdline_option(option);
 	}
 }
 
-void falco_configuration::set_cmdline_option(const string &opt)
+void falco_configuration::set_cmdline_option(const std::string &opt)
 {
-	pair<string, string> keyval;
+	std::pair<std::string, std::string> keyval;
 
 	if(!split(opt, '=', keyval))
 	{
-		throw logic_error("Error parsing config option \"" + opt + "\". Must be of the form key=val or key.subkey=val");
+		throw std::logic_error("Error parsing config option \"" + opt + "\". Must be of the form key=val or key.subkey=val");
 	}
 
 	m_config->set_scalar(keyval.first, keyval.second);

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -144,9 +144,9 @@ private:
 				{
 					if (i > 0 && nodeKey.empty() && key[i - 1] != '.')
 					{
-						throw runtime_error(
+						throw std::runtime_error(
 							"Parsing error: expected '.' character at pos " 
-							+ to_string(i - 1));
+							+ std::to_string(i - 1));
 					}
 					nodeKey += c;
 				}
@@ -155,9 +155,9 @@ private:
 				{
 					if (nodeKey.empty())
 					{
-						throw runtime_error(
+						throw std::runtime_error(
 							"Parsing error: unexpected character at pos " 
-							+ to_string(i));
+							+ std::to_string(i));
 					}
 					ret.reset(ret[nodeKey]);
 					nodeKey.clear();
@@ -177,7 +177,7 @@ private:
 		}
 		catch(const std::exception& e)
 		{
-			throw runtime_error("Config error at key \"" + key + "\": " + string(e.what()));
+			throw std::runtime_error("Config error at key \"" + key + "\": " + std::string(e.what()));
 		}
 	}
 	
@@ -219,7 +219,7 @@ public:
 	void init(const std::string& conf_filename, const std::vector<std::string>& cmdline_options);
 	void init(const std::vector<std::string>& cmdline_options);
 
-	static void read_rules_file_directory(const string& path, list<string>& rules_filenames, list<string> &rules_folders);
+	static void read_rules_file_directory(const std::string& path, std::list<std::string>& rules_filenames, std::list<std::string> &rules_folders);
 
 	// Rules list as passed by the user
 	std::list<std::string> m_rules_filenames;
@@ -374,7 +374,7 @@ namespace YAML {
 			if(!rhs.m_library_path.empty() && rhs.m_library_path.at(0) != '/')
 			{
 				// prepend share dir if path is not absolute
-				rhs.m_library_path = string(FALCO_ENGINE_PLUGINS_DIR) + rhs.m_library_path;
+				rhs.m_library_path = std::string(FALCO_ENGINE_PLUGINS_DIR) + rhs.m_library_path;
 			}
 
 			if(node["init_config"] && !node["init_config"].IsNull())
@@ -400,7 +400,7 @@ namespace YAML {
 
 			if(node["open_params"] && !node["open_params"].IsNull())
 			{
-				string open_params = node["open_params"].as<std::string>();
+				std::string open_params = node["open_params"].as<std::string>();
 				rhs.m_open_params = trim(open_params);
 			}
 

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 #include "logger.h"
 #include "banned.h" // This raises a compilation error when certain functions are used
 
-static void display_fatal_err(const string &&msg)
+static void display_fatal_err(const std::string &&msg)
 {
 	/**
 	 * If stderr logging is not enabled, also log to stderr. When
@@ -67,9 +67,9 @@ int falco_init(int argc, char **argv, bool &restart)
 			return EXIT_FAILURE;
 		}
 	}
-	catch(exception &e)
+	catch(std::exception &e)
 	{
-		display_fatal_err("Runtime error: " + string(e.what()) + ". Exiting.\n");
+		display_fatal_err("Runtime error: " + std::string(e.what()) + ". Exiting.\n");
 		return EXIT_FAILURE;
 	}
 

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -37,8 +37,6 @@ limitations under the License.
 
 #include "banned.h" // This raises a compilation error when certain functions are used
 
-using namespace std;
-
 static const char* s_internal_source = "internal";
 
 falco_outputs::falco_outputs(
@@ -119,8 +117,8 @@ void falco_outputs::add_output(falco::outputs::config oc)
 	m_outputs.push_back(oo);
 }
 
-void falco_outputs::handle_event(gen_event *evt, string &rule, string &source,
-				 falco_common::priority_type priority, string &format, std::set<std::string> &tags)
+void falco_outputs::handle_event(gen_event *evt, std::string &rule, std::string &source,
+				 falco_common::priority_type priority, std::string &format, std::set<std::string> &tags)
 {
 	falco_outputs::ctrl_msg cmsg = {};
 	cmsg.ts = evt->get_ts();
@@ -128,7 +126,7 @@ void falco_outputs::handle_event(gen_event *evt, string &rule, string &source,
 	cmsg.source = source;
 	cmsg.rule = rule;
 
-	string sformat;
+	std::string sformat;
 	if(m_time_format_iso_8601)
 	{
 		sformat = "*%evt.time.iso8601: ";
@@ -180,7 +178,7 @@ void falco_outputs::handle_msg(uint64_t ts,
 		time_t evttime = ts / 1000000000;
 		char time_sec[20]; // sizeof "YYYY-MM-DDTHH:MM:SS"
 		char time_ns[12];  // sizeof ".sssssssssZ"
-		string iso8601evttime;
+		std::string iso8601evttime;
 
 		strftime(time_sec, sizeof(time_sec), "%FT%T", gmtime(&evttime));
 		snprintf(time_ns, sizeof(time_ns), ".%09luZ", ts % 1000000000);
@@ -304,9 +302,9 @@ void falco_outputs::worker() noexcept
 						falco_logger::log(LOG_DEBUG, "Outputs worker received an unknown message type\n");
 				}
 			}
-			catch(const exception &e)
+			catch(const std::exception &e)
 			{
-				falco_logger::log(LOG_ERR, o->get_name() + ": " + string(e.what()) + "\n");
+				falco_logger::log(LOG_ERR, o->get_name() + ": " + std::string(e.what()) + "\n");
 			}
 		}
 		wd.cancel_timeout();

--- a/userspace/falco/grpc_server.cpp
+++ b/userspace/falco/grpc_server.cpp
@@ -69,7 +69,7 @@ static void gpr_log_dispatcher_func(gpr_log_func_args* args)
 		break;
 	}
 
-	string copy = "grpc: ";
+	std::string copy = "grpc: ";
 	copy.append(args->message);
 	copy.push_back('\n');
 	falco_logger::log(priority, std::move(copy));
@@ -171,9 +171,9 @@ void falco::grpc::server::init(
 
 void falco::grpc::server::init_mtls_server_builder()
 {
-	string private_key;
-	string cert_chain;
-	string root_certs;
+	std::string private_key;
+	std::string cert_chain;
+	std::string root_certs;
 	falco::utils::readfile(m_cert_chain, cert_chain);
 	falco::utils::readfile(m_private_key, private_key);
 	falco::utils::readfile(m_root_certs, root_certs);

--- a/userspace/falco/logger.cpp
+++ b/userspace/falco/logger.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 int falco_logger::level = LOG_INFO;
 bool falco_logger::time_format_iso_8601 = false;
 
-static sinsp_logger::severity decode_sinsp_severity(const string& s)
+static sinsp_logger::severity decode_sinsp_severity(const std::string& s)
 {
 	if(s == "trace")
 	{
@@ -65,7 +65,7 @@ void falco_logger::set_time_format_iso_8601(bool val)
 	falco_logger::time_format_iso_8601 = val;
 }
 
-void falco_logger::set_level(string &level)
+void falco_logger::set_level(std::string &level)
 {
 	if(level == "emergency")
 	{
@@ -134,7 +134,7 @@ void falco_logger::set_sinsp_logging(bool enable, const std::string& severity, c
 bool falco_logger::log_stderr = true;
 bool falco_logger::log_syslog = true;
 
-void falco_logger::log(int priority, const string&& msg)
+void falco_logger::log(int priority, const std::string&& msg)
 {
 
 	if(priority > falco_logger::level)
@@ -142,7 +142,7 @@ void falco_logger::log(int priority, const string&& msg)
 		return;
 	}
 
-	string copy = msg;
+	std::string copy = msg;
 
 	if (falco_logger::log_syslog)
 	{
@@ -178,7 +178,7 @@ void falco_logger::log(int priority, const string&& msg)
 		{
 			struct tm *ltm = std::localtime(&result);
 			char *atime = (ltm ? std::asctime(ltm) : NULL);
-			string tstr;
+			std::string tstr;
 			if(atime)
 			{
 				tstr = atime;

--- a/userspace/falco/logger.h
+++ b/userspace/falco/logger.h
@@ -26,11 +26,11 @@ class falco_logger
 	static void set_time_format_iso_8601(bool val);
 
 	// Will throw exception if level is unknown.
-	static void set_level(string &level);
+	static void set_level(std::string &level);
 
 	static void set_sinsp_logging(bool enable, const std::string& severity, const std::string& prefix);
 
-	static void log(int priority, const string&& msg);
+	static void log(int priority, const std::string&& msg);
 
 	static int level;
 	static bool log_stderr;

--- a/userspace/falco/outputs.h
+++ b/userspace/falco/outputs.h
@@ -49,7 +49,7 @@ struct message
 	std::string msg;
 	std::string rule;
 	std::string source;
-	map<std::string, std::string> fields;
+	std::map<std::string, std::string> fields;
 	std::set<std::string> tags;
 };
 

--- a/userspace/falco/outputs_file.cpp
+++ b/userspace/falco/outputs_file.cpp
@@ -27,7 +27,7 @@ void falco::outputs::output_file::open_file()
 	}
 	if(!m_outfile.is_open())
 	{
-		m_outfile.open(m_oc.options["filename"], fstream::app);
+		m_outfile.open(m_oc.options["filename"], std::fstream::app);
 		if (m_outfile.fail())
 		{
 			throw falco_exception("failed to open output file " + m_oc.options["filename"]);

--- a/userspace/falco/outputs_http.cpp
+++ b/userspace/falco/outputs_http.cpp
@@ -46,7 +46,7 @@ void falco::outputs::output_http::output(const message *msg)
 
 		if(res != CURLE_OK)
 		{
-			falco_logger::log(LOG_ERR, "libcurl error: " + string(curl_easy_strerror(res)));
+			falco_logger::log(LOG_ERR, "libcurl error: " + std::string(curl_easy_strerror(res)));
 		}
 		curl_easy_cleanup(curl);
 		curl = NULL;

--- a/userspace/falco/stats_writer.cpp
+++ b/userspace/falco/stats_writer.cpp
@@ -37,7 +37,7 @@ static void timer_handler(int signum)
 	s_timer.fetch_add(1, std::memory_order_relaxed);
 }
 
-bool stats_writer::init_ticker(uint32_t interval_msec, string &err)
+bool stats_writer::init_ticker(uint32_t interval_msec, std::string &err)
 {
 	struct itimerval timer;
 	struct sigaction handler;
@@ -46,7 +46,7 @@ bool stats_writer::init_ticker(uint32_t interval_msec, string &err)
 	handler.sa_handler = &timer_handler;
 	if (sigaction(SIGALRM, &handler, NULL) == -1)
 	{
-		err = string("Could not set up signal handler for periodic timer: ") + strerror(errno);
+		err = std::string("Could not set up signal handler for periodic timer: ") + strerror(errno);
 		return false;
 	}
 
@@ -55,7 +55,7 @@ bool stats_writer::init_ticker(uint32_t interval_msec, string &err)
 	timer.it_interval = timer.it_value;
 	if (setitimer(ITIMER_REAL, &timer, NULL) == -1)
 	{
-		err = string("Could not set up periodic timer: ") + strerror(errno);
+		err = std::string("Could not set up periodic timer: ") + strerror(errno);
 		return false;
 	}
 
@@ -76,8 +76,8 @@ stats_writer::stats_writer()
 stats_writer::stats_writer(const std::string &filename)
 	: m_initialized(true), m_total_samples(0)
 {
-	m_output.exceptions(ofstream::failbit | ofstream::badbit);
-	m_output.open(filename, ios_base::app);
+	m_output.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+	m_output.open(filename, std::ios_base::app);
 	m_worker = std::thread(&stats_writer::worker, this);
 }
 
@@ -151,11 +151,11 @@ void stats_writer::worker() noexcept
 			try
 			{
 				jmsg["sample"] = m_total_samples;
-				m_output << jmsg.dump() << endl;
+				m_output << jmsg.dump() << std::endl;
 			}
-			catch(const exception &e)
+			catch(const std::exception &e)
 			{
-				falco_logger::log(LOG_ERR, "stats_writer (worker): " + string(e.what()) + "\n");
+				falco_logger::log(LOG_ERR, "stats_writer (worker): " + std::string(e.what()) + "\n");
 			}
 		}
 	}

--- a/userspace/falco/webserver.cpp
+++ b/userspace/falco/webserver.cpp
@@ -77,7 +77,7 @@ void falco_webserver::start(
         {
             falco_logger::log(
                 LOG_ERR,
-                "falco_webserver: " + string(e.what()) + "\n");
+                "falco_webserver: " + std::string(e.what()) + "\n");
         }
         failed.store(true, std::memory_order_release);
     });


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

/area tests

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This PR completes the work of https://github.com/falcosecurity/libs/pull/769 by:
- Solving compilation issues arising in Falco which those libs changes
- Avoid relying on implicit `std::` namespace on most of the Falco codebase

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
