### PR TITLE
new: Add distroless Dockerfiles

### DIFF
--- a/docker/no-driver/Dockerfile
+++ b/docker/no-driver/Dockerfile
@@ -20,9 +20,7 @@ RUN curl -L -o falco.tar.gz \
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /falco/etc/falco/falco.yaml > /falco/etc/falco/falco.yaml.new \
     && mv /falco/etc/falco/falco.yaml.new /falco/etc/falco/falco.yaml
 
-# Our default glibc-dynamic image doesn't include libstdc++ so temporarily using this image
-# Working on an alternative (e.g. new image or adding the lib to glibc-dynamic)
-FROM cgr.dev/chainguard/cc-dynamic
+FROM cgr.dev/chainguard/glibc-dynamic
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
@@ -33,9 +31,7 @@ LABEL usage="docker run -i -t --privileged -v /var/run/docker.sock:/host/var/run
 ENV HOST_ROOT /host
 ENV HOME /root
 
-# Ideally these libs would be part of base image and not copied
-COPY --from=builder /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6 
-
 COPY --from=builder /falco /
+
 
 CMD ["/usr/bin/falco", "-o", "time_format_iso_8601=true"]

--- a/docker/no-driver/Dockerfile
+++ b/docker/no-driver/Dockerfile
@@ -32,6 +32,7 @@ LABEL usage="docker run -i -t --privileged -v /var/run/docker.sock:/host/var/run
 ENV HOST_ROOT /host
 ENV HOME /root
 
+USER root
 COPY --from=builder /falco /
 
 

--- a/docker/no-driver/Dockerfile
+++ b/docker/no-driver/Dockerfile
@@ -6,12 +6,13 @@ ARG VERSION_BUCKET=bin
 ENV FALCO_VERSION=${FALCO_VERSION}
 ENV VERSION_BUCKET=${VERSION_BUCKET}
 
-RUN apk update && apk add build-base gcc curl ca-certificates
+RUN apk update && apk add build-base gcc curl ca-certificates jq
 
 WORKDIR /
 
-RUN curl -L -o falco.tar.gz \
-    https://download.falco.org/packages/${VERSION_BUCKET}/$(uname -m)/falco-${FALCO_VERSION}-$(uname -m).tar.gz && \
+RUN FALCO_VERSION_URLENCODED=$(echo -n ${FALCO_VERSION}|jq -sRr @uri) && \
+    curl -L -o falco.tar.gz \
+    https://download.falco.org/packages/${VERSION_BUCKET}/$(uname -m)/falco-${FALCO_VERSION_URLENCODED}-$(uname -m).tar.gz && \
     tar -xvf falco.tar.gz && \
     rm -f falco.tar.gz && \
     mv falco-${FALCO_VERSION}-$(uname -m) falco && \

--- a/docker/no-driver/Dockerfile
+++ b/docker/no-driver/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as ubuntu
+FROM cgr.dev/chainguard/wolfi-base as builder
 
 ARG FALCO_VERSION
 ARG VERSION_BUCKET=bin
@@ -6,12 +6,12 @@ ARG VERSION_BUCKET=bin
 ENV FALCO_VERSION=${FALCO_VERSION}
 ENV VERSION_BUCKET=${VERSION_BUCKET}
 
-RUN apt-get -y update && apt-get -y install gridsite-clients curl ca-certificates
+RUN apk update && apk add build-base gcc curl ca-certificates
 
 WORKDIR /
 
 RUN curl -L -o falco.tar.gz \
-    https://download.falco.org/packages/${VERSION_BUCKET}/$(uname -m)/falco-$(urlencode ${FALCO_VERSION})-$(uname -m).tar.gz && \
+    https://download.falco.org/packages/${VERSION_BUCKET}/$(uname -m)/falco-${FALCO_VERSION}-$(uname -m).tar.gz && \
     tar -xvf falco.tar.gz && \
     rm -f falco.tar.gz && \
     mv falco-${FALCO_VERSION}-$(uname -m) falco && \
@@ -20,7 +20,9 @@ RUN curl -L -o falco.tar.gz \
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /falco/etc/falco/falco.yaml > /falco/etc/falco/falco.yaml.new \
     && mv /falco/etc/falco/falco.yaml.new /falco/etc/falco/falco.yaml
 
-FROM debian:11-slim
+# Our default glibc-dynamic image doesn't include libstdc++ so temporarily using this image
+# Working on an alternative (e.g. new image or adding the lib to glibc-dynamic)
+FROM cgr.dev/chainguard/cc-dynamic
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
@@ -28,12 +30,12 @@ LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
 LABEL usage="docker run -i -t --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro --name NAME IMAGE"
 # NOTE: for the "least privileged" use case, please refer to the official documentation
 
-RUN apt-get -y update && apt-get -y install ca-certificates curl jq \
-    && apt clean -y && rm -rf /var/lib/apt/lists/*
-
 ENV HOST_ROOT /host
 ENV HOME /root
 
-COPY --from=ubuntu /falco /
+# Ideally these libs would be part of base image and not copied
+COPY --from=builder /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6 
+
+COPY --from=builder /falco /
 
 CMD ["/usr/bin/falco", "-o", "time_format_iso_8601=true"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Adds distroless dockerfiles for Falco. These should be smaller and less likely to include vulnerabilities when scanned (due to simply having less packages in them).

Note there are two Dockerfiles, one of which builds from source, the other uses precompiled binaries.

**Which issue(s) this PR fixes**:

Fixes: https://github.com/falcosecurity/falco/issues/2181

**Special notes for your reviewer**:

This a draft currently, just wanted to put something up for discussion.

**Does this PR introduce a user-facing change?**:

YES

```release-note

BREAKING CHANGE: the Docker image no longer includes Debian utilities or a shell - meaning some debug workflows may be impacted.
```
