### PR TITLE
update: improve control and UX of ignored events

### DIFF
--- a/userspace/falco/app/actions/configure_interesting_sets.cpp
+++ b/userspace/falco/app/actions/configure_interesting_sets.cpp
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 #include "actions.h"
+#include "helpers.h"
+#include "../app.h"
 
 using namespace falco::app;
 using namespace falco::app::actions;
@@ -44,7 +46,7 @@ static void check_for_rules_unsupported_events(falco::app::state& s, const libsi
 {
 	/* Unsupported events are those events that are used in the rules
 	 * but that are not part of the selected event set. For now, this
-	 * is expected to happen only for high volume I/O syscalls for
+	 * is expected to happen only for high volume syscalls for
 	 * performance reasons. */
 	auto unsupported_sc_set = rules_sc_set.diff(s.selected_sc_set);
 	if (unsupported_sc_set.empty())
@@ -55,7 +57,7 @@ static void check_for_rules_unsupported_events(falco::app::state& s, const libsi
 	/* Get the names of the events (syscall and non syscall events) that were not activated and print them. */
 	auto names = libsinsp::events::sc_set_to_event_names(unsupported_sc_set);
 	std::cerr << "Loaded rules match syscalls that are not activated (e.g. were removed via config settings such as no -A flag or negative base_syscalls elements) or unsupported with current configuration: warning (unsupported-evttype): " + concat_set_in_order(names) << std::endl;
-	std::cerr << "If syscalls in rules include high volume I/O syscalls (-> activate via `-A` flag), else syscalls may have been removed via base_syscalls option or might be associated with syscalls undefined on your architecture (https://marcin.juszkiewicz.com.pl/download/tables/syscalls.html)" << std::endl;
+	std::cerr << "If syscalls in rules include high volume syscalls (-> activate via `-A` flag), else syscalls may have been removed via base_syscalls option or might be associated with syscalls undefined on your architecture (https://marcin.juszkiewicz.com.pl/download/tables/syscalls.html)" << std::endl;
 }
 
 static void select_event_set(falco::app::state& s, const libsinsp::events::set<ppm_sc_code>& rules_sc_set)
@@ -158,12 +160,12 @@ static void select_event_set(falco::app::state& s, const libsinsp::events::set<p
 
 	/* -A flag behavior:
 	 * (1) default: all syscalls in rules included, sinsp state enforcement
-	       without high volume I/O syscalls
+	       without high volume syscalls
 	 * (2) -A flag set: all syscalls in rules included, sinsp state enforcement
-	       and allowing high volume I/O syscalls */
+	       and allowing high volume syscalls */
 	if(!s.options.all_events)
 	{
-		auto ignored_sc_set = libsinsp::events::io_sc_set();
+		auto ignored_sc_set = falco::app::ignored_sc_set();
 		auto erased_sc_set = s.selected_sc_set.intersect(ignored_sc_set);
 		s.selected_sc_set = s.selected_sc_set.diff(ignored_sc_set);
 		if (!erased_sc_set.empty())

--- a/userspace/falco/app/actions/print_ignored_events.cpp
+++ b/userspace/falco/app/actions/print_ignored_events.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include "actions.h"
 #include "helpers.h"
+#include "../app.h"
 
 using namespace falco::app;
 using namespace falco::app::actions;
@@ -27,8 +28,8 @@ falco::app::run_result falco::app::actions::print_ignored_events(falco::app::sta
 		return run_result::ok();
 	}
 
-	std::cout << "Ignored I/O syscall(s):" << std::endl;
-	for(const auto& it : libsinsp::events::sc_set_to_event_names(libsinsp::events::io_sc_set()))
+	std::cout << "Ignored syscall(s):" << std::endl;
+	for(const auto& it : libsinsp::events::sc_set_to_event_names(falco::app::ignored_sc_set()))
 	{
 		std::cout << "- " << it.c_str() << std::endl;
 	}

--- a/userspace/falco/app/app.cpp
+++ b/userspace/falco/app/app.cpp
@@ -25,6 +25,15 @@ falco::atomic_signal_handler falco::app::g_reopen_outputs_signal;
 
 using app_action = std::function<falco::app::run_result(falco::app::state&)>;
 
+libsinsp::events::set<ppm_sc_code> falco::app::ignored_sc_set()
+{
+	// we ignore all the I/O syscalls that can have very high throughput and
+	// that can badly impact performance. Of those, we avoid ignoring the
+	// ones that are part of the base set used by libsinsp for maintaining
+	// its internal state.
+	return libsinsp::events::io_sc_set().diff(libsinsp::events::sinsp_state_sc_set());
+}
+
 bool falco::app::run(int argc, char** argv, bool& restart, std::string& errstr)
 {
 	falco::app::state s;    

--- a/userspace/falco/app/app.h
+++ b/userspace/falco/app/app.h
@@ -23,7 +23,10 @@ limitations under the License.
 namespace falco {
 namespace app {
 
+libsinsp::events::set<ppm_sc_code> ignored_sc_set();
+
 bool run(int argc, char** argv, bool& restart, std::string& errstr);
+
 bool run(falco::app::state& s, bool& restart, std::string& errstr);
 
 }; // namespace app

--- a/userspace/falco/app/options.cpp
+++ b/userspace/falco/app/options.cpp
@@ -164,7 +164,7 @@ void options::define(cxxopts::Options& opts)
 #else
 		("c",                             "Configuration file. If not specified tries " FALCO_SOURCE_CONF_FILE ", " FALCO_INSTALL_CONF_FILE ".", cxxopts::value(conf_filename), "<path>")
 #endif
-		("A",                             "Monitor each event defined in rules and configs + high volume I/O syscalls. Please use the -i option to list the I/O syscalls Falco supports. This option affects live captures only. Setting -A can impact performance.", cxxopts::value(all_events)->default_value("false"))
+		("A",                             "Monitor all events supported by Falco defined in rules and configs. Please use the -i option to list the events ignored by default without -A. This option affects live captures only. Setting -A can impact performance.", cxxopts::value(all_events)->default_value("false"))
 		("b,print-base64",                "Print data buffers in base64. This is useful for encoding binary data that needs to be used over media designed to consume this format.")
 		("cri",                           "Path to CRI socket for container metadata. Use the specified socket to fetch data from a CRI-compatible runtime. If not specified, uses the libs default. This option can be passed multiple times to specify socket to be tried until a successful one is found.", cxxopts::value(cri_socket_paths), "<path>")
 		("d,daemon",                      "Run as a daemon.", cxxopts::value(daemon)->default_value("false"))
@@ -182,7 +182,7 @@ void options::define(cxxopts::Options& opts)
 #ifdef HAS_MODERN_BPF
 		("modern-bpf",				  "[EXPERIMENTAL] Use BPF modern probe to capture system events.", cxxopts::value(modern_bpf)->default_value("false"))
 #endif
-		("i",                             "Print all high volume I/O syscalls that are ignored by default (i.e. without the -A flag) and exit.", cxxopts::value(print_ignored_events)->default_value("false"))
+		("i",                             "Print all high volume syscalls that are ignored by default for performance reasons (i.e. without the -A flag) and exit.", cxxopts::value(print_ignored_events)->default_value("false"))
 #ifndef MINIMAL_BUILD
 		("k,k8s-api",                     "Enable Kubernetes support by connecting to the API server specified as argument. E.g. \"http://admin:password@127.0.0.1:8080\". The API server can also be specified via the environment variable FALCO_K8S_API.", cxxopts::value(k8s_api), "<url>")
 		("K,k8s-api-cert",                "Use the provided files names to authenticate user and (optionally) verify the K8S API server identity. Each entry must specify full (absolute, or relative to the current directory) path to the respective file. Private key password is optional (needed only if key is password protected). CA certificate is optional. For all files, only PEM file format is supported. Specifying CA certificate only is obsoleted - when single entry is provided for this option, it will be interpreted as the name of a file containing bearer token. Note that the format of this command-line option prohibits use of files whose names contain ':' or '#' characters in the file name.", cxxopts::value(k8s_api_cert), "(<bt_file> | <cert_file>:<key_file[#password]>[:<ca_cert_file>])")


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind design

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR segregates the logic behind the `-i`/`-A` ignored events in a single place. The set of ignored events is now set to be the one of the high-throughput I/O syscalls (that can be impactful for performance), but excluding those that are part of the base set of events required by libsinsp to collect its internal state.

Accordingly, this removes all mentions to the I/O syscalls set from the CLI helpers and comments. The fact that we chose that set as ignored should be an implementation detail that we don't leak as part of the tool's UX. This way, the output of `-i` is the only contract we have with users about which events are forcely ignored without `-A`, which is also easier to test too.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This fixes an issue where Falco "ignores" some syscalls that were automatically added as part of the default base set, which ended up being written in the logs as ignored events even when not specified by users (e.g. `recvfrom`, `sendto`, ...).

cc @incertum, @Andreagit97, @FedeDP 

**Does this PR introduce a user-facing change?**:

```release-note
update: improve control and UX of ignored events
```
