### PR TITLE
cleanup: remove Mesos support from Falco.

### DIFF
--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -147,7 +147,7 @@ public:
 	// of all output expressions. You can also choose to replace
 	// %container.info with the extra information or add it to the
 	// end of the expression. This is used in open source falco to
-	// add k8s/mesos/container information to outputs when
+	// add k8s/container information to outputs when
 	// available.
 	//
 	void set_extra(std::string &extra, bool replace_container_info);

--- a/userspace/falco/app/actions/init_clients.cpp
+++ b/userspace/falco/app/actions/init_clients.cpp
@@ -64,27 +64,6 @@ falco::app::run_result falco::app::actions::init_clients(falco::app::state& s)
 		}
 		inspector->init_k8s_client(k8s_api_ptr, k8s_api_cert_ptr, k8s_node_name_ptr, s.options.verbose);
 	}
-
-	//
-	// DEPRECATED!
-	// Run mesos, if required
-	// todo(leogr): remove in Falco 0,.35
-	//
-	if(!s.options.mesos_api.empty())
-	{
-		// Differs from init_k8s_client in that it
-		// passes a pointer but the inspector does
-		// *not* own it and does not use it after
-		// init_mesos_client() returns.
-		falco_logger::log(LOG_WARNING, "Mesos support has been DEPRECATED and will be removed in the next version!\n");
-		inspector->init_mesos_client(&(s.options.mesos_api), s.options.verbose);
-	}
-	else if(char* mesos_api_env = getenv("FALCO_MESOS_API"))
-	{
-		falco_logger::log(LOG_WARNING, "Mesos support has been DEPRECATED and will be removed in the next version!\n");
-		std::string mesos_api_copy = mesos_api_env;
-		inspector->init_mesos_client(&mesos_api_copy, s.options.verbose);
-	}
 #endif
 
 	return run_result::ok();

--- a/userspace/falco/app/actions/init_falco_engine.cpp
+++ b/userspace/falco/app/actions/init_falco_engine.cpp
@@ -45,11 +45,6 @@ void configure_output_format(falco::app::state& s)
 		output_format = "k8s.ns=%k8s.ns.name k8s.pod=%k8s.pod.name container=%container.id vpid=%proc.vpid vtid=%thread.vtid";
 		replace_container_info = true;
 	}
-	else if(s.options.print_additional == "m" || s.options.print_additional == "mesos")
-	{
-		output_format = "task=%mesos.task.name container=%container.id";
-		replace_container_info = true;
-	}
 	else if(!s.options.print_additional.empty())
 	{
 		output_format = s.options.print_additional;

--- a/userspace/falco/app/options.cpp
+++ b/userspace/falco/app/options.cpp
@@ -195,9 +195,6 @@ void options::define(cxxopts::Options& opts)
 #ifndef MUSL_OPTIMIZED
 		("list-plugins",                  "Print info on all loaded plugins and exit.", cxxopts::value(list_plugins)->default_value("false"))
 #endif
-#ifndef MINIMAL_BUILD
-		("m,mesos-api",                   "This feature has been DEPRECATED and will be removed in the next version.", cxxopts::value(mesos_api), "<url[,marathon_url]>")
-#endif
 		("M",                             "Stop collecting after <num_seconds> reached.", cxxopts::value(duration_to_tot)->default_value("0"), "<num_seconds>")
 		("markdown",                      "When used with --list/--list-syscall-events, print the content in Markdown format", cxxopts::value<bool>(markdown))
 		("N",                             "When used with --list, only print field names.", cxxopts::value(names_only)->default_value("false"))

--- a/userspace/falco/app/options.h
+++ b/userspace/falco/app/options.h
@@ -63,7 +63,6 @@ public:
 	std::string print_plugin_info;
 	bool list_syscall_events;
 	bool markdown;
-	std::string mesos_api;
 	int duration_to_tot;
 	bool names_only;
 	std::vector<std::string> cmdline_config_options;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This follows up [#2328 add deprecation warning for Mesos](https://github.com/falcosecurity/falco/pull/2328) and completely removes the Mesos support from Falco.

/milestone 0.35.0

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
update!: remove `--mesos-api`, `-pmesos`, and `-pm` command-line flags
BREAKING CHANGE: support for metadata enrichment from Mesos has been removed.
```
