### PR TITLE
update(ci): update ci jobs to generate Falco images with the modern BPF probe

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
   # This build is 100% static, there are no host dependencies
   "build-musl":
     docker:
-      - image: alpine:3.12
+      - image: alpine:3.17
     steps:
       - checkout:
           path: /source-static/falco
@@ -64,13 +64,13 @@ jobs:
           command: apk update
       - run:
           name: Install build dependencies
-          command: apk add g++ gcc cmake make git bash perl linux-headers autoconf automake m4 libtool elfutils-dev libelf-static patch binutils
+          command: apk add g++ gcc cmake make git bash perl linux-headers autoconf automake m4 libtool elfutils-dev libelf-static patch binutils bpftool clang
       - run:
           name: Prepare project
           command: |
             mkdir -p /build-static/release
             cd /build-static/release
-            cmake -DCPACK_GENERATOR=TGZ -DBUILD_BPF=Off -DBUILD_DRIVER=Off -DCMAKE_BUILD_TYPE=Release -DUSE_BUNDLED_DEPS=On -DUSE_BUNDLED_LIBELF=Off -DMUSL_OPTIMIZED_BUILD=On -DFALCO_ETC_DIR=/etc/falco /source-static/falco
+            cmake -DCPACK_GENERATOR=TGZ -DBUILD_BPF=Off -DBUILD_DRIVER=Off -DCMAKE_BUILD_TYPE=Release -DUSE_BUNDLED_DEPS=On -DUSE_BUNDLED_LIBELF=Off -DBUILD_LIBSCAP_MODERN_BPF=ON -DMUSL_OPTIMIZED_BUILD=On -DFALCO_ETC_DIR=/etc/falco /source-static/falco
       - run:
           name: Build
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,51 +3,54 @@ jobs:
   "build-arm64":
     machine:
       enabled: true
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:2022.10.2
     resource_class: arm.medium
     steps:
+
+      # Install dependencies to build the modern BPF probe skeleton.
+      - run:
+          name: Install deps ⛓️
+          command: |
+            sudo apt update
+            sudo apt install -y --no-install-recommends ca-certificates cmake build-essential clang-14 git pkg-config autoconf automake libelf-dev
+            sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 90
+            sudo update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-14 90
+            git clone https://github.com/libbpf/bpftool.git --branch v7.0.0 --single-branch
+            cd bpftool
+            git submodule update --init
+            cd src && sudo make install
+
+      # Path to the source code
       - checkout:
           path: /tmp/source-arm64/falco
+
+      # Build the skeleton
       - run:
-          name: Prepare project
+          name: Build modern BPF skeleton 🐝
           command: |
-            mkdir -p /tmp/build-arm64 && mkdir -p /tmp/build-arm64/release && \
-            docker run -e BUILD_TYPE="release" -it -v /tmp/source-arm64:/source -v /tmp/build-arm64:/build \
-              falcosecurity/falco-builder:latest \
-              cmake
+            mkdir -p /tmp/source-arm64/falco/skeleton-build
+            cd /tmp/source-arm64/falco/skeleton-build && cmake -DUSE_BUNDLED_DEPS=ON -DBUILD_FALCO_MODERN_BPF=ON -DCREATE_TEST_TARGETS=Off ../
+            make ProbeSkeleton
+
+      # Build the Falco packages (tar, deb, rpm) inside the centos7 builder.
+      # This dockerfile returns as output:
+      # - the build directory. (under /tmp/${DEST_BUILD_DIR})
+      # - the 3 packages: tar, deb, rpm. (under /tmp/packages)
       - run:
-          name: Build
+          name: Build Falco packages 🏗️
           command: |
