### PR TITLE
build(cmake)!: deprecate `/etc/falco/rules.available`

### DIFF
--- a/cmake/cpack/debian/conffiles
+++ b/cmake/cpack/debian/conffiles
@@ -1,3 +1,2 @@
 /etc/falco/falco.yaml
-/etc/falco/rules.available/application_rules.yaml
 /etc/falco/falco_rules.local.yaml

--- a/cmake/modules/rules.cmake
+++ b/cmake/modules/rules.cmake
@@ -28,20 +28,6 @@ ExternalProject_Add(
   TEST_COMMAND ""
 )
 
-# application_rules.yaml
-set(FALCOSECURITY_RULES_APPLICATION_VERSION "application-rules-0.1.0")
-set(FALCOSECURITY_RULES_APPLICATION_CHECKSUM "SHA256=cf45c1a6997799610a7724ba7a2ceaa64a3bdc73d26cdfe06adb3f43e2321278")
-set(FALCOSECURITY_RULES_APPLICATION_PATH "${PROJECT_BINARY_DIR}/falcosecurity-rules-application-prefix/src/falcosecurity-rules-application/application_rules.yaml")
-ExternalProject_Add(
-  falcosecurity-rules-application
-  URL "https://download.falco.org/rules/${FALCOSECURITY_RULES_APPLICATION_VERSION}.tar.gz"
-  URL_HASH "${FALCOSECURITY_RULES_APPLICATION_CHECKSUM}"
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND ""
-  INSTALL_COMMAND ""
-  TEST_COMMAND ""
-)
-
 # falco_rules.local.yaml
 set(FALCOSECURITY_RULES_LOCAL_PATH "${PROJECT_BINARY_DIR}/falcosecurity-rules-local-prefix/falco_rules.local.yaml")
 file(WRITE "${FALCOSECURITY_RULES_LOCAL_PATH}" "# Your custom rules!\n")
@@ -53,7 +39,6 @@ endif()
 if(NOT DEFINED FALCO_RULES_DEST_FILENAME)
   set(FALCO_RULES_DEST_FILENAME "falco_rules.yaml")
   set(FALCO_LOCAL_RULES_DEST_FILENAME "falco_rules.local.yaml")
-  set(FALCO_APP_RULES_DEST_FILENAME "application_rules.yaml")
 endif()
 
 if(DEFINED FALCO_COMPONENT) # Allow a slim version of Falco to be embedded in other projects, intentionally *not* installing all rulesets.
@@ -79,12 +64,6 @@ else() # Default Falco installation
     FILES "${FALCOSECURITY_RULES_LOCAL_PATH}"
     DESTINATION "${FALCO_ETC_DIR}"
     RENAME "${FALCO_LOCAL_RULES_DEST_FILENAME}"
-    COMPONENT "${FALCO_COMPONENT_NAME}")
-
-  install(
-    FILES "${FALCOSECURITY_RULES_APPLICATION_PATH}"
-    DESTINATION "${FALCO_ETC_DIR}/rules.available"
-    RENAME "${FALCO_APP_RULES_DEST_FILENAME}"
     COMPONENT "${FALCO_COMPONENT_NAME}")
 
   install(DIRECTORY DESTINATION "${FALCO_ETC_DIR}/rules.d" COMPONENT "${FALCO_COMPONENT_NAME}")

--- a/docker/builder/modern-falco-builder.Dockerfile
+++ b/docker/builder/modern-falco-builder.Dockerfile
@@ -47,7 +47,6 @@ COPY --from=build-stage /build/release/falco-*.rpm /packages/
 # This is just a workaround to fix the CI build until we replace our actual testing framework.
 COPY --from=build-stage /build/release/cloudtrail-plugin-prefix ${DEST_BUILD_DIR}/cloudtrail-plugin-prefix
 COPY --from=build-stage /build/release/cloudtrail-rules-prefix ${DEST_BUILD_DIR}/cloudtrail-rules-prefix
-COPY --from=build-stage /build/release/falcosecurity-rules-application-prefix ${DEST_BUILD_DIR}/falcosecurity-rules-application-prefix
 COPY --from=build-stage /build/release/falcosecurity-rules-falco-prefix ${DEST_BUILD_DIR}/falcosecurity-rules-falco-prefix
 COPY --from=build-stage /build/release/falcosecurity-rules-local-prefix ${DEST_BUILD_DIR}/falcosecurity-rules-local-prefix
 COPY --from=build-stage /build/release/json-plugin-prefix ${DEST_BUILD_DIR}/json-plugin-prefix


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.34.0

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
build: `/etc/falco/rules.available` has been deprecated
build: `application_rules.yaml` is not shipped anymore with Falco
BREAKING CHANGE: if you relied upon `application_rules.yaml` you can download it from https://github.com/falcosecurity/rules/tree/main/rules and manually install it.
```
