### PR TITLE
update(scripts): add option for regenerating signatures of all dev and release packages

### DIFF
--- a/scripts/publish-deb
+++ b/scripts/publish-deb
@@ -180,7 +180,7 @@ if [ "${sign_all}" ]; then
         sign_deb ${tmp_repo_path} ${debSuite} ${file}
 
         echo "Syncing ${package}.asc to ${s3_bucket_repo}..."
-        aws s3 sync ${tmp_repo_path}/${debSuite}/${package}.asc ${s3_bucket_repo}/${debSuite}/${package}.asc --delete --acl public-read
+        aws s3 cp ${tmp_repo_path}/${debSuite}/${package}.asc ${s3_bucket_repo}/${debSuite}/${package}.asc --acl public-read
         aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}.asc
       fi
     fi

--- a/scripts/publish-deb
+++ b/scripts/publish-deb
@@ -2,7 +2,7 @@
 set -e
 
 usage() {
-    echo "usage: $0 -f <package_x86_64.deb> -f <package_aarch64.deb> -r <deb|deb-dev>"
+    echo "usage: $0 -f <package_x86_64.deb> -f <package_aarch64.deb> -r <deb|deb-dev> [-s]"
     exit 1
 }
 
@@ -21,6 +21,18 @@ join_arr() {
   echo "$*"
 }
 
+# Updates the signature of a DEB package in the local repository
+#
+# $1: path of the repository.
+# $2: suite (eg. "stable")
+# $3: path of the DEB file.
+sign_deb() {
+    pushd $1/$2 > /dev/null
+    rm -f $(basename -- $3).asc
+    gpg --detach-sign --digest-algo SHA256 --armor $(basename -- $3)
+    popd > /dev/null
+}
+
 # Add a package to the local DEB repository
 #
 # $1: path of the repository.
@@ -28,10 +40,7 @@ join_arr() {
 # $3: path of the DEB file.
 add_deb() {
     cp -f $3 $1/$2
-    pushd $1/$2 > /dev/null
-    rm -f $(basename -- $3).asc
-    gpg --detach-sign --digest-algo SHA256 --armor $(basename -- $3)
-    popd > /dev/null
+    sign_deb $1 $2 $3
 
     # Get package architecture from dpkg
     local arch=$(dpkg --info $3 |  awk '/Architecture/ {printf "%s", $2}')
@@ -102,7 +111,7 @@ update_repo() {
 }
 
 # parse options
-while getopts ":f::r:" opt; do
+while getopts ":f::r::s" opt; do
     case "${opt}" in
         f )
           files+=("${OPTARG}")
@@ -110,6 +119,9 @@ while getopts ":f::r:" opt; do
         r )
           repo="${OPTARG}"
           [[ "${repo}" == "deb" || "${repo}" == "deb-dev" ]] || usage
+          ;;
+        s )
+          sign_all="true"
           ;;
         : )
           echo "invalid option: ${OPTARG} requires an argument" 1>&2
@@ -147,7 +159,19 @@ echo "Fetching ${s3_bucket_repo}..."
 mkdir -p ${tmp_repo_path}
 aws s3 cp ${s3_bucket_repo} ${tmp_repo_path} --recursive
 
