### PR TITLE
update: bump libs and adapt Falco to new libsinsp event source management

### DIFF
--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -26,8 +26,8 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "4b26051e7b7558eb314ef6d240efa252d0a48fd7")
-    set(DRIVER_CHECKSUM "SHA256=5b4dd9e2ae0cd2efeaf9da37d8c29631241d448c9ce5b0e35d8dd7f81d814034")
+    set(DRIVER_VERSION "ffcd702cf22e99d4d999c278be0cc3d713c6375c")
+    set(DRIVER_CHECKSUM "SHA256=7ed19cd8e13887b02c823f5167aac3d1e997b0a60e305979848dfb339e1b774d")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -27,8 +27,8 @@ else()
   # In case you want to test against another falcosecurity/libs version (or branch, or commit) just pass the variable -
   # ie., `cmake -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "4b26051e7b7558eb314ef6d240efa252d0a48fd7")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=5b4dd9e2ae0cd2efeaf9da37d8c29631241d448c9ce5b0e35d8dd7f81d814034")
+    set(FALCOSECURITY_LIBS_VERSION "ffcd702cf22e99d4d999c278be0cc3d713c6375c")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=7ed19cd8e13887b02c823f5167aac3d1e997b0a60e305979848dfb339e1b774d")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/unit_tests/falco/app/actions/test_select_event_sources.cpp
+++ b/unit_tests/falco/app/actions/test_select_event_sources.cpp
@@ -44,10 +44,18 @@ TEST(ActionSelectEventSources, pre_post_conditions)
         falco::app::state s;
         s.loaded_sources = {"syscall", "some_source"};
         EXPECT_ACTION_OK(action(s));
-        EXPECT_EQ(s.loaded_sources, s.enabled_sources);
-        s.loaded_sources.insert("another_source");
+        EXPECT_EQ(s.loaded_sources.size(), s.enabled_sources.size());
+        for (const auto& v : s.loaded_sources)
+        {
+            ASSERT_TRUE(s.enabled_sources.find(v) != s.enabled_sources.end());
+        }
+        s.loaded_sources.push_back("another_source");
         EXPECT_ACTION_OK(action(s));
-        EXPECT_EQ(s.loaded_sources, s.enabled_sources);
+        EXPECT_EQ(s.loaded_sources.size(), s.enabled_sources.size());
+        for (const auto& v : s.loaded_sources)
+        {
+            ASSERT_TRUE(s.enabled_sources.find(v) != s.enabled_sources.end());
+        }
     }
 
     // enable only selected sources

