### PR TITLE
fix(scripts): driver loader insmod

### DIFF
--- a/scripts/debian/postinst.in
+++ b/scripts/debian/postinst.in
@@ -75,15 +75,11 @@ set -e
 echo "[POST-INSTALL] Trigger deamon-reload:"
 systemctl --system daemon-reload || true
 
-# If needed, try to load/compile the driver through falco-driver-loader
+# If needed, try to load/compile the driver through falco-driver-loader (only compile for kmod, that uses dkms)
 case "$chosen_driver" in
     "kmod")
-      echo "[POST-INSTALL] Call 'falco-driver-loader module':"
-      falco-driver-loader module
-      ;;
-    "bpf")
-      echo "[POST-INSTALL] Call 'falco-driver-loader bpf':"
-      falco-driver-loader bpf
+      echo "[POST-INSTALL] Call 'falco-driver-loader --compile module':"
+      falco-driver-loader --compile module
       ;;
 esac
 

--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -251,16 +251,10 @@ load_kernel_module_compile() {
 				return
 			fi
 			echo "* ${DRIVER_NAME} module found: ${KO_FILE}"
-			echo "* Trying to modprobe"
+			echo "* Trying to insmod"
 			chcon -t modules_object_t "$KO_FILE" > /dev/null 2>&1 || true
-			if modprobe "${DRIVER_NAME}" > /dev/null 2>&1; then
-				echo "* Success: ${DRIVER_NAME} module found in dkms and loaded"
-				exit 0
-			fi
-			echo "* Unable to load ${DRIVER_NAME} module"
-			echo "* Trying insmod"
 			if insmod "$KO_FILE" > /dev/null 2>&1; then
-				echo "* Success: ${DRIVER_NAME} module found in dkms and inserted"
+				echo "* Success: ${DRIVER_NAME} module found and loaded in dkms"
 				exit 0
 			fi
 			echo "* Unable to insmod ${DRIVER_NAME} module"
@@ -284,14 +278,6 @@ load_kernel_module_download() {
 	if curl -L --create-dirs ${FALCO_DRIVER_CURL_OPTIONS} -o "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" "${URL}"; then
 		echo "* Download succeeded"
 		chcon -t modules_object_t "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" > /dev/null 2>&1 || true
-		mkdir -p /lib/modules/${KERNEL_RELEASE}/kernel/drivers/falco/ || true
-		cp ${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME} /lib/modules/${KERNEL_RELEASE}/kernel/drivers/falco/falco.ko || true
-		depmod ${KERNEL_RELEASE} || true
-		if modprobe "${DRIVER_NAME}" > /dev/null 2>&1; then
-			echo "* Success: ${DRIVER_NAME} module found and loaded"
-			exit 0
-		fi
-		>&2 echo "Unable to load the prebuilt ${DRIVER_NAME} module"
 		if insmod "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}"; then
 			echo "* Success: ${DRIVER_NAME} module found and inserted"
 			exit 0
@@ -410,13 +396,6 @@ load_kernel_module() {
 	if [ -f "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" ]; then
 		echo "* Found a prebuilt ${DRIVER_NAME} module at ${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}, loading it"
 		chcon -t modules_object_t "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" > /dev/null 2>&1 || true
-		mkdir -p /lib/modules/${KERNEL_RELEASE}/kernel/drivers/falco/ || true
-		cp ${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME} /lib/modules/${KERNEL_RELEASE}/kernel/drivers/falco/falco.ko || true
-		depmod ${KERNEL_RELEASE} || true
-		if modprobe "${DRIVER_NAME}" > /dev/null 2>&1; then
-			echo "* Success: ${DRIVER_NAME} module found and loaded"
-			exit 0
-		fi
 		insmod "${HOME}/.falco/${DRIVER_VERSION}/${ARCH}/${FALCO_KERNEL_MODULE_FILENAME}" && echo "* Success: ${DRIVER_NAME} module found and inserted"
 		exit $?
 	fi
@@ -435,7 +414,7 @@ load_kernel_module() {
 	# Last try (might load a previous driver version)
 	echo "* Trying to load a system ${DRIVER_NAME} module, if present"
 	if modprobe "${DRIVER_NAME}" > /dev/null 2>&1; then
-		echo "* Success: ${DRIVER_NAME} module found and loaded"
+		echo "* Success: ${DRIVER_NAME} module found and loaded with modprobe"
 		exit 0
 	fi
 

--- a/scripts/rpm/postinstall.in
+++ b/scripts/rpm/postinstall.in
@@ -74,15 +74,11 @@ set -e
 echo "[POST-INSTALL] Trigger deamon-reload:"
 systemctl --system daemon-reload || true
 
-# If needed, try to load/compile the driver through falco-driver-loader
+# If needed, try to load/compile the driver through falco-driver-loader (only compile for kmod, that uses dkms)
 case "$chosen_driver" in
     "kmod")
-      echo "[POST-INSTALL] Call 'falco-driver-loader module':"
-      falco-driver-loader module
-      ;;
-    "bpf")
-      echo "[POST-INSTALL] Call 'falco-driver-loader bpf':"
-      falco-driver-loader bpf
+      echo "[POST-INSTALL] Call 'falco-driver-loader --compile module':"
+      falco-driver-loader --compile module
       ;;
 esac
 

--- a/scripts/systemd/falco-bpf.service
+++ b/scripts/systemd/falco-bpf.service
@@ -8,6 +8,7 @@ Wants=falcoctl-artifact-follow.service
 Type=simple
 User=root
 Environment=FALCO_BPF_PROBE=
+ExecStartPre=/usr/bin/falco-driver-loader bpf
 ExecStart=/usr/bin/falco --pidfile=/var/run/falco.pid
 UMask=0077
 TimeoutSec=30


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

Reverts 308736280dc70289511111dd094e193639f72cff; we always need to use `insmod` to avoid weird situations (eg: multiple drivers being installed at the same time, and modprobe choosing the oldest one).
Moreover, for package/host installations, enforce the usage of dkms, with `--compile` flag.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
