### PR TITLE
doc(userspace): provide users with a correct message when some syscalls are not defined

### DIFF
--- a/userspace/falco/app_actions/load_rules_files.cpp
+++ b/userspace/falco/app_actions/load_rules_files.cpp
@@ -67,7 +67,7 @@ void application::check_for_ignored_events()
 		std::cerr << (first ? "" : ", ") << it.c_str();
 		first = false;
 	}
-	std::cerr << std::endl << "These events could be associated with syscalls not defined on your architecture (please take a look here: https://marcin.juszkiewicz.com.pl/download/tables/syscalls.html). If syscalls are defined you have to run Falco with `-A` to catch these events" << std::endl;
+	std::cerr << std::endl << "These events might be associated with syscalls undefined on your architecture (please take a look here: https://marcin.juszkiewicz.com.pl/download/tables/syscalls.html). If syscalls are instead defined, you have to run Falco with `-A` to catch these events" << std::endl;
 }
 
 application::run_result application::load_rules_files()

--- a/userspace/falco/app_actions/load_rules_files.cpp
+++ b/userspace/falco/app_actions/load_rules_files.cpp
@@ -67,7 +67,7 @@ void application::check_for_ignored_events()
 		std::cerr << (first ? "" : ", ") << it.c_str();
 		first = false;
 	}
-	std::cerr << std::endl << "But these events are not returned unless running falco with -A" << std::endl;
+	std::cerr << std::endl << "These events could be associated with syscalls not defined on your architecture (please take a look here: https://marcin.juszkiewicz.com.pl/download/tables/syscalls.html). If syscalls are defined you have to run Falco with `-A` to catch these events" << std::endl;
 }
 
 application::run_result application::load_rules_files()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind documentation

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

As reported by @Happy-Dude here https://github.com/falcosecurity/falco/issues/2326, when running Falco on `aarch64`, Falco logs a misleading error message. Take as an example the issue log:

```
Loaded rules match the following events: symlink, mkdir, unlink, dup2, rmdir, link, open, rename, creat
```

All these syscalls are not defined on `aarch64` architectures but Falco is not yet able to detect it! As a first step, I would fix the log just to let the user know what is happening under the hood. Obviously, this is not the final solution, which will require some changes in the libraries to detect this sort of behavior, for this reason, the final fix will be shipped only in `Falco 0.35`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
doc(userspace): provide users with a correct message when some syscalls are not defined
```