-# update the repo
+# update signatures for all existing packages
+if [ "${sign_all}" ]; then
+  for file in ${tmp_repo_path}/${debSuite}/*; do
+    if [ -f "$file" ]; then # exclude directories, symlinks, etc...
+      if [[ ! $file == *.asc ]]; then # exclude signature files
+        echo "Signing ${file}..."
+        sign_deb ${tmp_repo_path} ${debSuite} ${file}
+      fi
+    fi
+  done
+fi
+
+# update the repo by adding new packages
 for file in "${files[@]}"; do
   echo "Adding ${file}..."
   add_deb ${tmp_repo_path} ${debSuite} ${file}

--- a/scripts/publish-deb
+++ b/scripts/publish-deb
@@ -180,7 +180,7 @@ if [ "${sign_all}" ]; then
         sign_deb ${tmp_repo_path} ${debSuite} ${file}
 
         echo "Syncing ${package}.asc to ${s3_bucket_repo}..."
-        aws s3 sync ${tmp_repo_path}/${debSuite}/${package}.asc ${s3_bucket_repo}/${debSuite}/${package}.asc --delete ---acl public-read
+        aws s3 sync ${tmp_repo_path}/${debSuite}/${package}.asc ${s3_bucket_repo}/${debSuite}/${package}.asc --delete --acl public-read
         aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}.asc
       fi
     fi
@@ -207,8 +207,8 @@ if ! [ ${#files[@]} -eq 0 ]; then
     aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}
     aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}.asc
   done
-
-  # sync dists
-  aws s3 sync ${tmp_repo_path}/dists ${s3_bucket_repo}/dists --delete --acl public-read
-  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/dists/*
 fi
+
+# sync dists
+aws s3 sync ${tmp_repo_path}/dists ${s3_bucket_repo}/dists --delete --acl public-read
+aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/dists/*

--- a/scripts/publish-deb
+++ b/scripts/publish-deb
@@ -164,8 +164,13 @@ if [ "${sign_all}" ]; then
   for file in ${tmp_repo_path}/${debSuite}/*; do
     if [ -f "$file" ]; then # exclude directories, symlinks, etc...
       if [[ ! $file == *.asc ]]; then # exclude signature files
-        echo "Signing ${file}..."
+        package=$(basename -- ${file})
+        echo "Signing ${package}..."
         sign_deb ${tmp_repo_path} ${debSuite} ${file}
+
+        echo "Synching ${package}.asc to ${s3_bucket_repo}..."
+        aws s3 sync ${tmp_repo_path}/${debSuite}/${package}.asc ${s3_bucket_repo}/${debSuite}/${package}.asc --delete ---acl public-read
+        aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}.asc
       fi
     fi
   done

--- a/scripts/publish-deb
+++ b/scripts/publish-deb
@@ -63,6 +63,27 @@ falco_arch_from_deb_arch() {
     esac  
 }
 
+# Sign the local DEB repository
+#
+# $1: path of the repository
+# $2: suite (eg. "stable")
+sign_repo() {
+    local release_dir=dists/$2
+    pushd $1 > /dev/null
+
+    # release signature - Release.gpg file
+    gpg --detach-sign --digest-algo SHA256 --armor ${release_dir}/Release
+    rm -f ${release_dir}/Release.gpg
+    mv ${release_dir}/Release.asc ${release_dir}/Release.gpg
+    
+    # release signature - InRelease file
+    gpg --armor --sign --clearsign --digest-algo SHA256 ${release_dir}/Release
+    rm -f ${release_dir}/InRelease
+    mv ${release_dir}/Release.asc ${release_dir}/InRelease
+
+    popd > /dev/null
+}
+
 # Update the local DEB repository
 #
 # $1: path of the repository
@@ -96,16 +117,6 @@ update_repo() {
       -o APT::FTPArchive::Release::Components=${component} \
       -o APT::FTPArchive::Release::Architectures="$(join_arr , "${architectures[@]}")" \
       ${release_dir} > ${release_dir}/Release
-
-    # release signature - Release.gpg file
-    gpg --detach-sign --digest-algo SHA256 --armor ${release_dir}/Release
-    rm -f ${release_dir}/Release.gpg
-    mv ${release_dir}/Release.asc ${release_dir}/Release.gpg
-    
-    # release signature - InRelease file
-    gpg --armor --sign --clearsign --digest-algo SHA256 ${release_dir}/Release
-    rm -f ${release_dir}/InRelease
-    mv ${release_dir}/Release.asc ${release_dir}/InRelease
 
     popd > /dev/null
 }
@@ -174,6 +185,7 @@ if [ "${sign_all}" ]; then
       fi
     fi
   done
+  sign_repo ${tmp_repo_path} ${debSuite}
 fi
 
 # update the repo by adding new packages
@@ -183,6 +195,7 @@ if ! [ ${#files[@]} -eq 0 ]; then
     add_deb ${tmp_repo_path} ${debSuite} ${file}
   done
   update_repo ${tmp_repo_path} ${debSuite}
+  sign_repo ${tmp_repo_path} ${debSuite}
 
   # publish
   for file in "${files[@]}"; do

--- a/scripts/publish-deb
+++ b/scripts/publish-deb
@@ -181,10 +181,10 @@ if [ "${sign_all}" ]; then
 
         echo "Syncing ${package}.asc to ${s3_bucket_repo}..."
         aws s3 cp ${tmp_repo_path}/${debSuite}/${package}.asc ${s3_bucket_repo}/${debSuite}/${package}.asc --acl public-read
-        aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}.asc
       fi
     fi
   done
+  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/*.asc
   sign_repo ${tmp_repo_path} ${debSuite}
 fi
 

--- a/scripts/publish-deb
+++ b/scripts/publish-deb
@@ -136,7 +136,7 @@ done
 shift $((OPTIND-1))
 
 # check options
-if [ ${#files[@]} -eq 0 ] || [ -z "${repo}" ]; then
+if ([ ${#files[@]} -eq 0 ] && [ -z "${sign_all}" ]) || [ -z "${repo}" ]; then
     usage
 fi
 
@@ -177,23 +177,25 @@ if [ "${sign_all}" ]; then
 fi
 
 # update the repo by adding new packages
-for file in "${files[@]}"; do
-  echo "Adding ${file}..."
-  add_deb ${tmp_repo_path} ${debSuite} ${file}
-done
-update_repo ${tmp_repo_path} ${debSuite}
+if ! [ ${#files[@]} -eq 0 ]; then
+  for file in "${files[@]}"; do
+    echo "Adding ${file}..."
+    add_deb ${tmp_repo_path} ${debSuite} ${file}
+  done
+  update_repo ${tmp_repo_path} ${debSuite}
 
-# publish
-for file in "${files[@]}"; do
-  package=$(basename -- ${file})
-  echo "Publishing ${package} to ${s3_bucket_repo}..."
-  aws s3 cp ${tmp_repo_path}/${debSuite}/${package} ${s3_bucket_repo}/${debSuite}/${package} --acl public-read
-  aws s3 cp ${tmp_repo_path}/${debSuite}/${package}.asc ${s3_bucket_repo}/${debSuite}/${package}.asc --acl public-read
+  # publish
+  for file in "${files[@]}"; do
+    package=$(basename -- ${file})
+    echo "Publishing ${package} to ${s3_bucket_repo}..."
+    aws s3 cp ${tmp_repo_path}/${debSuite}/${package} ${s3_bucket_repo}/${debSuite}/${package} --acl public-read
+    aws s3 cp ${tmp_repo_path}/${debSuite}/${package}.asc ${s3_bucket_repo}/${debSuite}/${package}.asc --acl public-read
 
-  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}
-  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}.asc
-done
+    aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}
+    aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}.asc
+  done
 
-# sync dists
-aws s3 sync ${tmp_repo_path}/dists ${s3_bucket_repo}/dists --delete --acl public-read
-aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/dists/*
+  # sync dists
+  aws s3 sync ${tmp_repo_path}/dists ${s3_bucket_repo}/dists --delete --acl public-read
+  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/dists/*
+fi

--- a/scripts/publish-deb
+++ b/scripts/publish-deb
@@ -168,7 +168,7 @@ if [ "${sign_all}" ]; then
         echo "Signing ${package}..."
         sign_deb ${tmp_repo_path} ${debSuite} ${file}
 
-        echo "Synching ${package}.asc to ${s3_bucket_repo}..."
+        echo "Syncing ${package}.asc to ${s3_bucket_repo}..."
         aws s3 sync ${tmp_repo_path}/${debSuite}/${package}.asc ${s3_bucket_repo}/${debSuite}/${package}.asc --delete ---acl public-read
         aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${debSuite}/${package}.asc
       fi

--- a/scripts/publish-rpm
+++ b/scripts/publish-rpm
@@ -107,7 +107,7 @@ if [ "${sign_all}" ]; then
         sign_rpm ${tmp_repo_path} ${file}
 
         echo "Syncing ${package}.asc to ${s3_bucket_repo}..."
-        aws s3 sync ${tmp_repo_path}/${package}.asc ${s3_bucket_repo}/${package}.asc --delete --acl public-read
+        aws s3 cp ${tmp_repo_path}/${package}.asc ${s3_bucket_repo}/${package}.asc --acl public-read
         aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}.asc
       fi
     fi

--- a/scripts/publish-rpm
+++ b/scripts/publish-rpm
@@ -95,8 +95,13 @@ if [ "${sign_all}" ]; then
   for file in ${tmp_repo_path}/*; do
     if [ -f "$file" ]; then # exclude directories, symlinks, etc...
       if [[ ! $file == *.asc ]]; then # exclude signature files
-        echo "Signing ${file}..."
+        package=$(basename -- ${file})
+        echo "Signing ${package}..."
         sign_rpm ${tmp_repo_path} ${file}
+
+        echo "Synching ${package}.asc to ${s3_bucket_repo}..."
+        aws s3 sync ${tmp_repo_path}/${package}.asc ${s3_bucket_repo}/${package}.asc --delete ---acl public-read
+        aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}.asc
       fi
     fi
   done

--- a/scripts/publish-rpm
+++ b/scripts/publish-rpm
@@ -107,7 +107,7 @@ if [ "${sign_all}" ]; then
         sign_rpm ${tmp_repo_path} ${file}
 
         echo "Syncing ${package}.asc to ${s3_bucket_repo}..."
-        aws s3 sync ${tmp_repo_path}/${package}.asc ${s3_bucket_repo}/${package}.asc --delete ---acl public-read
+        aws s3 sync ${tmp_repo_path}/${package}.asc ${s3_bucket_repo}/${package}.asc --delete --acl public-read
         aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}.asc
       fi
     fi
@@ -134,8 +134,8 @@ if ! [ ${#files[@]} -eq 0 ]; then
     aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}
     aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}.asc
   done
-
-  # sync repodata
-  aws s3 sync ${tmp_repo_path}/repodata ${s3_bucket_repo}/repodata --delete --acl public-read
-  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/repodata/*
 fi
+
+# sync repodata
+aws s3 sync ${tmp_repo_path}/repodata ${s3_bucket_repo}/repodata --delete --acl public-read
+aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/repodata/*

--- a/scripts/publish-rpm
+++ b/scripts/publish-rpm
@@ -108,10 +108,10 @@ if [ "${sign_all}" ]; then
 
         echo "Syncing ${package}.asc to ${s3_bucket_repo}..."
         aws s3 cp ${tmp_repo_path}/${package}.asc ${s3_bucket_repo}/${package}.asc --acl public-read
-        aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}.asc
       fi
     fi
   done
+  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/*.asc
   sign_repo ${tmp_repo_path}
 fi
 

--- a/scripts/publish-rpm
+++ b/scripts/publish-rpm
@@ -99,7 +99,7 @@ if [ "${sign_all}" ]; then
         echo "Signing ${package}..."
         sign_rpm ${tmp_repo_path} ${file}
 
-        echo "Synching ${package}.asc to ${s3_bucket_repo}..."
+        echo "Syncing ${package}.asc to ${s3_bucket_repo}..."
         aws s3 sync ${tmp_repo_path}/${package}.asc ${s3_bucket_repo}/${package}.asc --delete ---acl public-read
         aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}.asc
       fi

--- a/scripts/publish-rpm
+++ b/scripts/publish-rpm
@@ -71,7 +71,7 @@ while getopts ":f::r::s" opt; do
 done
 shift $((OPTIND-1))
 
-if [ ${#files[@]} -eq 0 ] || [ -z "${repo}" ]; then
+if ([ ${#files[@]} -eq 0 ] && [ -z "${sign_all}" ]) || [ -z "${repo}" ]; then
     usage
 fi
 
@@ -108,23 +108,25 @@ if [ "${sign_all}" ]; then
 fi
 
 # update the repo by adding new packages
-for file in "${files[@]}"; do
-  echo "Adding ${file}..."
-  add_rpm ${tmp_repo_path} ${file}
-done
-update_repo ${tmp_repo_path}
+if ! [ ${#files[@]} -eq 0 ]; then
+  for file in "${files[@]}"; do
+    echo "Adding ${file}..."
+    add_rpm ${tmp_repo_path} ${file}
+  done
+  update_repo ${tmp_repo_path}
 
-# publish
-for file in "${files[@]}"; do
-  package=$(basename -- ${file})
-  echo "Publishing ${package} to ${s3_bucket_repo}..."
-  aws s3 cp ${tmp_repo_path}/${package} ${s3_bucket_repo}/${package} --acl public-read
-  aws s3 cp ${tmp_repo_path}/${package}.asc ${s3_bucket_repo}/${package}.asc --acl public-read
+  # publish
+  for file in "${files[@]}"; do
+    package=$(basename -- ${file})
+    echo "Publishing ${package} to ${s3_bucket_repo}..."
+    aws s3 cp ${tmp_repo_path}/${package} ${s3_bucket_repo}/${package} --acl public-read
+    aws s3 cp ${tmp_repo_path}/${package}.asc ${s3_bucket_repo}/${package}.asc --acl public-read
 
-  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}
-  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}.asc
-done
+    aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}
+    aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/${package}.asc
+  done
 
-# sync repodata
-aws s3 sync ${tmp_repo_path}/repodata ${s3_bucket_repo}/repodata --delete --acl public-read
-aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/repodata/*
+  # sync repodata
+  aws s3 sync ${tmp_repo_path}/repodata ${s3_bucket_repo}/repodata --delete --acl public-read
+  aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DIST_ID} --paths ${cloudfront_path}/repodata/*
+fi

--- a/scripts/publish-rpm
+++ b/scripts/publish-rpm
@@ -34,17 +34,24 @@ add_rpm() {
     sign_rpm $1 $2
 }
 
+# Sign the local RPM repository
+#
+# $1: path of the repository.
+sign_repo() {
+    pushd $1 > /dev/null
+    rm -f repodata/repomd.xml.asc
+    gpg --detach-sign --digest-algo SHA256 --armor repodata/repomd.xml
+    popd > /dev/null
+}
+
 # Update the local RPM repository
 #
 # $1: path of the repository.
 update_repo() {
     pushd $1 > /dev/null
     createrepo --update --no-database .
-    rm -f repodata/repomd.xml.asc
-    gpg --detach-sign --digest-algo SHA256 --armor repodata/repomd.xml
     popd > /dev/null
 }
-
 
 # parse options
 while getopts ":f::r::s" opt; do
@@ -105,6 +112,7 @@ if [ "${sign_all}" ]; then
       fi
     fi
   done
+  sign_repo ${tmp_repo_path}
 fi
 
 # update the repo by adding new packages
@@ -114,6 +122,7 @@ if ! [ ${#files[@]} -eq 0 ]; then
     add_rpm ${tmp_repo_path} ${file}
   done
   update_repo ${tmp_repo_path}
+  sign_repo ${tmp_repo_path}
 
   # publish
   for file in "${files[@]}"; do

--- a/scripts/publish-rpm
+++ b/scripts/publish-rpm
@@ -2,7 +2,7 @@
 set -e
 
 usage() {
-    echo "usage: $0 -f <package_x86_64.rpm> -f <package_aarch64.rpm> -r <rpm|rpm-dev>"
+    echo "usage: $0 -f <package_x86_64.rpm> -f <package_aarch64.rpm> -r <rpm|rpm-dev> [-s]"
     exit 1
 }
 
@@ -14,16 +14,24 @@ check_program() {
   fi
 }
 
+# Updates the signature of a RPM package in the local repository
+#
+# $1: path of the repository.
+# $2: path of the RPM file.
+sign_rpm() {
+    pushd $1 > /dev/null
+    rm -f $(basename -- $2).asc
+    gpg --detach-sign --digest-algo SHA256 --armor $(basename -- $2)
+    popd > /dev/null
+}
+
 # Add a package to the local RPM repository
 #
 # $1: path of the repository.
 # $2: path of the RPM file.
 add_rpm() {
     cp -f $2 $1
-    pushd $1 > /dev/null
-    rm -f $(basename -- $2).asc
-    gpg --detach-sign --digest-algo SHA256 --armor $(basename -- $2)
-    popd > /dev/null
+    sign_rpm $1 $2
 }
 
 # Update the local RPM repository
@@ -39,7 +47,7 @@ update_repo() {
 
 
 # parse options
-while getopts ":f::r:" opt; do
+while getopts ":f::r::s" opt; do
     case "${opt}" in
         f )
           files+=("${OPTARG}")
@@ -47,6 +55,9 @@ while getopts ":f::r:" opt; do
         r )
           repo="${OPTARG}"
           [[ "${repo}" == "rpm" || "${repo}" == "rpm-dev" ]] || usage
+          ;;
+        s )
+          sign_all="true"
           ;;
         : )
           echo "invalid option: ${OPTARG} requires an argument" 1>&2
@@ -79,7 +90,19 @@ echo "Fetching ${s3_bucket_repo}..."
 mkdir -p ${tmp_repo_path}
 aws s3 cp ${s3_bucket_repo} ${tmp_repo_path} --recursive
 
-# update the repo
+# update signatures for all existing packages
+if [ "${sign_all}" ]; then
+  for file in ${tmp_repo_path}/*; do
+    if [ -f "$file" ]; then # exclude directories, symlinks, etc...
+      if [[ ! $file == *.asc ]]; then # exclude signature files
+        echo "Signing ${file}..."
+        sign_rpm ${tmp_repo_path} ${file}
+      fi
+    fi
+  done
+fi
+
+# update the repo by adding new packages
 for file in "${files[@]}"; do
   echo "Adding ${file}..."
   add_rpm ${tmp_repo_path} ${file}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

This PR adds a new `-s` optional parameter to the `publish-deb` and `publish-rpm` scripts that we use in our CI to upload and sign both dev and release packages on https://download.falco.org/?prefix=packages/. The flag is responsible of re-generating all the existing packages' signatures along with the newly-added ones.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(scripts): add option for regenerating signatures of all dev and release packages
```
