### PR TITLE
fix(userspace): use the right path for the `cpus_for_each_syscall_buffer` config

### DIFF
--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -311,7 +311,7 @@ void falco_configuration::load_yaml(const std::string& config_name, const yaml_h
 	 */
 	m_syscall_buf_size_preset = config.get_scalar<uint16_t>("syscall_buf_size_preset", 4);
 
-	m_cpus_for_each_syscall_buffer = config.get_scalar<uint16_t>("cpus_for_each_syscall_buffer", 1);
+	m_cpus_for_each_syscall_buffer = config.get_scalar<uint16_t>("modern_bpf.cpus_for_each_syscall_buffer", 1);
 
 	std::set<std::string> load_plugins;
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

In this PR https://github.com/falcosecurity/falco/pull/2363 I introduced a new config for the modern probe. Before the last commit the `cpus_for_each_syscall_buffer` config wasn't under the `modern_bpf:` path, I forgot to adjust the path in the last changes :man_facepalming: 

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
