### PR TITLE
chore(scripts/falco-driver-loader): improve curl resiliency

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -656,11 +656,11 @@ KERNEL_VERSION=$(uname -v | sed 's/#\([[:digit:]]\+\).*/\1/')
 
 DRIVERS_REPO=${DRIVERS_REPO:-"@DRIVERS_REPO@"}
 
+FALCO_DRIVER_CURL_OPTIONS="-fsS --connect-timeout 5 --max-time 60 --retry 3 --retry-max-time 120"
+
 if [ -n "$DRIVER_INSECURE_DOWNLOAD" ]
 then
-	FALCO_DRIVER_CURL_OPTIONS=-fsSk
-else
-	FALCO_DRIVER_CURL_OPTIONS=-fsS
+	FALCO_DRIVER_CURL_OPTIONS+=" -k"
 fi
 
 FALCO_DRIVER_CURL_OPTIONS+=" "${DRIVER_CURL_OPTIONS}


### PR DESCRIPTION
Fixes #2334

Signed-off-by: Furkan <furkan.turkal@trendyol.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. . Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

> If contributing rules or changes to rules, please make sure to also uncomment one of the following line:

> /kind rule-update

> /kind rule-create

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area rules

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2334

**Special notes for your reviewer**:

I used `--connect-timeout 5`, `--retry 3`, `--max-time 60` and `--retry-max-time 120`: curl will retry transient errors up to `3` times, each attempt is capped to `60` second, total time allowed for retries is `120` seconds and maximum time to allow for connecting is `5` seconds. Otherwise, curl could sit for hours waiting for missing packets.

Is there any test script to run some test `falco-driver-loader` script? I tried to test manually but somehow couldn't run the script:

```
DRIVERS_REPO="https://download.falco.org/driver" DRIVER_NAME=falco DRIVER_VERSION=foo FALCO_VERSION=0.30.1 ./falco-driver-loader.sh module --download
```

It seems environments couldn't set correctly: `Running falco-driver-loader for: falco version=@FALCO_VERSION@`. Can you please help me on this if it works?

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
update(scripts/falco-driver-loader): optimize the resiliency of module download script for air-gapped environments
```
