### PR TITLE
new(scripts): add bottlerocket support in falco-driver-loader.

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -162,6 +162,16 @@ get_target_id() {
 			exit 1
 		fi
 		;;
+	("bottlerocket")
+		TARGET_ID="${OS_ID}"
+		# variant_id has been sourced from os-release. Get only the first variant part
+		if [[ -n ${VARIANT_ID} ]];  then
+			# take just first part (eg: VARIANT_ID=aws-k8s-1.15 -> aws)
+			VARIANT_ID_CUT=${VARIANT_ID%%-*}
+		fi
+		# version_id has been sourced from os-release. Build a kernel version like: 1_1.11.0-aws
+		KERNEL_VERSION="1_${VERSION_ID}-${VARIANT_ID_CUT}"
+		;;
 	(*)
 		TARGET_ID=$(echo "${OS_ID}" | tr '[:upper:]' '[:lower:]')
 		;;


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

Adds support for bottlerocket OS in falco-driver-loader script.
See relevant PRs:
* https://github.com/falcosecurity/kernel-crawler/pull/79
* https://github.com/falcosecurity/driverkit/pull/239

Kernel-crawler will output a json similar to the minikube one:
```
{
"kernelversion": "1_1.11.1-vmware",
"kernelrelease": "5.15.59",
"target": "bottlerocket",
"kernelconfigdata": "..."
}
```

Basically, `kernelversion` ships OS version (`_1.11.1`) and flavor (`-vmware`).
Therefore, the changes in falco-driver-loader.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new(scripts): add bottlerocket support in falco-driver-loader
```
