### PR TITLE
new: driver drop failed

### DIFF
--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -26,8 +26,8 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "c8b0d6a8fdc1bb3ea9067bc2fdc3ae5858cff48f")
-    set(DRIVER_CHECKSUM "SHA256=e1b408896d700d50909feec5f28a6e761995bf367a60ce8d0a9365149e822145")
+    set(DRIVER_VERSION "e006bf38219d392cd5aeb3c1109e4bdaa9ef1617")
+    set(DRIVER_CHECKSUM "SHA256=185963f6d658e8963f218ec1d45056b7f6e391d05244f6499aec74807d2190fb")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -26,8 +26,8 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "6c11056815b9eff787c69f9b2188a2ae503533c9")
-    set(DRIVER_CHECKSUM "SHA256=e0d671e09993c5f402054aab70858af5fe372eec201d4e1744c0a01d2959b750")
+    set(DRIVER_VERSION "c8b0d6a8fdc1bb3ea9067bc2fdc3ae5858cff48f")
+    set(DRIVER_CHECKSUM "SHA256=e1b408896d700d50909feec5f28a6e761995bf367a60ce8d0a9365149e822145")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -27,8 +27,8 @@ else()
   # In case you want to test against another falcosecurity/libs version (or branch, or commit) just pass the variable -
   # ie., `cmake -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "6c11056815b9eff787c69f9b2188a2ae503533c9")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=e0d671e09993c5f402054aab70858af5fe372eec201d4e1744c0a01d2959b750")
+    set(FALCOSECURITY_LIBS_VERSION "c8b0d6a8fdc1bb3ea9067bc2fdc3ae5858cff48f")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=e1b408896d700d50909feec5f28a6e761995bf367a60ce8d0a9365149e822145")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -27,8 +27,8 @@ else()
   # In case you want to test against another falcosecurity/libs version (or branch, or commit) just pass the variable -
   # ie., `cmake -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "c8b0d6a8fdc1bb3ea9067bc2fdc3ae5858cff48f")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=e1b408896d700d50909feec5f28a6e761995bf367a60ce8d0a9365149e822145")
+    set(FALCOSECURITY_LIBS_VERSION "e006bf38219d392cd5aeb3c1109e4bdaa9ef1617")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=185963f6d658e8963f218ec1d45056b7f6e391d05244f6499aec74807d2190fb")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/falco.yaml
+++ b/falco.yaml
@@ -170,6 +170,10 @@ syscall_event_drops:
 syscall_event_timeouts:
   max_consecutives: 1000
 
+# Enabling this option allows Falco to drop failed syscalls exit events.
+# This can enable some small optimization both in CPU usage and ring buffer usage,
+# possibly leading to lower number of event losses.
+# Be careful: enabling it also means losing a bit of visibility on the system.
 syscall_drop_failed: false
 
 # --- [Description]

--- a/falco.yaml
+++ b/falco.yaml
@@ -170,7 +170,8 @@ syscall_event_drops:
 syscall_event_timeouts:
   max_consecutives: 1000
 
-# Enabling this option allows Falco to drop failed syscalls exit events.
+# Enabling this option allows Falco to drop failed syscalls exit events
+# in the kernel driver before the event is pushed onto the ring buffer.
 # This can enable some small optimization both in CPU usage and ring buffer usage,
 # possibly leading to lower number of event losses.
 # Be careful: enabling it also means losing a bit of visibility on the system.

--- a/falco.yaml
+++ b/falco.yaml
@@ -175,7 +175,7 @@ syscall_event_timeouts:
 # This can enable some small optimization both in CPU usage and ring buffer usage,
 # possibly leading to lower number of event losses.
 # Be careful: enabling it also means losing a bit of visibility on the system.
-syscall_drop_failed: false
+syscall_drop_failed_exit: false
 
 # --- [Description]
 #

--- a/falco.yaml
+++ b/falco.yaml
@@ -170,6 +170,8 @@ syscall_event_drops:
 syscall_event_timeouts:
   max_consecutives: 1000
 
+syscall_drop_failed: false
+
 # --- [Description]
 #
 # This is an index that controls the dimension of the syscall buffers.

--- a/userspace/falco/app/actions/helpers_inspector.cpp
+++ b/userspace/falco/app/actions/helpers_inspector.cpp
@@ -127,7 +127,7 @@ falco::app::run_result falco::app::actions::open_live_inspector(
 
 	if (s.config->m_syscall_drop_failed)
 	{
-		falco_logger::log(LOG_DEBUG, "Failed syscalls exit event will be dropped.\n");
+		falco_logger::log(LOG_DEBUG, "Failed syscall exit events are dropped in the kernel driver\n");
 		inspector->set_dropfailed(true);
 	}
 	return run_result::ok();

--- a/userspace/falco/app/actions/helpers_inspector.cpp
+++ b/userspace/falco/app/actions/helpers_inspector.cpp
@@ -125,10 +125,5 @@ falco::app::run_result falco::app::actions::open_live_inspector(
 		return run_result::fatal(e.what());
 	}
 
-	if (s.config->m_syscall_drop_failed_exit)
-	{
-		falco_logger::log(LOG_DEBUG, "Failed syscall exit events are dropped in the kernel driver\n");
-		inspector->set_dropfailed(true);
-	}
 	return run_result::ok();
 }

