### PR TITLE
fix(userspace/engine): correctly handle evttype indexing corner cases 

### DIFF
--- a/userspace/engine/filter_evttype_resolver.cpp
+++ b/userspace/engine/filter_evttype_resolver.cpp
@@ -17,6 +17,41 @@ limitations under the License.
 #include "filter_evttype_resolver.h"
 #include <sinsp.h>
 
+/**
+ * Given a rule filtering condition (in AST form), the following logic is
+ * responsible of returning the set of event types for which the
+ * filtering condition can be evaluated to true.
+ * 
+ * This implementation is based on the boolean algebric properties of sets 
+ * and works as follows depending on the type of nodes:
+ * - the evt types of "and" nodes are the intersection set of the evt types of
+ *   their children nodes.
+ * - the evt types of "or" nodes are the union set of the evt types of
+ *   their children nodes.
+ * - the evt types of leaf nodes (e.g. "evt.type=open" or "proc.name=cat")
+ *   depend on the type of check:
+ *   * checks based on evt types (e.g. =xxx, != xxx, in (xxx)) give a clear
+ *     definition of the matched event types. The "evt.type exists" check
+ *     matches every evt type.
+ *   * checks non-related to evt types are neutral and match all evt types
+ *     (e.g. proc.name=cat).
+ * 
+ * The tricky part is handling negation (e.g. "not evt.type=open").
+ * Given a set of event types, its negation is the difference between the
+ * "set of all events" and the set (e.g. all types but not the ones in the set).
+ * Reasonably, negation should not affect checks unrelated to evt types (e.g.
+ * "proc.name=cat" is equivalent to "not proc.name=cat" for evt type matching).
+ * The knowledge of whether a set of event types should be negated or not
+ * can't be handled nor propagated in "and" and "or" nodes. Since rules'
+ * conditions are boolean expression, the solution is to use De Morgan's Laws
+ * to push the negation evaluations down to the leaf nodes as follows:
+ * - "not (A and B)" is evaluated as "not A or not B"
+ * - "not (A or B)" is evaluated as "not A and not B"
+ * By happening only on leaf nodes, the set of matching event types can safely
+ * be constructed and negated depending on the different cases.
+ */
+
+
 using namespace libsinsp::filter;
 
 extern sinsp_evttables g_infotables;
@@ -26,7 +61,6 @@ static bool is_evttype_operator(const std::string& op)
 	return op == "==" || op == "=" || op == "!=" || op == "in";
 }
 
