### PR TITLE
chore(ci): build-musl-package does not need to wait for build-packages anymore

### DIFF
--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -151,7 +151,7 @@ jobs:
             ${{ github.workspace }}/build/falco-*.rpm
             
   build-musl-package:
-    needs: [fetch-version, build-packages]
+    needs: fetch-version
     # x86_64 only for now
     if: ${{ inputs.arch == 'x86_64' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

Speed up master and release CI by avoiding that `build-musl-package` waits for `build-packages`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
