### PR TITLE
new(falco/config): add new configurations for http_output

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -408,6 +408,15 @@ http_output:
   enabled: false
   url: http://some.url
   user_agent: "falcosecurity/falco"
+  # Tell Falco to not verify the remote server.
+  insecure: false
+  # Path to the CA certificate that can verify the remote server. 
+  ca_cert: ""
+  # Path to a specific file that will be used as the CA certificate store.
+  ca_bundle: ""
+  # Path to a folder that will be used as the CA certificate store. CA certificate need to be
+  # stored as indivitual PEM files in this directory.
+  ca_path: "/etc/ssl/certs"
 
 # Falco supports running a gRPC server with two main binding types
 # 1. Over the network with mandatory mutual TLS authentication (mTLS)

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -178,6 +178,22 @@ void falco_configuration::load_yaml(const std::string& config_name, const yaml_h
 		user_agent = config.get_scalar<std::string>("http_output.user_agent","falcosecurity/falco");
 		http_output.options["user_agent"] = user_agent;
 
+		bool insecure;
+		insecure = config.get_scalar<bool>("http_output.insecure", false);
+		http_output.options["insecure"] = insecure? std::string("true") : std::string("false");
+		
+		std::string ca_cert;
+		ca_cert = config.get_scalar<std::string>("http_output.ca_cert", "");
+		http_output.options["ca_cert"] = ca_cert;
+
+		std::string ca_bundle;
+		ca_bundle = config.get_scalar<std::string>("http_output.ca_bundle", "");
+		http_output.options["ca_bundle"] = ca_bundle;
+
+		std::string ca_path;
+		ca_path = config.get_scalar<std::string>("http_output.ca_path", "/etc/ssl/certs");
+		http_output.options["ca_path"] = ca_path;
+
 		m_outputs.push_back(http_output);
 	}
 

--- a/userspace/falco/outputs_http.cpp
+++ b/userspace/falco/outputs_http.cpp
@@ -34,15 +34,58 @@ void falco::outputs::output_http::output(const message *msg)
 		} else {
 			slist1 = curl_slist_append(slist1, "Content-Type: text/plain");
 		}
+		res = curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist1);
 
-		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist1);
-		curl_easy_setopt(curl, CURLOPT_URL, m_oc.options["url"].c_str());
-		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, msg->msg.c_str());
-		curl_easy_setopt(curl, CURLOPT_USERAGENT, m_oc.options["user_agent"].c_str());
-		curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, -1L);
+		if(res == CURLE_OK)
+		{
+			res = curl_easy_setopt(curl, CURLOPT_URL, m_oc.options["url"].c_str());
+		}
+		
+		if(res == CURLE_OK)
+		{
+			res = curl_easy_setopt(curl, CURLOPT_POSTFIELDS, msg->msg.c_str());
+		}
 
+		if(res == CURLE_OK)
+		{
+			res = curl_easy_setopt(curl, CURLOPT_USERAGENT, m_oc.options["user_agent"].c_str());
+		}
 
-		res = curl_easy_perform(curl);
+		if(res == CURLE_OK)
+		{
+		   res = curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, -1L);
+		}
+		
+		if(res == CURLE_OK)
+		{
+			if(m_oc.options["insecure"] == std::string("true"))
+			{
+				res = curl_easy_setopt(curl,CURLOPT_SSL_VERIFYPEER, 0L);
+
+				if(res == CURLE_OK)
+				{
+					res = curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+				}
+			}
+		}
+
+		if(res == CURLE_OK)
+		{
+			if (!m_oc.options["ca_cert"].empty())
+			{
+				res = curl_easy_setopt(curl, CURLOPT_CAINFO, m_oc.options["ca_cert"].c_str());
+			}else if(!m_oc.options["ca_bundle"].empty())
+			{
+				res = curl_easy_setopt(curl, CURLOPT_CAINFO, m_oc.options["ca_bundle"].c_str());
+			}else{
+				res = curl_easy_setopt(curl, CURLOPT_CAPATH, m_oc.options["ca_path"].c_str());
+			}
+		}
+		
+  		if(res == CURLE_OK)
+		{
+			res = curl_easy_perform(curl);
+		}
 
 		if(res != CURLE_OK)
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Falco now accepts user-provided Certificates and CA certificate stores that are used to verify the remote server to which the `http_output` is sent.

Four new config fields are available under the `http_output` section in **falco.yaml** configuration file:
```yaml
 # Tell Falco to not verify the remote server.
insecure: false
# Path to the CA certificate that can verify the remote server. 
ca_cert: ""
# Path to a specific file that will be used as the CA certificate store.
ca_bundle: ""
# Path to a folder that will be used as the CA certificate store. CA certificate need to be
# stored as indivitual PEM files in this directory.
ca_path: "/etc/ssl/certs"
```

Furthermore, this PR decouples Falco as a consumer of the `libcurl` from the libs. Making the certificate paths configurable at startup time allows Falco to support `https` endpoints in every scenario as far as a valid certificate is provided for the remote server. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2274
Fixes #2448 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
new(falco/config): add new configurations for http_output that allow custom CA certificates and stores.
```
