### PR TITLE
update(CI): mitigate frequent failure in CircleCI jobs

### DIFF
--- a/docker/builder/modern-falco-builder.Dockerfile
+++ b/docker/builder/modern-falco-builder.Dockerfile
@@ -27,10 +27,11 @@ WORKDIR /build/release
 # We need `make tests` and `make all` for integration tests.
 RUN source scl_source enable devtoolset-9; \
     cmake ${CMAKE_OPTIONS} /source; \
-    make falco -j${MAKE_JOBS}; \
-    make package; \
-    make tests -j${MAKE_JOBS}; \
-    make all -j${MAKE_JOBS}
+    make falco -j${MAKE_JOBS}
+
+RUN make package
+RUN make tests -j${MAKE_JOBS}
+RUN make all -j${MAKE_JOBS}
 
 FROM scratch AS export-stage
 

--- a/docker/builder/modern-falco-builder.Dockerfile
+++ b/docker/builder/modern-falco-builder.Dockerfile
@@ -24,12 +24,12 @@ RUN curl -L -o /tmp/cmake.tar.gz https://github.com/Kitware/CMake/releases/downl
 COPY . /source
 WORKDIR /build/release
 
-# We need `make tests` and `make all` for integration tests.
 RUN source scl_source enable devtoolset-9; \
     cmake ${CMAKE_OPTIONS} /source; \
     make falco -j${MAKE_JOBS}
-
 RUN make package
+
+# We need `make tests` and `make all` for integration tests.
 RUN make tests -j${MAKE_JOBS}
 RUN make all -j${MAKE_JOBS}
 
@@ -40,4 +40,23 @@ ARG DEST_BUILD_DIR="/build"
 COPY --from=build-stage /build/release/falco-*.tar.gz /packages/
 COPY --from=build-stage /build/release/falco-*.deb /packages/
 COPY --from=build-stage /build/release/falco-*.rpm /packages/
-COPY --from=build-stage /build/release/ ${DEST_BUILD_DIR}
+
+# This is what we need for integration tests. We don't export all the build directory
+# outside the container since its size is almost 6 GB, we export only what is strictly necessary
+# for integration tests.
+# This is just a workaround to fix the CI build until we replace our actual testing framework.
+COPY --from=build-stage /build/release/cloudtrail-plugin-prefix ${DEST_BUILD_DIR}/cloudtrail-plugin-prefix
+COPY --from=build-stage /build/release/cloudtrail-rules-prefix ${DEST_BUILD_DIR}/cloudtrail-rules-prefix
+COPY --from=build-stage /build/release/falcosecurity-rules-application-prefix ${DEST_BUILD_DIR}/falcosecurity-rules-application-prefix
+COPY --from=build-stage /build/release/falcosecurity-rules-falco-prefix ${DEST_BUILD_DIR}/falcosecurity-rules-falco-prefix
+COPY --from=build-stage /build/release/falcosecurity-rules-local-prefix ${DEST_BUILD_DIR}/falcosecurity-rules-local-prefix
+COPY --from=build-stage /build/release/json-plugin-prefix ${DEST_BUILD_DIR}/json-plugin-prefix
+COPY --from=build-stage /build/release/k8saudit-plugin-prefix ${DEST_BUILD_DIR}/k8saudit-plugin-prefix
+COPY --from=build-stage /build/release/k8saudit-rules-prefix ${DEST_BUILD_DIR}/k8saudit-rules-prefix
+COPY --from=build-stage /build/release/scripts ${DEST_BUILD_DIR}/scripts
+COPY --from=build-stage /build/release/test ${DEST_BUILD_DIR}/test
+COPY --from=build-stage /build/release/userspace/falco/falco ${DEST_BUILD_DIR}/userspace/falco/falco
+COPY --from=build-stage /build/release/userspace/falco/config_falco.h ${DEST_BUILD_DIR}/userspace/falco/config_falco.h
+COPY --from=build-stage /build/release/falco-*.tar.gz ${DEST_BUILD_DIR}/
+COPY --from=build-stage /build/release/falco-*.deb ${DEST_BUILD_DIR}/
+COPY --from=build-stage /build/release/falco-*.rpm ${DEST_BUILD_DIR}/


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This PR performs 2 main actions on the modern-falco-builder to mitigate some issues with the Falco CI:

* It splits various `make` commands into different docker RUN instructions, in this way we can catch errors in single steps. With the previous approach :point_down: we were not able to catch failures when `make package` failed: the CI job was successful but the build failed https://app.circleci.com/pipelines/github/falcosecurity/falco/3647/workflows/1fca77ee-28c8-4a4c-8344-ff44f3db447f/jobs/31261

```docker
RUN source scl_source enable devtoolset-9; \
    cmake ${CMAKE_OPTIONS} /source; \
    make falco -j${MAKE_JOBS}; \
    make package; \
    make tests -j${MAKE_JOBS}; \
    make all -j${MAKE_JOBS} 
```

* Recently many CI jobs are failing with `context timeout exceeding` this is because the modern builder container is not able to copy the whole Falco build directory from the container to the CircleCI job's VM. The size of the build directory is almost `6 GB`, this huge size causes this context timeout! With this patch, we export only what is really relevant to our integration tests reducing the build directory dimension from `6 GB` to `600 MB`!

This is not the final solution obviously this is just a workaround to mitigate there frequent CI failures we are facing

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
