### PR TITLE
update(systemd): solve some issues with systemd unit

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -31,14 +31,14 @@ configure_file("${PROJECT_SOURCE_DIR}/scripts/systemd/falcoctl-artifact-follow.s
 		"${PROJECT_BINARY_DIR}/scripts/systemd" COPYONLY)
 
 # Debian
-configure_file(debian/postinst.in debian/postinst)
-configure_file(debian/postrm.in debian/postrm)
-configure_file(debian/prerm.in debian/prerm)
+configure_file(debian/postinst.in debian/postinst COPYONLY)
+configure_file(debian/postrm.in debian/postrm COPYONLY)
+configure_file(debian/prerm.in debian/prerm COPYONLY)
 
 # Rpm
-configure_file(rpm/postinstall.in rpm/postinstall)
-configure_file(rpm/postuninstall.in rpm/postuninstall)
-configure_file(rpm/preuninstall.in rpm/preuninstall)
+configure_file(rpm/postinstall.in rpm/postinstall COPYONLY)
+configure_file(rpm/postuninstall.in rpm/postuninstall COPYONLY)
+configure_file(rpm/preuninstall.in rpm/preuninstall COPYONLY)
 
 configure_file(falco-driver-loader falco-driver-loader @ONLY)
 

--- a/scripts/debian/postinst.in
+++ b/scripts/debian/postinst.in
@@ -35,7 +35,7 @@ systemctl --system disable 'falcoctl-artifact-follow.service' || true
 systemctl --system unmask falcoctl-artifact-follow.service || true
 
 if [ "$1" = "configure" ]; then
-        if [ -x /usr/bin/dialog ]; then
+        if [ -x /usr/bin/dialog ] && [ "${FALCO_FRONTEND}" != "noninteractive" ]; then
           # If dialog is installed, create a dialog to let users choose the correct driver for them
           CHOICE=$(dialog --clear --title "Falco drivers" --menu "Choose your preferred driver:" 12 55 4 \
                 1 "Manual configuration (no unit is started)" \

--- a/scripts/rpm/postinstall.in
+++ b/scripts/rpm/postinstall.in
@@ -34,7 +34,7 @@ systemctl --system disable 'falcoctl-artifact-follow.service' || true
 systemctl --system unmask falcoctl-artifact-follow.service || true
 
 if [ $1 -eq 1 ]; then
-        if [ -x /usr/bin/dialog ]; then
+        if [ -x /usr/bin/dialog ] && [ "${FALCO_FRONTEND}" != "noninteractive" ]; then
             # If dialog is installed, create a dialog to let users choose the correct driver for them
             CHOICE=$(dialog --clear --title "Falco drivers" --menu "Choose your preferred driver:" 12 55 4 \
                     1 "Manual configuration (no unit is started)" \

--- a/scripts/systemd/falco-bpf.service
+++ b/scripts/systemd/falco-bpf.service
@@ -3,9 +3,6 @@ Description=Falco: Container Native Runtime Security with ebpf
 Documentation=https://falco.org/docs/
 Before=falcoctl-artifact-follow.service
 Wants=falcoctl-artifact-follow.service
-Conflicts=falco-kmod.service
-Conflicts=falco-modern-bpf.service
-Conflicts=falco-custom.service
 
 [Service]
 Type=simple

--- a/scripts/systemd/falco-custom.service
+++ b/scripts/systemd/falco-custom.service
@@ -3,9 +3,6 @@ Description=Falco: Container Native Runtime Security with custom configuration
 Documentation=https://falco.org/docs/
 Before=falcoctl-artifact-follow.service
 Wants=falcoctl-artifact-follow.service
-Conflicts=falco-kmod.service
-Conflicts=falco-bpf.service
-Conflicts=falco-modern-bpf.service
 
 [Service]
 Type=simple

--- a/scripts/systemd/falco-kmod.service
+++ b/scripts/systemd/falco-kmod.service
@@ -5,9 +5,6 @@ After=falco-kmod-inject.service
 Requires=falco-kmod-inject.service
 Before=falcoctl-artifact-follow.service
 Wants=falcoctl-artifact-follow.service
-Conflicts=falco-bpf.service
-Conflicts=falco-modern-bpf.service
-Conflicts=falco-custom.service
 
 [Service]
 Type=simple

--- a/scripts/systemd/falco-modern-bpf.service
+++ b/scripts/systemd/falco-modern-bpf.service
@@ -3,9 +3,6 @@ Description=Falco: Container Native Runtime Security with modern ebpf
 Documentation=https://falco.org/docs/
 Before=falcoctl-artifact-follow.service
 Wants=falcoctl-artifact-follow.service
-Conflicts=falco-kmod.service
-Conflicts=falco-bpf.service
-Conflicts=falco-custom.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR solves some issues with `systemd` units. 

1. With the actual implementation `systemd restart` and `systemd condrestart` cause:

    ```
    Transaction contains conflicting jobs 'restart' and 'stop' for falcoctl-artifact-follow.service. Probably contradicting requirement dependencies configured.
    ```
    
    This issue is solved by removing the `Conflicts=` directive. The `Conflicts=` directive was here just to protect users from running more than one Falco instance with `systemd`, but since this causes issues we prefer to disable this behavior allowing to use `restart`/`condrestart` commands

2. The PR provides a new environment variable to disable the dialog at installation time `FALCO_FRONTEND`, if you don't want the dialog enabled by default when starting the unit you should use  `FALCO_FRONTEND=noninteractive`. Examples:

    ```
    sudo FALCO_FRONTEND=noninteractive apt install falco 
    sudo FALCO_FRONTEND=noninteractive yum install falco 
    ```


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
