### PR TITLE
update(userspace): change `modern_bpf.cpus_for_each_syscall_buffer` default value

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -232,16 +232,16 @@ syscall_buf_size_preset: 4
 # `cpus_for_each_syscall_buffer`
 #
 # --- [Description]
-# 
+#
 # This is an index that controls how many CPUs you want to assign to a single
-# syscall buffer (ring buffer). By default every CPU has its syscall buffer, 
-# so the mapping is 1:1. The modern BPF probe allows you to choose a different 
-# mapping, for example, 2:1 would mean a syscall buffer every 2 CPUs
+# syscall buffer (ring buffer). By default, every syscall buffer is associated to
+# 2 CPUs, so the mapping is 1:2. The modern BPF probe allows you to choose different
+# mappings, for example, 1:1 would mean a syscall buffer for each CPU.
 #
 # --- [Usage]
 #
 # You can choose between different indexes: from `0` to `MAX_NUMBER_ONLINE_CPUs`.
-# `0` is a special value and it means a single syscall buffer shared between all 
+# `0` is a special value and it means a single syscall buffer shared between all
 # your online CPUs. `0` has the same effect as `MAX_NUMBER_ONLINE_CPUs`, the rationale
 # is that `0` allows you to create a single buffer without knowing the number of online
 # CPUs on your system.
@@ -249,17 +249,17 @@ syscall_buf_size_preset: 4
 #
 # Consider a system with 7 online CPUs:
 #
-#          CPUs     0  X  2  3  X  X  6  7  8  9   (X means offline CPU) 
+#          CPUs     0  X  2  3  X  X  6  7  8  9   (X means offline CPU)
 #
-# - `1` (Default value) means a syscall buffer for each CPU so 7 buffers
+# - `1` means a syscall buffer for each CPU so 7 buffers
 #
-#          CPUs     0  X  2  3  X  X  6  7  8  9   (X means offline CPU) 
+#          CPUs     0  X  2  3  X  X  6  7  8  9   (X means offline CPU)
 #                   |     |  |        |  |  |  |
 #       BUFFERs     0     1  2        3  4  5  6
-# 
-# - `2` means a syscall buffer for each CPU pair, so 4 buffers
 #
-#          CPUs     0  X  2  3  X  X  6  7  8  9   (X means offline CPU) 
+# - `2` (Default value) means a syscall buffer for each CPU pair, so 4 buffers
+#
+#          CPUs     0  X  2  3  X  X  6  7  8  9   (X means offline CPU)
 #                   |     |  |        |  |  |  |
 #       BUFFERs     0     0  1        1  2  2  3
 #
@@ -268,28 +268,28 @@ syscall_buf_size_preset: 4
 #
 # - `0` or `MAX_NUMBER_ONLINE_CPUs` mean a syscall buffer shared between all CPUs, so 1 buffer
 #
-#          CPUs     0  X  2  3  X  X  6  7  8  9   (X means offline CPU) 
+#          CPUs     0  X  2  3  X  X  6  7  8  9   (X means offline CPU)
 #                   |     |  |        |  |  |  |
 #       BUFFERs     0     0  0        0  0  0  0
 #
 # Moreover you can combine this param with `syscall_buf_size_preset`
 # index, for example, you could create a huge single syscall buffer
-# shared between all your online CPUs of 512 MB (so `syscall_buf_size_preset=10`). 
+# shared between all your online CPUs of 512 MB (so `syscall_buf_size_preset=10`).
 #
 # --- [Suggestions]
 #
-# We chose index `1` (so one syscall buffer for each CPU) as default to keep parity
-# between our drivers (bpf and kernel module). By the way, you are free to find the preferred
-# configuration for your system. Considering a fixed `syscall_buf_size_preset` and so
-# a fixed buffer dimension:
+# We chose index `2` (so one syscall buffer for each CPU pair) as default because the modern bpf probe
+# follows a different memory allocation strategy with respect to the other 2 drivers (bpf and kernel module).
+# By the way, you are free to find the preferred configuration for your system.
+# Considering a fixed `syscall_buf_size_preset` and so a fixed buffer dimension:
 # - a lower number of buffers can speed up your system (lower memory footprint)
 # - a too lower number of buffers could increase contention in the kernel causing an
 #   overall slowdown of the system.
-# If you don't have huge events throughtputs and you are not experimenting with tons of drops
+# If you don't have huge events throughputs and you are not experimenting with tons of drops
 # you can try to reduce the number of buffers to have a lower memory footprint
 
 modern_bpf:
-  cpus_for_each_syscall_buffer: 1
+  cpus_for_each_syscall_buffer: 2
 ############## [EXPERIMENTAL] Modern BPF probe specific ##############
 
 # Falco continuously monitors outputs performance. When an output channel does not allow

--- a/userspace/falco/app_actions/load_rules_files.cpp
+++ b/userspace/falco/app_actions/load_rules_files.cpp
@@ -172,6 +172,14 @@ application::run_result application::load_rules_files()
 		check_for_ignored_events();
 	}
 
+	if(m_options.all_events && m_options.modern_bpf)
+	{
+		/* Right now the modern BPF probe doesn't support the -A flag, we implemented just 
+		 * the "simple set" syscalls.
+		 */
+		falco_logger::log(LOG_INFO, "The '-A' flag has no effect with the modern BPF probe, no further syscalls will be added\n");
+	}
+
 	if (m_options.describe_all_rules)
 	{
 		m_state->engine->describe_rule(NULL);

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -57,7 +57,7 @@ falco_configuration::falco_configuration():
 	m_metadata_download_chunk_wait_us(1000),
 	m_metadata_download_watch_freq_sec(1),
 	m_syscall_buf_size_preset(4),
-	m_cpus_for_each_syscall_buffer(1)
+	m_cpus_for_each_syscall_buffer(2)
 {
 }
 
@@ -311,7 +311,7 @@ void falco_configuration::load_yaml(const std::string& config_name, const yaml_h
 	 */
 	m_syscall_buf_size_preset = config.get_scalar<uint16_t>("syscall_buf_size_preset", 4);
 
-	m_cpus_for_each_syscall_buffer = config.get_scalar<uint16_t>("modern_bpf.cpus_for_each_syscall_buffer", 1);
+	m_cpus_for_each_syscall_buffer = config.get_scalar<uint16_t>("modern_bpf.cpus_for_each_syscall_buffer", 2);
 
 	std::set<std::string> load_plugins;
 


### PR DESCRIPTION
**What type of PR is this?**

/kind design

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR changes the `cpus_for_each_syscall_buffer` default value to `2`. In this way, the memory footprint of the modern bpf should be comparable with the other 2 drivers. See the thread here for more info :point_down: 
 https://lore.kernel.org/bpf/CAEf4BzbYoGY2e_Nf1EOgzDdjGOLbSjJ5OmHRDFnYUA_VDYD6zQ@mail.gmail.com/T/#mdf8c6015b18a49edc95e4e7a8e4f7fcaf304cfc4

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace): change `modern_bpf.cpus_for_each_syscall_buffer` default value
```