--- a/userspace/engine/falco_common.h
+++ b/userspace/engine/falco_common.h
@@ -52,7 +52,7 @@ struct falco_exception : std::exception
 
 namespace falco_common
 {
-	const std::string syscall_source = "syscall";
+	const std::string syscall_source = sinsp_syscall_event_source_name;
 
 	// Same as numbers/indices into the above vector
 	enum priority_type

--- a/userspace/engine/falco_engine_version.h
+++ b/userspace/engine/falco_engine_version.h
@@ -21,4 +21,4 @@ limitations under the License.
 // This is the result of running "falco --list -N | sha256sum" and
 // represents the fields supported by this version of Falco. It's used
 // at build time to detect a changed set of fields.
-#define FALCO_FIELDS_CHECKSUM "8684342b994f61ca75a1a494e1197b86b53715c59ad60de3768d4d74ea4ba2c9"
+#define FALCO_FIELDS_CHECKSUM "8c28f9cdff607c308e3ba56db36f998f20119cdd7cf3da11e53c181204077da2"

--- a/userspace/falco/app/actions/init_falco_engine.cpp
+++ b/userspace/falco/app/actions/init_falco_engine.cpp
@@ -90,19 +90,19 @@ void add_source_to_engine(falco::app::state& s, const std::string& src)
 
 falco::app::run_result falco::app::actions::init_falco_engine(falco::app::state& s)
 {
+	// add syscall as first source, this is also what each inspector do
+	// in their own list of registered event sources
+	add_source_to_engine(s, falco_common::syscall_source);
+
 	// add all non-syscall event sources in engine
 	for (const auto& src : s.loaded_sources)
 	{
+		// we skip the syscall source because we already added it
 		if (src != falco_common::syscall_source)
 		{
-			// we skip the syscall as we want it to be the one added for last
-			// in the engine. This makes the source index assignment easier.
 			add_source_to_engine(s, src);
 		}
 	}
-
-	// add syscall as last source
-	add_source_to_engine(s, falco_common::syscall_source);
 
 	// note: in capture mode, we can assume that the plugin source index will
 	// be the same in both the falco engine and the sinsp plugin manager.

--- a/userspace/falco/app/actions/init_inspectors.cpp
+++ b/userspace/falco/app/actions/init_inspectors.cpp
@@ -146,7 +146,7 @@ falco::app::run_result falco::app::actions::init_inspectors(falco::app::state& s
 				// event source, we must register the plugin supporting
 				// that event source and also plugins with field extraction
 				// capability that are compatible with that event source
-				if (is_input || (p->caps() & CAP_EXTRACTION && p->is_source_compatible(src)))
+				if (is_input || (p->caps() & CAP_EXTRACTION && sinsp_plugin::is_source_compatible(p->extract_event_sources(), src)))
 				{
 					plugin = src_info->inspector->register_plugin(config->m_library_path);
 				}
@@ -187,7 +187,7 @@ falco::app::run_result falco::app::actions::init_inspectors(falco::app::state& s
 	{
 		if(used_plugins.find(p->name()) == used_plugins.end() 
 			&& p->caps() & CAP_EXTRACTION
-			&& !(p->caps() & CAP_SOURCING && p->is_source_compatible(p->event_source())))
+			&& !(p->caps() & CAP_SOURCING && sinsp_plugin::is_source_compatible(p->extract_event_sources(), p->event_source())))
 		{
 			return run_result::fatal("Plugin '" + p->name()
 				+ "' has field extraction capability but is not compatible with any known event source");

--- a/userspace/falco/app/actions/load_plugins.cpp
+++ b/userspace/falco/app/actions/load_plugins.cpp
@@ -55,7 +55,11 @@ falco::app::run_result falco::app::actions::load_plugins(falco::app::state& s)
 		{
 			auto sname = plugin->event_source();
 			s.source_infos.insert(empty_src_info, sname);
-			s.loaded_sources.insert(sname);
+			// note: this avoids duplicate values
+			if (std::find(s.loaded_sources.begin(), s.loaded_sources.end(), sname) == s.loaded_sources.end())
+			{
+				s.loaded_sources.push_back(sname);
+			}
 		}
 	}
 

--- a/userspace/falco/app/actions/select_event_sources.cpp
+++ b/userspace/falco/app/actions/select_event_sources.cpp
@@ -22,7 +22,7 @@ using namespace falco::app::actions;
 
 falco::app::run_result falco::app::actions::select_event_sources(falco::app::state& s)
 {
-	s.enabled_sources = s.loaded_sources;
+	s.enabled_sources = { s.loaded_sources.begin(), s.loaded_sources.end() };
 
 	// event sources selection is meaningless when reading trace files
 	if (s.is_capture_mode())
@@ -40,7 +40,7 @@ falco::app::run_result falco::app::actions::select_event_sources(falco::app::sta
 		s.enabled_sources.clear();
 		for(const auto &src : s.options.enable_sources)
 		{
-			if (s.loaded_sources.find(src) == s.loaded_sources.end())
+			if (std::find(s.loaded_sources.begin(), s.loaded_sources.end(), src) == s.loaded_sources.end())
 			{
 				return run_result::fatal("Attempted enabling an unknown event source: " + src);
 			}
@@ -51,7 +51,7 @@ falco::app::run_result falco::app::actions::select_event_sources(falco::app::sta
 	{
 		for(const auto &src : s.options.disable_sources)
 		{
-			if (s.loaded_sources.find(src) == s.loaded_sources.end())
+			if (std::find(s.loaded_sources.begin(), s.loaded_sources.end(), src) == s.loaded_sources.end())
 			{
 				return run_result::fatal("Attempted disabling an unknown event source: " + src);
 			}

--- a/userspace/falco/app/state.h
+++ b/userspace/falco/app/state.h
@@ -98,8 +98,10 @@ struct state
     std::shared_ptr<falco_engine> engine;
 
     // The set of loaded event sources (by default, the syscall event
-    // source plus all event sources coming from the loaded plugins)
-    std::unordered_set<std::string> loaded_sources;
+    // source plus all event sources coming from the loaded plugins).
+    // note: this has to be a vector to preserve the loading order,
+    // however it's not supposed to contain duplicate values.
+    std::vector<std::string> loaded_sources;
 
     // The set of enabled event sources (can be altered by using
     // the --enable-source and --disable-source options)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

/area engine

**What this PR does / why we need it**:

This syncs Falco with the latest libs, and adapts the event source management logic to match the one of libsinsp. Moreover, we now make sure that the plugin loading order is preserved as in the Falco configuration. This allows for an optimal and more predictable event source management. Also, more explicit errors are thrown when events with unexpected event source are fetched during a capture (both live and offline).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update: bump libs and adapt Falco to new libsinsp event source management
```