-
 size_t falco_event_types::get_ppm_event_max()
 {
 	return PPM_EVENT_MAX;
@@ -34,11 +68,18 @@ size_t falco_event_types::get_ppm_event_max()
 
 void filter_evttype_resolver::visitor::inversion(falco_event_types& types)
 {
-	falco_event_types all_types;
-	evttypes("", all_types);
-	if (types != all_types) // we don't invert the "all types" set
+	// we don't invert "neutral" checks
+	if (m_last_node_has_evttypes)
 	{
-		types = all_types.diff(types);
+		types = m_all_events.diff(types);
+	}
+}
+
+void filter_evttype_resolver::visitor::try_inversion(falco_event_types& types)
+{
+	if (m_inside_negation)
+	{
+		inversion(types);
 	}
 }
 
@@ -71,8 +112,6 @@ void filter_evttype_resolver::evttypes(
 	std::set<uint16_t>& out) const
 {
 	visitor v;
-	v.m_expect_value = false;
-	v.m_last_node_evttypes.clear();
 	filter->accept(&v);
 	v.m_last_node_evttypes.for_each([&out](uint16_t val){out.insert(val); return true;});
 }
@@ -81,35 +120,28 @@ void filter_evttype_resolver::evttypes(
 	std::shared_ptr<ast::expr> filter,
 	std::set<uint16_t>& out) const
 {
-	visitor v;
-	v.m_expect_value = false;
-	v.m_last_node_evttypes.clear();
-	filter.get()->accept(&v);
-	v.m_last_node_evttypes.for_each([&out](uint16_t val){out.insert(val); return true;} );
+	evttypes(filter.get(), out);
 }
 
-// "and" nodes evttypes are the intersection of the evttypes of their children.
-// we initialize the set with "all event types"
-void filter_evttype_resolver::visitor::visit(ast::and_expr* e)
+void filter_evttype_resolver::visitor::conjunction(
+	const std::vector<std::unique_ptr<ast::expr>>& children)
 {
-	falco_event_types types;
-	evttypes("", types);
+	falco_event_types types = m_all_events;
 	m_last_node_evttypes.clear();
-	for (auto &c : e->children)
+	for (auto &c : children)
 	{
-		falco_event_types inters;
 		c->accept(this);
 		types = types.intersect(m_last_node_evttypes);
 	}
 	m_last_node_evttypes = types;
 }
 
-// "or" nodes evttypes are the union of the evttypes their children
-void filter_evttype_resolver::visitor::visit(ast::or_expr* e)
+void filter_evttype_resolver::visitor::disjunction(
+	const std::vector<std::unique_ptr<ast::expr>>& children)
 {
 	falco_event_types types;
 	m_last_node_evttypes.clear();
-	for (auto &c : e->children)
+	for (auto &c : children)
 	{
 		c->accept(this);
 		types.merge(m_last_node_evttypes);
@@ -117,57 +149,105 @@ void filter_evttype_resolver::visitor::visit(ast::or_expr* e)
 	m_last_node_evttypes = types;
 }
 
+void filter_evttype_resolver::visitor::visit(ast::and_expr* e)
+{
+	if (m_inside_negation)
+	{
+		disjunction(e->children);
+	}
+	else
+	{
+		conjunction(e->children);
+	}
+}
+
+void filter_evttype_resolver::visitor::visit(ast::or_expr* e)
+{
+	if (m_inside_negation)
+	{
+		conjunction(e->children);
+	}
+	else
+	{
+		disjunction(e->children);
+	}
+}
+
 void filter_evttype_resolver::visitor::visit(ast::not_expr* e)
 {
 	m_last_node_evttypes.clear();
+	auto inside_negation = m_inside_negation;
+	m_inside_negation = !m_inside_negation;
 	e->child->accept(this);
-	inversion(m_last_node_evttypes);
+	m_inside_negation = inside_negation;
 }
 
 void filter_evttype_resolver::visitor::visit(ast::binary_check_expr* e)
 {
 	m_last_node_evttypes.clear();
+	m_last_node_has_evttypes = false;
 	if (e->field == "evt.type" && is_evttype_operator(e->op))
 	{
+		// note: we expect m_inside_negation and m_last_node_has_evttypes
+		// to be handled and altered by the child node
 		m_expect_value = true;
 		e->value->accept(this);
 		m_expect_value = false;
 		if (e->op == "!=")
 		{
+			// note: since we push the "negation" down to the tree leaves
+			// (following de morgan's laws logic), the child node may have
+			// already inverted the set of matched event type. As such,
+			// inverting here again is safe for supporting both the
+			// single-negation and double-negation cases.
 			inversion(m_last_node_evttypes);
 		}
 		return;
 	}
-	evttypes("", m_last_node_evttypes);
+	m_last_node_evttypes = m_all_events;
+	try_inversion(m_last_node_evttypes);
 }
 
 void filter_evttype_resolver::visitor::visit(ast::unary_check_expr* e)
 {
 	m_last_node_evttypes.clear();
-	evttypes("", m_last_node_evttypes);
+	m_last_node_has_evttypes = e->field == "evt.type" && e->op == "exists";
+	m_last_node_evttypes = m_all_events;
+	try_inversion(m_last_node_evttypes);
 }
 
 void filter_evttype_resolver::visitor::visit(ast::value_expr* e)
 {
 	m_last_node_evttypes.clear();
+	m_last_node_has_evttypes = m_expect_value;
 	if (m_expect_value)
 	{
 		evttypes(e->value, m_last_node_evttypes);
-		return;
 	}
-	evttypes("", m_last_node_evttypes);
+	else
+	{
+		// this case only happens if a macro has not yet been substituted
+		// with an actual condition. Should not happen, but we handle it
+		// for consistency.
+		m_last_node_evttypes = m_all_events;
+	}
+	try_inversion(m_last_node_evttypes);
 }
 
 void filter_evttype_resolver::visitor::visit(ast::list_expr* e)
 {
 	m_last_node_evttypes.clear();
+	m_last_node_has_evttypes = false;
 	if (m_expect_value)
 	{
+		m_last_node_has_evttypes = true;
 		for (auto &v : e->values)
 		{
 			evttypes(v, m_last_node_evttypes);
-		}	
+		}
+		try_inversion(m_last_node_evttypes);
 		return;
 	}
-	evttypes("", m_last_node_evttypes);
+	m_last_node_evttypes = m_all_events;
+	try_inversion(m_last_node_evttypes);
 }

--- a/userspace/engine/filter_evttype_resolver.cpp
+++ b/userspace/engine/filter_evttype_resolver.cpp
@@ -22,7 +22,7 @@ limitations under the License.
  * responsible of returning the set of event types for which the
  * filtering condition can be evaluated to true.
  * 
- * This implementation is based on the boolean algebric properties of sets 
+ * This implementation is based on the boolean algebraic properties of sets 
  * and works as follows depending on the type of nodes:
  * - the evt types of "and" nodes are the intersection set of the evt types of
  *   their children nodes.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Thanks to @incertum findings we discovered that the current event type resolver had some uncovered corner cases (see: https://github.com/falcosecurity/libs/pull/854#issuecomment-1411151732). This mostly involved cases where rules conditions have an `evt.type` combined with `not` negation, so it should not be a big deal, however fixing it is crucial for the correctness and predictability of rules' indexing.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/engine): correctly handle evttype indexing corner cases 
```
