### PR TITLE
update(unit_tests): add first action tests for select_event_sources

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -59,5 +59,5 @@ message(STATUS "FALCO_UNIT_TESTS_LIBRARIES: ${FALCO_UNIT_TESTS_LIBRARIES}")
 
 add_executable(falco_unit_tests ${FALCO_UNIT_TESTS_SOURCES})
 target_include_directories(falco_unit_tests ${FALCO_UNIT_TESTS_INCLUDES})
-target_link_libraries(falco_unit_tests ${FALCO_UNIT_TESTS_DEPENDENCIES})
-add_dependencies(falco_unit_tests ${FALCO_UNIT_TESTS_LIBRARIES})
+target_link_libraries(falco_unit_tests ${FALCO_UNIT_TESTS_LIBRARIES})
+add_dependencies(falco_unit_tests ${FALCO_UNIT_TESTS_DEPENDENCIES})

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -41,15 +41,16 @@ set(FALCO_UNIT_TESTS_INCLUDES
 set(FALCO_UNIT_TESTS_DEPENDENCIES
   gtest
   gtest_main
-  falco_engine
-  sinsp
+  falco_application
 )
+
+get_target_property(FALCO_APPLICATION_LIBRARIES falco_application LINK_LIBRARIES)
 
 set(FALCO_UNIT_TESTS_LIBRARIES
   gtest
   gtest_main
-  falco_engine
-  sinsp
+  falco_application
+  ${FALCO_APPLICATION_LIBRARIES}
 )
 
 message(STATUS "FALCO_UNIT_TESTS_SOURCES: ${FALCO_UNIT_TESTS_SOURCES}")

--- a/unit_tests/falco/actions/test_select_event_sources.cpp
+++ b/unit_tests/falco/actions/test_select_event_sources.cpp
@@ -1,0 +1,97 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless ASSERTd by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <gtest/gtest.h>
+#include <falco/app/state.h>
+#include <falco/app/actions/actions.h>
+
+#define EXPECT_ACTION_OK(r)     { EXPECT_TRUE(r.success); EXPECT_TRUE(r.proceed); EXPECT_EQ(r.errstr, ""); }
+#define EXPECT_ACTION_FAIL(r)   { EXPECT_FALSE(r.success); EXPECT_FALSE(r.proceed); EXPECT_NE(r.errstr, ""); }
+
+TEST(ActionSelectEventSources, pre_post_conditions)
+{
+    auto action = falco::app::actions::select_event_sources;
+
+    // requires sources to be already loaded
+    {
+        falco::app::state s;
+        EXPECT_ACTION_FAIL(action(s));
+    }
+
+    // ignore source selection in capture mode
+    {
+        falco::app::state s;
+        s.options.trace_filename = "some_capture_file.scap";
+        EXPECT_TRUE(s.is_capture_mode());
+        EXPECT_ACTION_OK(action(s));
+    }
+
+    // enable all loaded sources by default, even with multiple calls
+    {
+        falco::app::state s;
+        s.loaded_sources = {"syscall", "some_source"};
+        EXPECT_ACTION_OK(action(s));
+        EXPECT_EQ(s.loaded_sources, s.enabled_sources);
+        s.loaded_sources.insert("another_source");
+        EXPECT_ACTION_OK(action(s));
+        EXPECT_EQ(s.loaded_sources, s.enabled_sources);
+    }
+
+    // enable only selected sources
+    {
+        falco::app::state s;
+        s.loaded_sources = {"syscall", "some_source"};
+        s.options.enable_sources = {"syscall"};
+        EXPECT_ACTION_OK(action(s));
+        EXPECT_EQ(s.enabled_sources.size(), 1);
+        EXPECT_EQ(*s.enabled_sources.begin(), "syscall");
+    }
+
+    // enable all loaded sources expect the disabled ones
+    {
+        falco::app::state s;
+        s.loaded_sources = {"syscall", "some_source"};
+        s.options.disable_sources = {"syscall"};
+        EXPECT_ACTION_OK(action(s));
+        EXPECT_EQ(s.enabled_sources.size(), 1);
+        EXPECT_EQ(*s.enabled_sources.begin(), "some_source");
+    }
+
+    // enable unknown sources
+    {
+        falco::app::state s;
+        s.loaded_sources = {"syscall", "some_source"};
+        s.options.enable_sources = {"some_other_source"};
+        EXPECT_ACTION_FAIL(action(s));
+    }
+
+    // disable unknown sources
+    {
+        falco::app::state s;
+        s.loaded_sources = {"syscall", "some_source"};
+        s.options.disable_sources = {"some_other_source"};
+        EXPECT_ACTION_FAIL(action(s));
+    }
+
+    // mix enable and disable sources options
+    {
+        falco::app::state s;
+        s.loaded_sources = {"syscall", "some_source"};
+        s.options.disable_sources = {"syscall"};
+        s.options.enable_sources = {"syscall"};
+        EXPECT_ACTION_FAIL(action(s));
+    }
+}

--- a/userspace/falco/CMakeLists.txt
+++ b/userspace/falco/CMakeLists.txt
@@ -57,7 +57,6 @@ set(
   event_drops.cpp
   stats_writer.cpp
   versions_info.cpp
-  falco.cpp
 )
 
 set(
@@ -138,23 +137,28 @@ if(NOT MINIMAL_BUILD)
   )
 endif()
 
-add_executable(
-  falco
+add_library(
+  falco_application STATIC
   ${FALCO_SOURCES}
 )
 
-add_dependencies(falco ${FALCO_DEPENDENCIES})
+add_dependencies(falco_application ${FALCO_DEPENDENCIES})
 
 target_link_libraries(
-  falco
+  falco_application
   ${FALCO_LIBRARIES}
 )
 
 target_include_directories(
-  falco
+  falco_application
   PUBLIC
   ${FALCO_INCLUDE_DIRECTORIES}
 )
+
+add_executable(falco falco.cpp)
+add_dependencies(falco falco_application ${FALCO_DEPENDENCIES})
+target_link_libraries(falco falco_application ${FALCO_LIBRARIES})
+target_include_directories(falco PUBLIC ${FALCO_INCLUDE_DIRECTORIES})
 
 if(NOT MINIMAL_BUILD)
   add_custom_command(


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

/area tests

**What this PR does / why we need it**:

Following the effort of https://github.com/falcosecurity/falco/pull/2414, this PR adds a first suite of unit tests for Falco app's action `select_event_sources` (a low-hanging fruit compared to the others).

To do so, the CMake setup has been changed a bit due to the need of the gtest binary to be linked with the source code under userspace/falco (it was not so far, thus making all that code practically untestable if not header-only). The changes involve creating an intermediate `falco_application` static library target, which is then linked to the unit test binary and to the `falco` executable (which also compiles the falco.cpp main entrypoint).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
