### PR TITLE
fix(scripts/systemd): restored stdout in unit files

### DIFF
--- a/scripts/systemd/falco-bpf.service
+++ b/scripts/systemd/falco-bpf.service
@@ -20,7 +20,6 @@ ProtectSystem=full
 ProtectKernelTunables=true
 RestrictRealtime=true
 RestrictAddressFamilies=~AF_PACKET
-StandardOutput=null
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/systemd/falco-custom.service
+++ b/scripts/systemd/falco-custom.service
@@ -19,7 +19,6 @@ ProtectSystem=full
 ProtectKernelTunables=true
 RestrictRealtime=true
 RestrictAddressFamilies=~AF_PACKET
-StandardOutput=null
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/systemd/falco-kmod.service
+++ b/scripts/systemd/falco-kmod.service
@@ -22,7 +22,6 @@ ProtectKernelTunables=true
 ReadWriteDirectories=/sys/module/falco
 RestrictRealtime=true
 RestrictAddressFamilies=~AF_PACKET
-StandardOutput=null
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/systemd/falco-modern-bpf.service
+++ b/scripts/systemd/falco-modern-bpf.service
@@ -19,7 +19,6 @@ ProtectSystem=full
 ProtectKernelTunables=true
 RestrictRealtime=true
 RestrictAddressFamilies=~AF_PACKET
-StandardOutput=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Redirecting stdout to null in the unit files results in partial logs. E.g.: in the case that a rule is broken, no hint is printed to the logs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
