### PR TITLE
new(ci): added new workflow to automatic tag and publish new builder and tester images upon changes

### DIFF
--- a/.github/workflows/images_bumper.yml
+++ b/.github/workflows/images_bumper.yml
@@ -1,0 +1,64 @@
+name: Builder and Tester Images Bumper
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      builder_changed: ${{ steps.filter.outputs.builder }}
+      tester_changed: ${{ steps.filter.outputs.tester }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          builder:
+            - 'docker/builder/**'
+          tester:
+            - 'docker/tester/**'
+
+  update-builder-tester-images:
+    runs-on: ubuntu-22.04
+    needs: paths-filter
+    if: needs.paths-filter.outputs.builder_changed == 'true' || needs.paths-filter.outputs.tester_changed == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_SECRET }}
+          
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'amd64,arm64'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
+      - name: Build and push new builder image
+        if: needs.paths-filter.outputs.builder_changed == 'true'
+        uses: docker/build-push-action@v3
+        with:
+          context: docker/builder
+          platforms: linux/amd64,linux/arm64
+          tags: latest
+          push: true
+
+      - name: Build and push new tester image
+        if: needs.paths-filter.outputs.tester_changed == 'true'
+        uses: docker/build-push-action@v3
+        with:
+          context: docker/tester
+          platforms: linux/amd64,linux/arm64
+          tags: latest
+          push: true


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

Builder and Tester images aren't automatically pushed right now; they are manually pushed instead.
This PR  aims at making their build and push automatic upon any change to their docker/X folder.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
