### PR TITLE
cleanup(unit_tests): try making test_configure_interesting_sets more robust

### DIFF
--- a/unit_tests/falco/app/actions/test_configure_interesting_sets.cpp
+++ b/unit_tests/falco/app/actions/test_configure_interesting_sets.cpp
@@ -91,6 +91,7 @@ static std::shared_ptr<falco_engine> mock_engine_from_filters(const strset_t& fi
 
 TEST(ConfigureInterestingSets, engine_codes_syscalls_set)
 {
+
 	auto engine = mock_engine_from_filters(s_sample_filters);
 	auto enabled_count = engine->num_rules_for_ruleset(s_sample_ruleset);
 	ASSERT_EQ(enabled_count, s_sample_filters.size());
@@ -112,32 +113,32 @@ TEST(ConfigureInterestingSets, engine_codes_syscalls_set)
 
 TEST(ConfigureInterestingSets, preconditions_postconditions)
 {
-	falco::app::state s;
 	auto mock_engine = mock_engine_from_filters(s_sample_filters);
+	falco::app::state s1;
 
-	s.engine = mock_engine;
-	s.config = nullptr;
-	auto result = falco::app::actions::configure_interesting_sets(s);
+	s1.engine = mock_engine;
+	s1.config = nullptr;
+	auto result = falco::app::actions::configure_interesting_sets(s1);
 	ASSERT_FALSE(result.success);
 	ASSERT_NE(result.errstr, "");
 
-	s.engine = nullptr;
-	s.config = std::make_shared<falco_configuration>();
-	result = falco::app::actions::configure_interesting_sets(s);
+	s1.engine = nullptr;
+	s1.config = std::make_shared<falco_configuration>();
+	result = falco::app::actions::configure_interesting_sets(s1);
 	ASSERT_FALSE(result.success);
 	ASSERT_NE(result.errstr, "");
 
-	s.engine = mock_engine;
-	s.config = std::make_shared<falco_configuration>();
-	result = falco::app::actions::configure_interesting_sets(s);
+	s1.engine = mock_engine;
+	s1.config = std::make_shared<falco_configuration>();
+	result = falco::app::actions::configure_interesting_sets(s1);
 	ASSERT_TRUE(result.success);
 	ASSERT_EQ(result.errstr, "");
 
-	auto prev_selection_size = s.selected_sc_set.size();
-	result = falco::app::actions::configure_interesting_sets(s);
+	auto prev_selection_size = s1.selected_sc_set.size();
+	result = falco::app::actions::configure_interesting_sets(s1);
 	ASSERT_TRUE(result.success);
 	ASSERT_EQ(result.errstr, "");
-	ASSERT_EQ(prev_selection_size, s.selected_sc_set.size());
+	ASSERT_EQ(prev_selection_size, s1.selected_sc_set.size());
 }
 
 TEST(ConfigureInterestingSets, engine_codes_nonsyscalls_set)
@@ -173,11 +174,13 @@ TEST(ConfigureInterestingSets, engine_codes_nonsyscalls_set)
 
 TEST(ConfigureInterestingSets, selection_not_allevents)
 {
+	falco::app::state s2;
 	// run app action with fake engine and without the `-A` option
-	falco::app::state s;
-	s.engine = mock_engine_from_filters(s_sample_filters);
-	s.options.all_events = false;
-	auto result = falco::app::actions::configure_interesting_sets(s);
+	s2.engine = mock_engine_from_filters(s_sample_filters);
+	s2.options.all_events = false;
+
+	ASSERT_EQ(s2.options.all_events, false);
+	auto result = falco::app::actions::configure_interesting_sets(s2);
 	ASSERT_TRUE(result.success);
 	ASSERT_EQ(result.errstr, "");
 
@@ -185,8 +188,8 @@ TEST(ConfigureInterestingSets, selection_not_allevents)
 	// also check if a warning has been printed in stderr
 
 	// check that the final selected set is the one expected
-	ASSERT_GT(s.selected_sc_set.size(), 1);
-	auto selected_sc_names = libsinsp::events::sc_set_to_names(s.selected_sc_set);
+	ASSERT_GT(s2.selected_sc_set.size(), 1);
+	auto selected_sc_names = libsinsp::events::sc_set_to_names(s2.selected_sc_set);
 	auto expected_sc_names = strset_t({
 		// note: we expect the "read" syscall to have been erased
 		"connect", "accept", "accept4", "umount2", "open", "ptrace", "mmap", "execve", // from ruleset
@@ -201,7 +204,7 @@ TEST(ConfigureInterestingSets, selection_not_allevents)
 	ASSERT_NAMES_NOCONTAIN(selected_sc_names, erased_sc_names);
 
 	// check that final selected set is exactly sinsp state + ruleset
-	auto rule_set = s.engine->sc_codes_for_ruleset(s_sample_source, s_sample_ruleset);
+	auto rule_set = s2.engine->sc_codes_for_ruleset(s_sample_source, s_sample_ruleset);
 	auto state_set = libsinsp::events::sinsp_state_sc_set();
 	for (const auto &erased : io_set)
 	{
@@ -210,17 +213,17 @@ TEST(ConfigureInterestingSets, selection_not_allevents)
 	}
 	auto union_set = state_set.merge(rule_set);
 	auto inter_set = state_set.intersect(rule_set);
-	ASSERT_EQ(s.selected_sc_set.size(), state_set.size() + rule_set.size() - inter_set.size());
-	ASSERT_EQ(s.selected_sc_set, union_set);
+	ASSERT_EQ(s2.selected_sc_set.size(), state_set.size() + rule_set.size() - inter_set.size());
+	ASSERT_EQ(s2.selected_sc_set, union_set);
 }
 
 TEST(ConfigureInterestingSets, selection_allevents)
 {
+	falco::app::state s3;
 	// run app action with fake engine and with the `-A` option
-	falco::app::state s;
-	s.engine = mock_engine_from_filters(s_sample_filters);
-	s.options.all_events = true;
-	auto result = falco::app::actions::configure_interesting_sets(s);
+	s3.engine = mock_engine_from_filters(s_sample_filters);
+	s3.options.all_events = true;
+	auto result = falco::app::actions::configure_interesting_sets(s3);
 	ASSERT_TRUE(result.success);
 	ASSERT_EQ(result.errstr, "");
 
@@ -228,8 +231,8 @@ TEST(ConfigureInterestingSets, selection_allevents)
 	// also check if a warning has not been printed in stderr
 
 	// check that the final selected set is the one expected
-	ASSERT_GT(s.selected_sc_set.size(), 1);
-	auto selected_sc_names = libsinsp::events::sc_set_to_names(s.selected_sc_set);
+	ASSERT_GT(s3.selected_sc_set.size(), 1);
+	auto selected_sc_names = libsinsp::events::sc_set_to_names(s3.selected_sc_set);
 	auto expected_sc_names = strset_t({
 		// note: we expect the "read" syscall to not be erased
 		"connect", "accept", "accept4", "umount2", "open", "ptrace", "mmap", "execve", "read", // from ruleset
@@ -239,29 +242,29 @@ TEST(ConfigureInterestingSets, selection_allevents)
 	ASSERT_NAMES_CONTAIN(selected_sc_names, expected_sc_names);
 
 	// check that final selected set is exactly sinsp state + ruleset
-	auto rule_set = s.engine->sc_codes_for_ruleset(s_sample_source, s_sample_ruleset);
+	auto rule_set = s3.engine->sc_codes_for_ruleset(s_sample_source, s_sample_ruleset);
 	auto state_set = libsinsp::events::sinsp_state_sc_set();
 	auto union_set = state_set.merge(rule_set);
 	auto inter_set = state_set.intersect(rule_set);
-	ASSERT_EQ(s.selected_sc_set.size(), state_set.size() + rule_set.size() - inter_set.size());
-	ASSERT_EQ(s.selected_sc_set, union_set);
+	ASSERT_EQ(s3.selected_sc_set.size(), state_set.size() + rule_set.size() - inter_set.size());
+	ASSERT_EQ(s3.selected_sc_set, union_set);
 }
 
 TEST(ConfigureInterestingSets, selection_generic_evts)
 {
+	falco::app::state s4;
 	// run app action with fake engine and without the `-A` option
-	falco::app::state s;
-	s.options.all_events = false;
+	s4.options.all_events = false;
 	auto filters = s_sample_filters;
 	filters.insert(s_sample_generic_filters.begin(), s_sample_generic_filters.end());
-	s.engine = mock_engine_from_filters(filters);
-	auto result = falco::app::actions::configure_interesting_sets(s);
+	s4.engine = mock_engine_from_filters(filters);
+	auto result = falco::app::actions::configure_interesting_sets(s4);
 	ASSERT_TRUE(result.success);
 	ASSERT_EQ(result.errstr, "");
 
 	// check that the final selected set is the one expected
-	ASSERT_GT(s.selected_sc_set.size(), 1);
-	auto selected_sc_names = libsinsp::events::sc_set_to_names(s.selected_sc_set);
+	ASSERT_GT(s4.selected_sc_set.size(), 1);
+	auto selected_sc_names = libsinsp::events::sc_set_to_names(s4.selected_sc_set);
 	auto expected_sc_names = strset_t({
 		// note: we expect the "read" syscall to not be erased
 		"connect", "accept", "accept4", "umount2", "open", "ptrace", "mmap", "execve", // from ruleset
@@ -281,19 +284,19 @@ TEST(ConfigureInterestingSets, selection_generic_evts)
 // - if `-A` is not set, events from the IO set are removed from the selected set
 TEST(ConfigureInterestingSets, selection_custom_base_set)
 {
+	falco::app::state s5;
 	// run app action with fake engine and without the `-A` option
-	falco::app::state s;
-	s.options.all_events = true;
-	s.engine = mock_engine_from_filters(s_sample_filters);
+	s5.options.all_events = true;
+	s5.engine = mock_engine_from_filters(s_sample_filters);
 	auto default_base_set = libsinsp::events::sinsp_state_sc_set();
 
 	// non-empty custom base set (both positive and negative)
-	s.config->m_base_syscalls_repair = false;
-	s.config->m_base_syscalls_custom_set = {"syncfs", "!accept"};
-	auto result = falco::app::actions::configure_interesting_sets(s);
+	s5.config->m_base_syscalls_repair = false;
+	s5.config->m_base_syscalls_custom_set = {"syncfs", "!accept"};
+	auto result = falco::app::actions::configure_interesting_sets(s5);
 	ASSERT_TRUE(result.success);
 	ASSERT_EQ(result.errstr, "");
-	auto selected_sc_names = libsinsp::events::sc_set_to_names(s.selected_sc_set);
+	auto selected_sc_names = libsinsp::events::sc_set_to_names(s5.selected_sc_set);
 	auto expected_sc_names = strset_t({
 		// note: `syncfs` has been added due to the custom base set, and `accept`
 		// has been remove due to the negative base set.
@@ -307,22 +310,22 @@ TEST(ConfigureInterestingSets, selection_custom_base_set)
 	ASSERT_NAMES_EQ(selected_sc_names, expected_sc_names);
 
 	// non-empty custom base set (both positive and negative with collision)
-	s.config->m_base_syscalls_repair = false;
-	s.config->m_base_syscalls_custom_set = {"syncfs", "accept", "!accept"};
-	result = falco::app::actions::configure_interesting_sets(s);
+	s5.config->m_base_syscalls_repair = false;
+	s5.config->m_base_syscalls_custom_set = {"syncfs", "accept", "!accept"};
+	result = falco::app::actions::configure_interesting_sets(s5);
 	ASSERT_TRUE(result.success);
 	ASSERT_EQ(result.errstr, "");
-	selected_sc_names = libsinsp::events::sc_set_to_names(s.selected_sc_set);
+	selected_sc_names = libsinsp::events::sc_set_to_names(s5.selected_sc_set);
 	// note: in case of collision, negation has priority, so the expected
 	// names are the same as the case above
 	ASSERT_NAMES_EQ(selected_sc_names, expected_sc_names);
 
 	// non-empty custom base set (only positive)
-	s.config->m_base_syscalls_custom_set = {"syncfs"};
-	result = falco::app::actions::configure_interesting_sets(s);
+	s5.config->m_base_syscalls_custom_set = {"syncfs"};
+	result = falco::app::actions::configure_interesting_sets(s5);
 	ASSERT_TRUE(result.success);
 	ASSERT_EQ(result.errstr, "");
-	selected_sc_names = libsinsp::events::sc_set_to_names(s.selected_sc_set);
+	selected_sc_names = libsinsp::events::sc_set_to_names(s5.selected_sc_set);
 	expected_sc_names = strset_t({
 		// note: accept is not negated anymore
 		"connect", "accept", "accept4", "umount2", "open", "ptrace", "mmap", "execve", "read", "syncfs", "sched_process_exit"
@@ -330,11 +333,11 @@ TEST(ConfigureInterestingSets, selection_custom_base_set)
 	ASSERT_NAMES_EQ(selected_sc_names, expected_sc_names);
 
 	// non-empty custom base set (only negative)
-	s.config->m_base_syscalls_custom_set = {"!accept"};
-	result = falco::app::actions::configure_interesting_sets(s);
+	s5.config->m_base_syscalls_custom_set = {"!accept"};
+	result = falco::app::actions::configure_interesting_sets(s5);
 	ASSERT_TRUE(result.success);
 	ASSERT_EQ(result.errstr, "");
-	selected_sc_names = libsinsp::events::sc_set_to_names(s.selected_sc_set);
+	selected_sc_names = libsinsp::events::sc_set_to_names(s5.selected_sc_set);
 	expected_sc_names = unordered_set_union(
 		libsinsp::events::sc_set_to_names(default_base_set),
 		strset_t({ "connect", "umount2", "open", "ptrace", "mmap", "execve", "read"}));
@@ -344,12 +347,12 @@ TEST(ConfigureInterestingSets, selection_custom_base_set)
 	ASSERT_NAMES_EQ(selected_sc_names, expected_sc_names);
 
 	// non-empty custom base set (positive, without -A)
-	s.options.all_events = false;
-	s.config->m_base_syscalls_custom_set = {"read"};
-	result = falco::app::actions::configure_interesting_sets(s);
+	s5.options.all_events = false;
+	s5.config->m_base_syscalls_custom_set = {"read"};
+	result = falco::app::actions::configure_interesting_sets(s5);
 	ASSERT_TRUE(result.success);
 	ASSERT_EQ(result.errstr, "");
-	selected_sc_names = libsinsp::events::sc_set_to_names(s.selected_sc_set);
+	selected_sc_names = libsinsp::events::sc_set_to_names(s5.selected_sc_set);
 	expected_sc_names = strset_t({
 		// note: read is both part of the custom base set and the rules set,
 		// but we expect the unset -A option to take precedence
@@ -362,23 +365,22 @@ TEST(ConfigureInterestingSets, selection_custom_base_set)
 
 TEST(ConfigureInterestingSets, selection_custom_base_set_repair)
 {
+	falco::app::state s6;
 	// run app action with fake engine and without the `-A` option
-	falco::app::state s;
-	s.options.all_events = false;
-	s.engine = mock_engine_from_filters(s_sample_filters);
+	s6.options.all_events = false;
+	s6.engine = mock_engine_from_filters(s_sample_filters);
 
-	// simulate empty custom set but repair option set.
 	// note: here we use file syscalls (e.g. open, openat) and have a custom
 	// positive set, so we expect syscalls such as "close" to be selected as
 	// repaired. Also, given that we use some network syscalls, we expect "bind"
 	// to be selected event if we negate it, because repairment should have
 	// take precedence.
-	s.config->m_base_syscalls_custom_set = {"openat", "!bind"};
-	s.config->m_base_syscalls_repair = true;
-	auto result = falco::app::actions::configure_interesting_sets(s);
+	s6.config->m_base_syscalls_custom_set = {"openat", "!bind"};
+	s6.config->m_base_syscalls_repair = true;
+	auto result = falco::app::actions::configure_interesting_sets(s6);
 	ASSERT_TRUE(result.success);
 	ASSERT_EQ(result.errstr, "");
-	auto selected_sc_names = libsinsp::events::sc_set_to_names(s.selected_sc_set);
+	auto selected_sc_names = libsinsp::events::sc_set_to_names(s6.selected_sc_set);
 	auto expected_sc_names = strset_t({
 		// note: expecting syscalls from mock rules and `sinsp_repair_state_sc_set` enforced syscalls
 		"connect", "accept", "accept4", "umount2", "open", "ptrace", "mmap", "execve", "sched_process_exit", \
@@ -387,4 +389,30 @@ TEST(ConfigureInterestingSets, selection_custom_base_set_repair)
 	ASSERT_NAMES_CONTAIN(selected_sc_names, expected_sc_names);
 	auto unexpected_sc_names = libsinsp::events::sc_set_to_names(libsinsp::events::io_sc_set());
 	ASSERT_NAMES_NOCONTAIN(selected_sc_names, unexpected_sc_names);
+}
+
+TEST(ConfigureInterestingSets, selection_empty_custom_base_set_repair)
+{
+	falco::app::state s7;
+	// run app action with fake engine and with the `-A` option
+	s7.options.all_events = true;
+	s7.engine = mock_engine_from_filters(s_sample_filters);
+
+	// simulate empty custom set but repair option set.
+	s7.config->m_base_syscalls_custom_set = {};
+	s7.config->m_base_syscalls_repair = true;
+	auto result = falco::app::actions::configure_interesting_sets(s7);
+	auto s7_rules_set = s7.engine->sc_codes_for_ruleset(s_sample_source, s_sample_ruleset);
+	ASSERT_TRUE(result.success);
+	ASSERT_EQ(result.errstr, "");
+	auto selected_sc_names = libsinsp::events::sc_set_to_names(s7.selected_sc_set);
+	auto expected_sc_names = strset_t({
+		// note: expecting syscalls from mock rules and `sinsp_repair_state_sc_set` enforced syscalls
+		"connect", "accept", "accept4", "umount2", "open", "ptrace", "mmap", "execve", "sched_process_exit", \
+		"bind", "socket", "clone3", "close", "setuid"
+	});
+	ASSERT_NAMES_CONTAIN(selected_sc_names, expected_sc_names);
+	auto s7_state_set = libsinsp::events::sinsp_repair_state_sc_set(s7_rules_set);
+	ASSERT_EQ(s7.selected_sc_set, s7_state_set);
+	ASSERT_EQ(s7.selected_sc_set.size(), s7_state_set.size());
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

/kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

@jasondellaluce still getting errors locally with current master, e.g.

```
[----------] Global test environment tear-down
[==========] 30 tests from 9 test suites ran. (3009 ms total)
[  PASSED  ] 28 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] ConfigureInterestingSets.selection_not_allevents
[  FAILED  ] ConfigureInterestingSets.selection_allevents

 2 FAILED TESTS
[]$ git status
nothing to commit, working tree clean
[]$ git log
commit 0b6e243582c0e467efb6c2355259c4eefaa28c91 (HEAD -> master, upstream/master)
```

Have been reading more about it and everywhere people warn that gtests can influence each other. SetUp and TearDown didn't do anything, oddly just changing some variable names per test did help :woman_shrugging: ... now everything is passing again locally. Unsure if it's now also just random or really helped, at the same time these changes won't hurt at all. Let's see if the CI remains intact.

Also experimented with adding a generic syscall such as `init_module` to the `s_sample_filters` ... let's try adding it after the final libs patch to make sure we get consistent new / final behavior throughout.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
cleanup(unit_tests): try making test_configure_interesting_sets more robust
```
