### PR TITLE
new(userspace/falco): [EXPERIMENTAL] allow modern bpf probe to assign more than one CPU to a single ring buffer

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -225,6 +225,24 @@ syscall_event_timeouts:
 
 syscall_buf_size_preset: 4
 
+
+############## [EXPERIMENTAL] Modern BPF probe specific ##############
+
+# These configs are experimental they could change over releases
+
+# Possible values: {0, 1, 2, ..., MAX_CPUS_NUMBER}
+cpus_for_each_syscall_buffer: 1
+
+# Possible values:
+# - true: allocate ring buffers only for online CPUs
+# - false: allocate ring buffers for all available CPUs
+online_cpus_only: true
+
+############## [EXPERIMENTAL] Modern BPF probe specific ##############
+
+
+
+
 # Falco continuously monitors outputs performance. When an output channel does not allow
 # to deliver an alert within a given deadline, an error is reported indicating
 # which output is blocking notifications.

--- a/falco.yaml
+++ b/falco.yaml
@@ -225,23 +225,72 @@ syscall_event_timeouts:
 
 syscall_buf_size_preset: 4
 
-
 ############## [EXPERIMENTAL] Modern BPF probe specific ##############
+# Please note: these configs regard only the modern BPF probe. They
+# are experimental so they could change over releases.
+#
+# `cpus_for_each_syscall_buffer`
+#
+# --- [Description]
+# 
+# This is an index that controls how many CPUs you want to assign to a single
+# syscall buffer (ring buffer). By default every CPU has its syscall buffer, 
+# so the mapping is 1:1. The modern BPF probe allows you to choose a different 
+# mapping, for example, 2:1 would mean a syscall buffer every 2 CPUs
+#
+# --- [Usage]
+#
+# You can choose between different indexes: from `0` to `MAX_NUMBER_ONLINE_CPUs`.
+# `0` is a special value and it means a single syscall buffer shared between all 
+# your online CPUs. `0` has the same effect as `MAX_NUMBER_ONLINE_CPUs`, the rationale
+# is that `0` allows you to create a single buffer without knowing the number of online
+# CPUs on your system.
+# Let's consider an example to better understand it:
+#
+# Consider a system with 7 online CPUs:
+#
+#          CPUs     0  X  2  3  X  X  6  7  8  9   (X means offline CPU) 
+#
+# - `1` (Default value) means a syscall buffer for each CPU so 7 buffers
+#
+#          CPUs     0  X  2  3  X  X  6  7  8  9   (X means offline CPU) 
+#                   |     |  |        |  |  |  |
+#       BUFFERs     0     1  2        3  4  5  6
+# 
+# - `2` means a syscall buffer for each CPU pair, so 4 buffers
+#
+#          CPUs     0  X  2  3  X  X  6  7  8  9   (X means offline CPU) 
+#                   |     |  |        |  |  |  |
+#       BUFFERs     0     0  1        1  2  2  3
+#
+# Please note that we need 4 buffers, 3 buffers are associated with CPU pairs, the last
+# one is mapped with just 1 CPU since we have an odd number of CPUs.
+#
+# - `0` or `MAX_NUMBER_ONLINE_CPUs` mean a syscall buffer shared between all CPUs, so 1 buffer
+#
+#          CPUs     0  X  2  3  X  X  6  7  8  9   (X means offline CPU) 
+#                   |     |  |        |  |  |  |
+#       BUFFERs     0     0  0        0  0  0  0
+#
+# Moreover you can combine this param with `syscall_buf_size_preset`
+# index, for example, you could create a huge single syscall buffer
+# shared between all your online CPUs of 512 MB (so `syscall_buf_size_preset=10`). 
+#
+# --- [Suggestions]
+#
+# We chose index `1` (so one syscall buffer for each CPU) as default to keep parity
+# between our drivers (bpf and kernel module). By the way, you are free to find the preferred
+# configuration for your system. Considering a fixed `syscall_buf_size_preset` and so
+# a fixed buffer dimension:
+# - a lower number of buffers can speed up your system (lower memory footprint)
+# - a too lower number of buffers could increase contention in the kernel causing an
+#   overall slowdown of the system.
+# If you don't have huge events throughtputs and you are not experimenting with tons of drops
+# you can try to reduce the number of buffers to have a lower memory footprint
 
