### PR TITLE
fix(userspace/falco): fixed grpc server shutdown.

### DIFF
--- a/userspace/falco/grpc_server.cpp
+++ b/userspace/falco/grpc_server.cpp
@@ -222,10 +222,7 @@ void falco::grpc::server::run()
 	}
 	// todo(leodido) > log "gRPC server running: threadiness=m_threads.size()"
 
-	while(server_impl::is_running())
-	{
-		std::this_thread::sleep_for(std::chrono::milliseconds(100));
-	}
+	m_server->Wait();
 	// todo(leodido) > log "stopping gRPC server"
 	stop();
 }
@@ -233,7 +230,6 @@ void falco::grpc::server::run()
 void falco::grpc::server::stop()
 {
 	falco_logger::log(LOG_INFO, "Shutting down gRPC server. Waiting until external connections are closed by clients\n");
-	m_server->Shutdown();
 	m_completion_queue->Shutdown();
 
 	falco_logger::log(LOG_INFO, "Waiting for the gRPC threads to complete\n");

--- a/userspace/falco/grpc_server.h
+++ b/userspace/falco/grpc_server.h
@@ -56,7 +56,6 @@ private:
 	std::string m_cert_chain;
 	std::string m_root_certs;
 
-	std::unique_ptr<::grpc::Server> m_server;
 	std::vector<std::thread> m_threads;
 	::grpc::ServerBuilder m_server_builder;
 	void init_mtls_server_builder();

--- a/userspace/falco/grpc_server_impl.cpp
+++ b/userspace/falco/grpc_server_impl.cpp
@@ -87,4 +87,5 @@ void falco::grpc::server_impl::version(const context& ctx, const version::reques
 void falco::grpc::server_impl::shutdown()
 {
 	m_stop = true;
+	m_server->Shutdown();
 }

--- a/userspace/falco/grpc_server_impl.h
+++ b/userspace/falco/grpc_server_impl.h
@@ -43,6 +43,8 @@ protected:
 	// Version
 	void version(const context& ctx, const version::request& req, version::response& res);
 
+	std::unique_ptr<::grpc::Server> m_server;
+
 private:
 	std::atomic<bool> m_stop{false};
 };


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR fixes the grpc server shutdown.
Nowadays, we support hot-reload by default when ruleset/config is updated; this led to sigabrts when the grpc server was enabled since it was not properly shutdown.

**Which issue(s) this PR fixes**:

Fixes #2342

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix(userspace/falco): fix grpc server shutdown
```
