### PR TITLE
support older rhel distros in falco-driver-loader

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -113,6 +113,9 @@ get_target_id() {
 	elif [ -f "${HOST_ROOT}/etc/centos-release" ]; then
 		# Older CentOS distros
 		OS_ID=centos
+	elif [ -f "${HOST_ROOT}/etc/redhat-release" ]; then
+		# Older RHEL distros
+		OS_ID=rhel
 	else
 		return 1
 	fi


### PR DESCRIPTION
With current version, this error comes out while trying to run `falco-driver-loader` on RHEL 6:
```
Getting environment information
Detected an unsupported target system, please get in touch with the Falco community
```
because `/etc/os-release` file is not there.

Instead, `/etc/redhat-release` file is present (just like `/etc/centos-release` in older CentOS distros, already supported).

Tested on:
```
Linux rhel6.localdomain 2.6.32-754.el6.x86_64 #1 SMP Thu May 24 18:18:25 EDT 2018 x86_64 x86_64 x86_64 GNU/Linux
```

Signed-off-by: gentooise <andrea.genuise@ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?** not sure

<!--
> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create
-->

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?** not sure

<!--
> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area rules

> /area tests

> /area proposals

> /area CI
-->

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

<!--
**What this PR does / why we need it**: to support older rhel distros

**Which issue(s) this PR fixes**: no related issue, may open one
-->
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

<!--
Fixes #
-->

**Special notes for your reviewer**: none

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
Support older RHEL distros in falco-driver-loader script
```
