### PR TITLE
update(cmake): bump libs and driver to 6ca2fc1fa9a9f5482dc92468a0a6e3404ae46723

### DIFF
--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -26,8 +26,8 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "652d6d134d5c2b355467de5be922135e53053412")
-    set(DRIVER_CHECKSUM "SHA256=6bd1825f5eca7235bd962613ec407c38e7e550fb115029551e97a61cf6ba17e4")
+    set(DRIVER_VERSION "6ca2fc1fa9a9f5482dc92468a0a6e3404ae46723")
+    set(DRIVER_CHECKSUM "SHA256=4d390bdde2c061491cb73d5703a2e0db7bd681a4738b4a9e50252fff3628dd29")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -27,8 +27,8 @@ else()
   # In case you want to test against another falcosecurity/libs version (or branch, or commit) just pass the variable -
   # ie., `cmake -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "652d6d134d5c2b355467de5be922135e53053412")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=6bd1825f5eca7235bd962613ec407c38e7e550fb115029551e97a61cf6ba17e4")
+    set(FALCOSECURITY_LIBS_VERSION "6ca2fc1fa9a9f5482dc92468a0a6e3404ae46723")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=4d390bdde2c061491cb73d5703a2e0db7bd681a4738b4a9e50252fff3628dd29")
   endif()
 
   # cd /path/to/build && cmake /path/to/source


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This bumps the libs and driver version to pull-in the changes of https://github.com/falcosecurity/libs/pull/957.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(cmake): bump libs and driver to 6ca2fc1fa9a9f5482dc92468a0a6e3404ae46723
```