-            docker run -e BUILD_TYPE="release" -it -v /tmp/source-arm64:/source -v /tmp/build-arm64:/build \
-              falcosecurity/falco-builder:latest \
-              all
-      - run:
-          name: Run unit tests
-          command: |
-            docker run -e BUILD_TYPE="release" -it -v /tmp/source-arm64:/source -v /tmp/build-arm64:/build \
-              falcosecurity/falco-builder:latest \
-              tests
-      - run:
-          name: Build packages
-          command: |
-            docker run -e BUILD_TYPE="release" -it -v /tmp/source-arm64:/source -v /tmp/build-arm64:/build \
-              falcosecurity/falco-builder:latest \
-              package
-      - run:
-          name: Prepare Artifacts
-          command: |
-            mkdir -p /tmp/packages
-            cp /tmp/build-arm64/release/*.deb /tmp/packages
-            cp /tmp/build-arm64/release/*.tar.gz /tmp/packages
-            cp /tmp/build-arm64/release/*.rpm /tmp/packages
+            DOCKER_BUILDKIT=1 docker build -f /tmp/source-arm64/falco/docker/builder/modern-falco-builder.Dockerfile --output type=local,dest=/tmp --build-arg CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DUSE_BUNDLED_DEPS=On -DFALCO_ETC_DIR=/etc/falco -DBUILD_FALCO_MODERN_BPF=ON -DMODERN_BPF_SKEL_DIR=/source/skeleton-build/skel_dir -DBUILD_DRIVER=Off -DBUILD_BPF=Off" --build-arg DEST_BUILD_DIR=/build-arm64/release /tmp/source-arm64/falco
+
       - store_artifacts:
           path: /tmp/packages
           destination: /packages
+
       - persist_to_workspace:
           root: /tmp
           paths:
             - build-arm64/release
             - source-arm64
+
   # Build a statically linked Falco release binary using musl
   # This build is 100% static, there are no host dependencies
   "build-musl":
@@ -96,43 +99,57 @@ jobs:
           paths:
             - build-static/release
             - source-static
-  # Build using our own builder base image using centos 7
+
   # This build is static, dependencies are bundled in the Falco binary
   "build-centos7":
-    docker:
-      - image: falcosecurity/falco-builder:latest
-        environment:
-          BUILD_TYPE: "release"
+    machine:
+      enabled: true
+      image: ubuntu-2204:2022.10.2
     steps:
-      - checkout:
-          path: /source/falco
+
+      # Install dependencies to build the modern BPF probe skeleton.
       - run:
-          name: Prepare project
-          command: /usr/bin/entrypoint cmake
-      - run:
-          name: Build
-          command: /usr/bin/entrypoint all
-      - run:
-          name: Run unit tests
-          command: /usr/bin/entrypoint tests
-      - run:
-          name: Build packages
-          command: /usr/bin/entrypoint package
-      - persist_to_workspace:
-          root: /
-          paths:
-            - build/release
-            - source
-      - run:
-          name: Prepare artifacts
+          name: Install deps ⛓️
           command: |
-            mkdir -p /tmp/packages
-            cp /build/release/*.deb /tmp/packages
-            cp /build/release/*.tar.gz /tmp/packages
-            cp /build/release/*.rpm /tmp/packages
+            sudo apt update
+            sudo apt install -y --no-install-recommends ca-certificates cmake build-essential clang-14 git pkg-config autoconf automake libelf-dev
+            sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 90
+            sudo update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-14 90
+            git clone https://github.com/libbpf/bpftool.git --branch v7.0.0 --single-branch
+            cd bpftool
+            git submodule update --init
+            cd src && sudo make install
+
+      # Path for the source code
+      - checkout:
+          path: /tmp/source/falco
+
+      - run:
+          name: Build modern BPF skeleton 🐝
+          command: |
+            mkdir -p /tmp/source/falco/skeleton-build
+            cd /tmp/source/falco/skeleton-build && cmake -DUSE_BUNDLED_DEPS=ON -DBUILD_FALCO_MODERN_BPF=ON -DCREATE_TEST_TARGETS=Off ../
+            make ProbeSkeleton
+
+      # Build the Falco packages (tar, deb, rpm) inside the centos7 builder.
+      # This dockerfile returns as output:
+      # - the build directory. (under /tmp/${DEST_BUILD_DIR})
+      # - the 3 packages: tar, deb, rpm. (under /tmp/packages)
+      - run:
+          name: Build Falco packages 🏗️
+          command: |
+            DOCKER_BUILDKIT=1 docker build -f /tmp/source/falco/docker/builder/modern-falco-builder.Dockerfile --output type=local,dest=/tmp --build-arg CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DUSE_BUNDLED_DEPS=On -DFALCO_ETC_DIR=/etc/falco -DBUILD_FALCO_MODERN_BPF=ON -DMODERN_BPF_SKEL_DIR=/source/skeleton-build/skel_dir -DBUILD_DRIVER=Off -DBUILD_BPF=Off" --build-arg DEST_BUILD_DIR=/build/release /tmp/source/falco
+
       - store_artifacts:
           path: /tmp/packages
           destination: /packages
+
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - build/release
+            - source
+
   # Execute integration tests based on the build results coming from the "build-centos7" job
   "tests-integration":
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     machine:
       enabled: true
       image: ubuntu-2204:2022.10.2
-    resource_class: arm.medium
+    resource_class: arm.large
     steps:
 
       # Install dependencies to build the modern BPF probe skeleton.
@@ -105,6 +105,7 @@ jobs:
     machine:
       enabled: true
       image: ubuntu-2204:2022.10.2
+    resource_class: large
     steps:
 
       # Install dependencies to build the modern BPF probe skeleton.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
   "build-musl":
     docker:
       - image: alpine:3.17
+    resource_class: large
     steps:
       - checkout:
           path: /source-static/falco
@@ -75,12 +76,12 @@ jobs:
           name: Build
           command: |
             cd /build-static/release
-            make -j4 all
+            make -j6 all
       - run:
           name: Package
           command: |
             cd /build-static/release
-            make -j4 package
+            make -j6 package
       - run:
           name: Run unit tests
           command: |

--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -26,8 +26,8 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "4.0.0-rc1+driver")
-    set(DRIVER_CHECKSUM "SHA256=82d18ca00d245e5b7195c420b00a4c895190b6de77be0feb13b98861d749f257")
+    set(DRIVER_VERSION "090f4f08c341ef1bb866170deef1c6b72e7e5d43")
+    set(DRIVER_CHECKSUM "SHA256=8b24b8ebb83c5d0a323e5ab0d8b8858ec2ffa5b6d0496c9eab9b5c796f7ced3b")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -26,8 +26,8 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "090f4f08c341ef1bb866170deef1c6b72e7e5d43")
-    set(DRIVER_CHECKSUM "SHA256=8b24b8ebb83c5d0a323e5ab0d8b8858ec2ffa5b6d0496c9eab9b5c796f7ced3b")
+    set(DRIVER_VERSION "4.0.0+driver")
+    set(DRIVER_CHECKSUM "SHA256=0f71a4e4492847ce6ca35fe6f9ecdf682f603c878397e57d7628a0cd60a29aed")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -27,8 +27,8 @@ else()
   # In case you want to test against another falcosecurity/libs version (or branch, or commit) just pass the variable -
   # ie., `cmake -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "0.10.0-rc1")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=af2fcd9017d1611d3c5068405632eb3aa5cd578514ed8f06cb02ebca5556fd1d")
+    set(FALCOSECURITY_LIBS_VERSION "090f4f08c341ef1bb866170deef1c6b72e7e5d43")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=8b24b8ebb83c5d0a323e5ab0d8b8858ec2ffa5b6d0496c9eab9b5c796f7ced3b")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -27,8 +27,8 @@ else()
   # In case you want to test against another falcosecurity/libs version (or branch, or commit) just pass the variable -
   # ie., `cmake -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "090f4f08c341ef1bb866170deef1c6b72e7e5d43")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=8b24b8ebb83c5d0a323e5ab0d8b8858ec2ffa5b6d0496c9eab9b5c796f7ced3b")
+    set(FALCOSECURITY_LIBS_VERSION "0.10.0")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=08863e345668e984e5d00db4ff02540a52d739a8b2792046615dff4bfbc0459d")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/docker/builder/README.md
+++ b/docker/builder/README.md
@@ -1,0 +1,8 @@
+# Builder folder
+
+* We use `Dockerfile` to build the `centos7` Falco builder image.
+* We use `modern-falco-builder.Dockerfile` to build Falco with the modern probe and return it as a Dockerfile output. This Dockerfile doesn't generate a Docker image but returns as output (through the `--output` command):
+  * Falco `tar.gz`.
+  * Falco `deb` package.
+  * Falco `rpm` package.
+  * Falco build directory, used by other CI jobs.

--- a/docker/builder/modern-falco-builder.Dockerfile
+++ b/docker/builder/modern-falco-builder.Dockerfile
@@ -1,0 +1,42 @@
+
+FROM centos:7 AS build-stage
+
+# To build Falco you need to pass the cmake option
+ARG CMAKE_OPTIONS=""
+ARG MAKE_JOBS=4
+
+# Install all the dependencies
+WORKDIR /
+
+RUN yum -y install centos-release-scl; \
+    yum -y install devtoolset-8-gcc devtoolset-8-gcc-c++; \
+    source scl_source enable devtoolset-8; \
+    yum install -y git wget make m4 rpm-build
+
+# With some previous cmake versions it fails when downloading `zlib` with curl in the libs building phase
+RUN curl -L -o /tmp/cmake.tar.gz https://github.com/Kitware/CMake/releases/download/v3.22.5/cmake-3.22.5-linux-$(uname -m).tar.gz; \
+    gzip -d /tmp/cmake.tar.gz; \
+    tar -xpf /tmp/cmake.tar --directory=/tmp; \
+    cp -R /tmp/cmake-3.22.5-linux-$(uname -m)/* /usr; \
+    rm -rf /tmp/cmake-3.22.5-linux-$(uname -m)/
+
+# Copy Falco folder from the build context
+COPY . /source
+WORKDIR /build/release
+
+# We need `make tests` and `make all` for integration tests.
+RUN source scl_source enable devtoolset-8; \
+    cmake ${CMAKE_OPTIONS} /source; \
+    make falco -j${MAKE_JOBS}; \
+    make package; \
+    make tests -j${MAKE_JOBS}; \
+    make all -j${MAKE_JOBS}
+
+FROM scratch AS export-stage
+
+ARG DEST_BUILD_DIR="/build"
+
+COPY --from=build-stage /build/release/falco-*.tar.gz /packages/
+COPY --from=build-stage /build/release/falco-*.deb /packages/
+COPY --from=build-stage /build/release/falco-*.rpm /packages/
+COPY --from=build-stage /build/release/ ${DEST_BUILD_DIR}

--- a/docker/builder/modern-falco-builder.Dockerfile
+++ b/docker/builder/modern-falco-builder.Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7 AS build-stage
 
 # To build Falco you need to pass the cmake option
 ARG CMAKE_OPTIONS=""
-ARG MAKE_JOBS=4
+ARG MAKE_JOBS=6
 
 # Install all the dependencies
 WORKDIR /

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_subdirectory(trace_files)
 
-add_subdirectory(plugins)
-add_subdirectory(confs/plugins)
+if(NOT MUSL_OPTIMIZED_BUILD)
+    add_subdirectory(plugins)
+    add_subdirectory(confs/plugins)
+endif()


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

/area CI

**What this PR does / why we need it**:

This PR brings the necessary changes in the circle-ci jobs to build a Falco image for the modern bpf probe. I added a docker image that returns Falco packages as output (deb, rpm, tar).

This PR is the dual of https://github.com/falcosecurity/falco/pull/2282, the idea is to merge this for the release and leave the other PR open until Falco 0.34 is released so users can continue to test the modern probe if they want :) 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(ci): update ci jobs to generate Falco images with the modern BPF probe
```