--- a/userspace/falco/app/actions/helpers_inspector.cpp
+++ b/userspace/falco/app/actions/helpers_inspector.cpp
@@ -125,7 +125,7 @@ falco::app::run_result falco::app::actions::open_live_inspector(
 		return run_result::fatal(e.what());
 	}
 
-	if (s.config->m_syscall_drop_failed)
+	if (s.config->m_syscall_drop_failed_exit)
 	{
 		falco_logger::log(LOG_DEBUG, "Failed syscall exit events are dropped in the kernel driver\n");
 		inspector->set_dropfailed(true);

--- a/userspace/falco/app/actions/helpers_inspector.cpp
+++ b/userspace/falco/app/actions/helpers_inspector.cpp
@@ -125,5 +125,10 @@ falco::app::run_result falco::app::actions::open_live_inspector(
 		return run_result::fatal(e.what());
 	}
 
+	if (s.config->m_syscall_drop_failed)
+	{
+		falco_logger::log(LOG_DEBUG, "Failed syscalls exit event will be dropped.\n");
+		inspector->set_dropfailed(true);
+	}
 	return run_result::ok();
 }

--- a/userspace/falco/app/actions/init_inspectors.cpp
+++ b/userspace/falco/app/actions/init_inspectors.cpp
@@ -48,6 +48,12 @@ static void init_syscall_inspector(falco::app::state& s, std::shared_ptr<sinsp> 
 		inspector->set_snaplen(s.options.snaplen);
 	}
 
+	if (s.config->m_syscall_drop_failed_exit)
+	{
+		falco_logger::log(LOG_INFO, "Failed syscall exit events are dropped in the kernel driver\n");
+		inspector->set_dropfailed(true);
+	}
+
 	inspector->set_hostname_and_port_resolution_mode(false);
 }
 

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -57,7 +57,8 @@ falco_configuration::falco_configuration():
 	m_metadata_download_chunk_wait_us(1000),
 	m_metadata_download_watch_freq_sec(1),
 	m_syscall_buf_size_preset(4),
-	m_cpus_for_each_syscall_buffer(2)
+	m_cpus_for_each_syscall_buffer(2),
+	m_syscall_drop_failed(false)
 {
 }
 
@@ -312,6 +313,8 @@ void falco_configuration::load_yaml(const std::string& config_name, const yaml_h
 	m_syscall_buf_size_preset = config.get_scalar<uint16_t>("syscall_buf_size_preset", 4);
 
 	m_cpus_for_each_syscall_buffer = config.get_scalar<uint16_t>("modern_bpf.cpus_for_each_syscall_buffer", 2);
+
+	m_syscall_drop_failed = config.get_scalar<bool>("syscall_drop_failed", false);
 
 	m_base_syscalls.clear();
 	config.get_sequence<std::unordered_set<std::string>>(m_base_syscalls, std::string("base_syscalls"));

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -58,7 +58,7 @@ falco_configuration::falco_configuration():
 	m_metadata_download_watch_freq_sec(1),
 	m_syscall_buf_size_preset(4),
 	m_cpus_for_each_syscall_buffer(2),
-	m_syscall_drop_failed(false)
+	m_syscall_drop_failed_exit(false)
 {
 }
 
@@ -314,7 +314,7 @@ void falco_configuration::load_yaml(const std::string& config_name, const yaml_h
 
 	m_cpus_for_each_syscall_buffer = config.get_scalar<uint16_t>("modern_bpf.cpus_for_each_syscall_buffer", 2);
 
-	m_syscall_drop_failed = config.get_scalar<bool>("syscall_drop_failed", false);
+	m_syscall_drop_failed_exit = config.get_scalar<bool>("syscall_drop_failed_exit", false);
 
 	m_base_syscalls.clear();
 	config.get_sequence<std::unordered_set<std::string>>(m_base_syscalls, std::string("base_syscalls"));

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -106,7 +106,7 @@ public:
 	// Number of CPUs associated with a single ring buffer.
 	uint16_t m_cpus_for_each_syscall_buffer;
 
-	bool m_syscall_drop_failed;
+	bool m_syscall_drop_failed_exit;
 
 	// User supplied base_syscalls, overrides any Falco state engine enforcement.
 	std::unordered_set<std::string> m_base_syscalls;

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -106,6 +106,8 @@ public:
 	// Number of CPUs associated with a single ring buffer.
 	uint16_t m_cpus_for_each_syscall_buffer;
 
+	bool m_syscall_drop_failed;
+
 	// User supplied base_syscalls, overrides any Falco state engine enforcement.
 	std::unordered_set<std::string> m_base_syscalls;
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR bumps libs to latest master (https://github.com/falcosecurity/libs/commit/c8b0d6a8fdc1bb3ea9067bc2fdc3ae5858cff48f).
Moreover, it introduces a new `syscall_drop_failed` config option to instrument drivers to drop failed syscalls exit events, exposing the new feature impl by https://github.com/falcosecurity/libs/pull/834.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
new(cmake): bumped libs to c8b0d6a8fdc1bb3ea9067bc2fdc3ae5858cff48f
new(userspace): add a new `syscall_drop_failed` config option to drop failed syscalls exit events
```
