### PR TITLE
fix(scripts): use falco-driver-loader only into install scripts

### DIFF
--- a/scripts/debian/postinst.in
+++ b/scripts/debian/postinst.in
@@ -75,11 +75,16 @@ set -e
 echo "[POST-INSTALL] Trigger deamon-reload:"
 systemctl --system daemon-reload || true
 
-# If needed, try to load/compile the driver through falco-driver-loader (only compile for kmod, that uses dkms)
+# If needed, try to load/compile the driver through falco-driver-loader
 case "$chosen_driver" in
     "kmod")
+      # Only compile for kmod, in this way we use dkms
       echo "[POST-INSTALL] Call 'falco-driver-loader --compile module':"
       falco-driver-loader --compile module
+      ;;
+    "bpf")
+      echo "[POST-INSTALL] Call 'falco-driver-loader bpf':"
+      falco-driver-loader bpf
       ;;
 esac
 

--- a/scripts/rpm/postinstall.in
+++ b/scripts/rpm/postinstall.in
@@ -74,11 +74,16 @@ set -e
 echo "[POST-INSTALL] Trigger deamon-reload:"
 systemctl --system daemon-reload || true
 
-# If needed, try to load/compile the driver through falco-driver-loader (only compile for kmod, that uses dkms)
+# If needed, try to load/compile the driver through falco-driver-loader
 case "$chosen_driver" in
     "kmod")
+      # Only compile for kmod, in this way we use dkms
       echo "[POST-INSTALL] Call 'falco-driver-loader --compile module':"
       falco-driver-loader --compile module
+      ;;
+    "bpf")
+      echo "[POST-INSTALL] Call 'falco-driver-loader bpf':"
+      falco-driver-loader bpf
       ;;
 esac
 

--- a/scripts/systemd/falco-bpf.service
+++ b/scripts/systemd/falco-bpf.service
@@ -8,7 +8,6 @@ Wants=falcoctl-artifact-follow.service
 Type=simple
 User=root
 Environment=FALCO_BPF_PROBE=
-ExecStartPre=/usr/bin/falco-driver-loader bpf
 ExecStart=/usr/bin/falco --pidfile=/var/run/falco.pid
 UMask=0077
 TimeoutSec=30


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This PR reverts part of  [7a794b70a71896a3eb1971ca66cc0c19b9a104e6](https://github.com/falcosecurity/falco/commit/d5a7181fe1b7724e00790cb521bff99bde169d56): the falco-driver-loader should be used only in installation scripts otherwise we need separate units with high privileged to download/compile drivers

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
fix(scripts): use falco-driver-loader only into install scripts
```
