### PR TITLE
fix(docker/falco): trust latest GPG key

### DIFF
--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -88,7 +88,7 @@ RUN rm -rf /usr/bin/clang \
 	&& ln -s /usr/bin/clang-7 /usr/bin/clang \
 	&& ln -s /usr/bin/llc-7 /usr/bin/llc
 
-RUN curl -s https://falco.org/repo/falcosecurity-3672BA8F.asc | apt-key add - \
+RUN curl -s https://falco.org/repo/falcosecurity-packages.asc | apt-key add - \
 	&& echo "deb https://download.falco.org/packages/${VERSION_BUCKET} stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list \
 	&& apt-get update -y \
 	&& if [ "$FALCO_VERSION" = "latest" ]; then apt-get install -y --no-install-recommends falco; else apt-get install -y --no-install-recommends falco=${FALCO_VERSION}; fi \


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

/area CI

**What this PR does / why we need it**:

This PR fixes the Dockerfile we use for building the `falcosecurity/falco` image by trusting the latest GPG organization key used to sign packages available at `https://falco.org/repo/falcosecurity-packages.asc`. 

This is supposed to fix the current CI issues we have due to the GPG key currently being rotated.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(docker/falco): trust latest GPG key
```