-# These configs are experimental they could change over releases
-
-# Possible values: {0, 1, 2, ..., MAX_CPUS_NUMBER}
-cpus_for_each_syscall_buffer: 1
-
-# Possible values:
-# - true: allocate ring buffers only for online CPUs
-# - false: allocate ring buffers for all available CPUs
-online_cpus_only: true
-
+modern_bpf:
+  cpus_for_each_syscall_buffer: 1
 ############## [EXPERIMENTAL] Modern BPF probe specific ##############
-
-
-
 
 # Falco continuously monitors outputs performance. When an output channel does not allow
 # to deliver an alert within a given deadline, an error is reported indicating

--- a/userspace/falco/app_actions/open_inspector.cpp
+++ b/userspace/falco/app_actions/open_inspector.cpp
@@ -77,11 +77,9 @@ application::run_result application::open_live_inspector(
 		}
 		else if(m_options.modern_bpf) /* modern BPF engine. */
 		{
-			std::string interesting_CPUs = m_state->config->m_online_cpus_only ? "online" : "available";
 			falco_logger::log(LOG_INFO, "Opening capture with modern BPF probe.");
 			falco_logger::log(LOG_INFO, "One ring buffer every '" + std::to_string(m_state->config->m_cpus_for_each_syscall_buffer) +  "' CPUs.");
-			falco_logger::log(LOG_INFO, "Allocate ring buffers for " + interesting_CPUs + " only.");
-			inspector->open_modern_bpf(m_state->syscall_buffer_bytes_size, m_state->config->m_cpus_for_each_syscall_buffer, m_state->config->m_online_cpus_only, m_state->ppm_sc_of_interest, m_state->tp_of_interest);
+			inspector->open_modern_bpf(m_state->syscall_buffer_bytes_size, m_state->config->m_cpus_for_each_syscall_buffer, true, m_state->ppm_sc_of_interest, m_state->tp_of_interest);
 		}
 		else if(getenv(FALCO_BPF_ENV_VARIABLE) != NULL) /* BPF engine. */
 		{

--- a/userspace/falco/app_actions/open_inspector.cpp
+++ b/userspace/falco/app_actions/open_inspector.cpp
@@ -77,8 +77,11 @@ application::run_result application::open_live_inspector(
 		}
 		else if(m_options.modern_bpf) /* modern BPF engine. */
 		{
-			falco_logger::log(LOG_INFO, "Opening capture with modern BPF probe");
-			inspector->open_modern_bpf(m_state->syscall_buffer_bytes_size, DEFAULT_CPU_FOR_EACH_BUFFER, true, m_state->ppm_sc_of_interest, m_state->tp_of_interest);
+			std::string interesting_CPUs = m_state->config->m_online_cpus_only ? "online" : "available";
+			falco_logger::log(LOG_INFO, "Opening capture with modern BPF probe.");
+			falco_logger::log(LOG_INFO, "One ring buffer every '" + std::to_string(m_state->config->m_cpus_for_each_syscall_buffer) +  "' CPUs.");
+			falco_logger::log(LOG_INFO, "Allocate ring buffers for " + interesting_CPUs + " only.");
+			inspector->open_modern_bpf(m_state->syscall_buffer_bytes_size, m_state->config->m_cpus_for_each_syscall_buffer, m_state->config->m_online_cpus_only, m_state->ppm_sc_of_interest, m_state->tp_of_interest);
 		}
 		else if(getenv(FALCO_BPF_ENV_VARIABLE) != NULL) /* BPF engine. */
 		{

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -57,9 +57,7 @@ falco_configuration::falco_configuration():
 	m_metadata_download_chunk_wait_us(1000),
 	m_metadata_download_watch_freq_sec(1),
 	m_syscall_buf_size_preset(4),
-	m_cpus_for_each_syscall_buffer(1),
-	m_online_cpus_only(true),
-	m_config(NULL)
+	m_cpus_for_each_syscall_buffer(1)
 {
 }
 
@@ -311,12 +309,9 @@ void falco_configuration::load_yaml(const std::string& config_name, const yaml_h
 	/* We put this value in the configuration file because in this way we can change the dimension at every reload.
 	 * The default value is `4` -> 8 MB.
 	 */
-	m_syscall_buf_size_preset = m_config->get_scalar<uint16_t>("syscall_buf_size_preset", 4);
-	
-	m_cpus_for_each_syscall_buffer = m_config->get_scalar<uint16_t>("cpus_for_each_syscall_buffer", 1);
+	m_syscall_buf_size_preset = config.get_scalar<uint16_t>("syscall_buf_size_preset", 4);
 
-	m_online_cpus_only = m_config->get_scalar<bool>("online_cpus_only", true);
-
+	m_cpus_for_each_syscall_buffer = config.get_scalar<uint16_t>("cpus_for_each_syscall_buffer", 1);
 
 	std::set<std::string> load_plugins;
 

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -56,7 +56,10 @@ falco_configuration::falco_configuration():
 	m_metadata_download_max_mb(100),
 	m_metadata_download_chunk_wait_us(1000),
 	m_metadata_download_watch_freq_sec(1),
-	m_syscall_buf_size_preset(4)
+	m_syscall_buf_size_preset(4),
+	m_cpus_for_each_syscall_buffer(1),
+	m_online_cpus_only(true),
+	m_config(NULL)
 {
 }
 
@@ -308,7 +311,12 @@ void falco_configuration::load_yaml(const std::string& config_name, const yaml_h
 	/* We put this value in the configuration file because in this way we can change the dimension at every reload.
 	 * The default value is `4` -> 8 MB.
 	 */
-	m_syscall_buf_size_preset = config.get_scalar<uint16_t>("syscall_buf_size_preset", 4);
+	m_syscall_buf_size_preset = m_config->get_scalar<uint16_t>("syscall_buf_size_preset", 4);
+	
+	m_cpus_for_each_syscall_buffer = m_config->get_scalar<uint16_t>("cpus_for_each_syscall_buffer", 1);
+
+	m_online_cpus_only = m_config->get_scalar<bool>("online_cpus_only", true);
+
 
 	std::set<std::string> load_plugins;
 

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -103,6 +103,12 @@ public:
 	// Index corresponding to the syscall buffer dimension.
 	uint16_t m_syscall_buf_size_preset;
 
+	// Number of CPUs associated with a single ring buffer.
+	uint16_t m_cpus_for_each_syscall_buffer;
+
+	// If true allocate ring buffers only for online CPUs
+	bool m_online_cpus_only;
+
 	std::vector<plugin_config> m_plugins;
 
 private:

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -106,9 +106,6 @@ public:
 	// Number of CPUs associated with a single ring buffer.
 	uint16_t m_cpus_for_each_syscall_buffer;
 
-	// If true allocate ring buffers only for online CPUs
-	bool m_online_cpus_only;
-
 	std::vector<plugin_config> m_plugins;
 
 private:


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR allows Falco to take advantage of a new modern BPF feature: to assign more than one CPU to a single ring buffer.
This feature is EXPERIMENTAL, and you can use it only with the modern BPF probe. With EXPERIMENTAL, we mean that this config could be changed or removed across releases.
You can find more info about the feature datil here: https://github.com/falcosecurity/libs/pull/820
To learn how to use this new config see `falco.yaml` file in the PR

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new(userspace/falco): [EXPERIMENTAL] allow modern bpf probe to assign more than one CPU to a single ring buffer
```
