### PR TITLE
new(userspace,tests): add proper support for generic events indexing.

### DIFF
--- a/unit_tests/engine/test_filter_evttype_resolver.cpp
+++ b/unit_tests/engine/test_filter_evttype_resolver.cpp
@@ -31,8 +31,7 @@ std::set<uint16_t> get_set_difference(std::set<uint16_t> exclude_set = {})
 {
 	std::set<uint16_t> set_difference = {};
 
-	/* Not considering GENERIC_E GENERIC_X */
-	for(uint32_t i = 2; i < PPM_EVENT_MAX; i++)
+	for(uint32_t i = PPME_GENERIC_E; i < PPM_EVENT_MAX; i++)
 	{
 		/* Skip events that are unused. */
 		if(sinsp::is_unused_event(i))

--- a/userspace/engine/filter_evttype_resolver.cpp
+++ b/userspace/engine/filter_evttype_resolver.cpp
@@ -44,16 +44,25 @@ void filter_evttype_resolver::visitor::inversion(falco_event_types& types)
 
 void filter_evttype_resolver::visitor::evttypes(const std::string& evtname, falco_event_types& out)
 {
-	// Fill in from 2 to PPM_EVENT_MAX-1. 0 and 1 are excluded as
-	// those are PPM_GENERIC_E/PPME_GENERIC_X
-	const struct ppm_event_info* etable = g_infotables.m_event_info;
-	for(uint16_t i = 2; i < PPM_EVENT_MAX; i++)
+	for(uint16_t i = PPME_GENERIC_E; i < PPM_EVENT_MAX; i++)
 	{
-		// Skip unused events or events not matching the requested evtname
-		if(!sinsp::is_unused_event(i) && (evtname.empty() || std::string(etable[i].name) == evtname))
+		// Skip unused events
+		if(sinsp::is_unused_event(i))
 		{
-			out.insert(i);
+			continue;
 		}
+
+		// Fetch event names associated with event id
+		const auto evtnames = m_inspector.get_events_names({i});
+		for (const auto& name : evtnames)
+		{
+			// Skip events not matching the requested evtname
+			if(evtname.empty() || name == evtname)
+			{
+				out.insert(i);
+			}
+		}
+
 	}
 }
 

--- a/userspace/engine/filter_evttype_resolver.h
+++ b/userspace/engine/filter_evttype_resolver.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <memory>
 #include <functional>
 #include <stdexcept>
+#include <sinsp.h>
 
 class falco_event_types
 {
@@ -188,7 +189,7 @@ public:
 private:
 	struct visitor : public libsinsp::filter::ast::expr_visitor
 	{
-		visitor(): m_expect_value(false) {}
+		visitor(): m_expect_value(false),m_inspector() {}
 		visitor(visitor&&) = default;
 		visitor& operator = (visitor&&) = default;
 		visitor(const visitor&) = default;
@@ -196,6 +197,7 @@ private:
 
 		bool m_expect_value;
 		falco_event_types m_last_node_evttypes;
+		sinsp m_inspector;
 
 		void visit(libsinsp::filter::ast::and_expr* e) override;
 		void visit(libsinsp::filter::ast::or_expr* e) override;

--- a/userspace/falco/app_actions/print_syscall_events.cpp
+++ b/userspace/falco/app_actions/print_syscall_events.cpp
@@ -73,7 +73,7 @@ application::run_result application::print_syscall_events()
 	if(m_options.list_syscall_events)
 	{
 		configure_interesting_sets();
-		const auto events = get_event_entries(false, m_state->ppm_event_info_of_interest);
+		const auto events = get_event_entries(true, m_state->ppm_event_info_of_interest);
 
 		if(m_options.markdown)
 		{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR adds support for generic events usage in rules file. 
I set it as `new` instead of `fix` because this was a previous choice; nowadays, i think it might be useful to allow users to filter on generic events, like if people want to know if a `fchownat` happened.

Of course, you need to enable the `-A` switch to get all events (generic too)!
Moreover, all generic events are indexed under the same bucket (0 for enter and 1 for exit); again, this is a performance penalty, but users are already well educated about `-A` enforcing a perf penalty.

**Which issue(s) this PR fixes**:

Fixes #2348

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new(engine): support generic events indexing
```
