### PR TITLE
cleanup(userspace/falco): do not enter dropping mode.

### DIFF
--- a/userspace/falco/app_actions/open_inspector.cpp
+++ b/userspace/falco/app_actions/open_inspector.cpp
@@ -123,11 +123,5 @@ application::run_result application::open_live_inspector(
 		return run_result::fatal(e.what());
 	}
 
-	// This must be done after the open
-	if (!m_options.all_events)
-	{
-		inspector->start_dropping_mode(1);
-	}
-
 	return run_result::ok();
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

When not run in `-A` mode, Falco will start dropping mode.
Dropping mode enables following logic in drivers:
* parameter passed to `start_dropping_mode` is the "sampling_ratio", ie: how much a second is "sampled"; if you pass `1` (what we are doing in Falco), you are saying that you want each second to be fully sampled; if you pass `2`, it means you want to sample each 0.5s, and so on.
* So, Falco is passing `1` basically disabling the sampling logic (that can be found here: https://github.com/falcosecurity/libs/blob/master/driver/main.c#L1695)
* instead, it is just enabling the dropping logic: https://github.com/falcosecurity/libs/blob/master/driver/main.c#L1677
* what it does is: drop all `UF_ALWAYS_DROP` events + drop some more events, by using following logic: https://github.com/falcosecurity/libs/blob/master/driver/main.c#L1607

Considering that nowadays all `UF_ALWAYS_DROP` events are already dropped by syscalls of interest when not in `-A` mode (and we are looking to expand current behavior with adaptive syscalls), and that the `drop_nostate_event` dropping logic should not have a big impact on perf, i think we can entirely skip all this (weird) logic altogether.
Note, moreover, that the `drop_nostate_event` logic could possibly be fully superseeded by https://github.com/falcosecurity/libs/pull/834 (that would of course be a opt-in feature).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
