### PR TITLE
fix(ci): simplify and fix multi-arch image publishing process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,6 @@ jobs:
     uses: falcosecurity/falco/.github/workflows/reusable_build_docker.yaml@master
     with:
       arch: x86_64
-      is_latest: ${{ needs.release-settings.outputs.is_latest == 'true' }}
       bucket_suffix: ${{ needs.release-settings.outputs.bucket_suffix }}
       version: ${{ github.event.release.tag_name }}
       tag: ${{ github.event.release.tag_name }}
@@ -91,7 +90,6 @@ jobs:
     uses: falcosecurity/falco/.github/workflows/reusable_build_docker.yaml@master
     with:
       arch: aarch64
-      is_latest: ${{ needs.release-settings.outputs.is_latest == 'true' }}
       bucket_suffix: ${{ needs.release-settings.outputs.bucket_suffix }}
       version: ${{ github.event.release.tag_name }}
       tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/reusable_build_docker.yaml
+++ b/.github/workflows/reusable_build_docker.yaml
@@ -19,11 +19,6 @@ on:
         description: The tag to use (e.g. "master" or "0.35.0")
         required: true
         type: string
-      is_latest:
-        description: Update the latest tag with the new image
-        required: false
-        type: boolean
-        default: false
 
 # Here we just build all docker images as tarballs, 
 # then we upload all the tarballs to be later downloaded by reusable_publish_docker workflow.
@@ -48,10 +43,7 @@ jobs:
             VERSION_BUCKET=bin${{ inputs.bucket_suffix }}
             FALCO_VERSION=${{ inputs.version }}
           tags: |
-            falcosecurity/falco-no-driver:${{ inputs.arch }}-${{ inputs.tag }}
-            falcosecurity/falco:${{ inputs.arch }}-${{ inputs.tag }}-slim
-            public.ecr.aws/falcosecurity/falco-no-driver:${{ inputs.arch }}-${{ inputs.tag }}
-            public.ecr.aws/falcosecurity/falco:${{ inputs.arch }}-${{ inputs.tag }}-slim
+            docker.io/falcosecurity/falco-no-driver:${{ inputs.arch }}-${{ inputs.tag }}
           outputs: type=docker,dest=/tmp/falco-no-driver-${{ inputs.arch }}.tar
             
       - name: Build falco image
@@ -62,8 +54,7 @@ jobs:
             VERSION_BUCKET=deb${{ inputs.bucket_suffix }}
             FALCO_VERSION=${{ inputs.version }}
           tags: |
-            falcosecurity/falco:${{ inputs.arch }}-${{ inputs.tag }}
-            public.ecr.aws/falcosecurity/falco:${{ inputs.arch }}-${{ inputs.tag }}
+            docker.io/falcosecurity/falco:${{ inputs.arch }}-${{ inputs.tag }}
           outputs: type=docker,dest=/tmp/falco-${{ inputs.arch }}.tar
             
       - name: Build falco-driver-loader image
@@ -73,50 +64,9 @@ jobs:
           build-args: |
             FALCO_IMAGE_TAG=${{ inputs.arch }}-${{ inputs.tag }}
           tags: |
-            falcosecurity/falco-driver-loader:${{ inputs.arch }}-${{ inputs.tag }}
-            public.ecr.aws/falcosecurity/falco-driver-loader:${{ inputs.arch }}-${{ inputs.tag }}
+            docker.io/falcosecurity/falco-driver-loader:${{ inputs.arch }}-${{ inputs.tag }}
           outputs: type=docker,dest=/tmp/falco-driver-loader-${{ inputs.arch }}.tar  
             
-      - name: Build no-driver latest image
-        if: ${{ inputs.is_latest }}
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ github.workspace }}/docker/no-driver/
-          build-args: |
-            VERSION_BUCKET=bin
-            FALCO_VERSION=${{ inputs.version }}
-          tags: |
-            falcosecurity/falco-no-driver:${{ inputs.arch }}-latest
-            falcosecurity/falco:${{ inputs.arch }}-latest-slim
-            public.ecr.aws/falcosecurity/falco-no-driver:${{ inputs.arch }}-latest
-            public.ecr.aws/falcosecurity/falco:${{ inputs.arch }}-latest-slim
-          outputs: type=docker,dest=/tmp/falco-no-driver-latest-${{ inputs.arch }}.tar
-            
-      - name: Build falco latest image
-        if: ${{ inputs.is_latest }}
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ github.workspace }}/docker/falco/
-          build-args: |
-            VERSION_BUCKET=deb
-            FALCO_VERSION=${{ inputs.version }}
-          tags: |
-            falcosecurity/falco:${{ inputs.arch }}-latest
-            public.ecr.aws/falcosecurity/falco:${{ inputs.arch }}-latest
-          outputs: type=docker,dest=/tmp/falco-latest-${{ inputs.arch }}.tar
-            
-      - name: Build falco-driver-loader latest image
-        if: ${{ inputs.is_latest }}
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ github.workspace }}/docker/driver-loader/
-          build-args: |
-            FALCO_IMAGE_TAG=${{ inputs.arch }}-latest
-          tags: |
-            falcosecurity/falco-driver-loader:${{ inputs.arch }}-latest
-            public.ecr.aws/falcosecurity/falco-driver-loader:${{ inputs.arch }}-latest
-          outputs: type=docker,dest=/tmp/falco-driver-loader-latest-${{ inputs.arch }}.tar
-       
       - name: Upload images tarballs
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/reusable_publish_docker.yaml
+++ b/.github/workflows/reusable_publish_docker.yaml
@@ -50,123 +50,63 @@ jobs:
         uses: aws-actions/amazon-ecr-login@2f9f10ea3fa2eed41ac443fee8bfbd059af2d0a4 # v1.6.0
         with:
           registry-type: public    
-          
-      - name: Create and push no-driver manifest
-        uses: Noelware/docker-manifest-action@0.3.1
+      
+      - name: Setup Crane
+        uses: imjasonh/setup-crane@v0.3
         with:
-          inputs: falcosecurity/falco-no-driver:${{ inputs.tag }}
-          images: falcosecurity/falco-no-driver:aarch64-${{ inputs.tag }},falcosecurity/falco-no-driver:x86_64-${{ inputs.tag }}
-          push: true
-          
-      - name: Create and push slim manifest
-        uses: Noelware/docker-manifest-action@0.3.1
-        with:
-          inputs: falcosecurity/falco:${{ inputs.tag }}-slim
-          images: falcosecurity/falco:aarch64-${{ inputs.tag }}-slim,falcosecurity/falco:x86_64-${{ inputs.tag }}-slim
-          push: true     
-          
-      - name: Create and push no-driver manifest for ecr
-        uses: Noelware/docker-manifest-action@0.3.1
-        with:
-          inputs: public.ecr.aws/falcosecurity/falco-no-driver:${{ inputs.tag }}
-          images: public.ecr.aws/falcosecurity/falco-no-driver:aarch64-${{ inputs.tag }},public.ecr.aws/falcosecurity/falco-no-driver:x86_64-${{ inputs.tag }}
-          push: true
-          
-      - name: Create and push slim manifest for ecr
-        uses: Noelware/docker-manifest-action@0.3.1
-        with:
-          inputs: public.ecr.aws/falcosecurity/falco:${{ inputs.tag }}-slim
-          images: public.ecr.aws/falcosecurity/falco:aarch64-${{ inputs.tag }}-slim,public.ecr.aws/falcosecurity/falco:x86_64-${{ inputs.tag }}-slim
-          push: true      
+          version: v0.15.1
 
-      - name: Create and push no-driver latest manifest
-        if: ${{ inputs.is_latest }}
+      # We're pushing the arch-specific manifests to Docker Hub so that we'll be able to easily create the index/multiarch later
+      - name: Push arch-specific images to Docker Hub
+        run: |
+          docker push docker.io/falcosecurity/falco-no-driver:aarch64-${{ inputs.tag }}
+          docker push docker.io/falcosecurity/falco-no-driver:x86_64-${{ inputs.tag }}
+          docker push docker.io/falcosecurity/falco:aarch64-${{ inputs.tag }}
+          docker push docker.io/falcosecurity/falco:x86_64-${{ inputs.tag }}
+          docker push docker.io/falcosecurity/falco-driver-loader:aarch64-${{ inputs.tag }}
+          docker push docker.io/falcosecurity/falco-driver-loader:x86_64-${{ inputs.tag }}
+
+      - name: Create no-driver manifest on Docker Hub
         uses: Noelware/docker-manifest-action@0.3.1
         with:
-          inputs: falcosecurity/falco-no-driver:latest
-          images: falcosecurity/falco-no-driver:aarch64-latest,falcosecurity/falco-no-driver:x86_64-latest
+          inputs: docker.io/falcosecurity/falco-no-driver:${{ inputs.tag }}
+          images: docker.io/falcosecurity/falco-no-driver:aarch64-${{ inputs.tag }},docker.io/falcosecurity/falco-no-driver:x86_64-${{ inputs.tag }}
           push: true
           
-      - name: Create and push slim latest manifest
-        if: ${{ inputs.is_latest }}
+      - name: Tag slim manifest on Docker Hub
+        run: |
+          crane tag docker.io/falcosecurity/falco-no-driver:${{ inputs.tag }} docker.io/falcosecurity/falco:${{ inputs.tag }}-slim
+
+      - name: Create falco manifest on Docker Hub
         uses: Noelware/docker-manifest-action@0.3.1
         with:
-          inputs: falcosecurity/falco:latest-slim
-          images: falcosecurity/falco:aarch64-latest-slim,falcosecurity/falco:x86_64-latest-slim
+          inputs: docker.io/falcosecurity/falco:${{ inputs.tag }}
+          images: docker.io/falcosecurity/falco:aarch64-${{ inputs.tag }},docker.io/falcosecurity/falco:x86_64-${{ inputs.tag }}
           push: true
           
-      - name: Create and push no-driver latest manifest for ecr
-        if: ${{ inputs.is_latest }}
+      - name: Create falco-driver-loader manifest on Docker Hub
         uses: Noelware/docker-manifest-action@0.3.1
         with:
-          inputs: public.ecr.aws/falcosecurity/falco-no-driver:latest
-          images: public.ecr.aws/falcosecurity/falco-no-driver:aarch64-latest,public.ecr.aws/falcosecurity/falco-no-driver:x86_64-latest
+          inputs: docker.io/falcosecurity/falco-driver-loader:${{ inputs.tag }}
+          images: docker.io/falcosecurity/falco-driver-loader:aarch64-${{ inputs.tag }},docker.io/falcosecurity/falco-driver-loader:x86_64-${{ inputs.tag }}
           push: true
-          
-      - name: Create and push slim latest manifest for ecr
-        if: ${{ inputs.is_latest }}
-        uses: Noelware/docker-manifest-action@0.3.1
-        with:
-          inputs: public.ecr.aws/falcosecurity/falco:latest-slim
-          images: public.ecr.aws/falcosecurity/falco:aarch64-latest-slim,public.ecr.aws/falcosecurity/falco:x86_64-latest-slim
-          push: true        
-    
-      - name: Create and push falco manifest
-        uses: Noelware/docker-manifest-action@0.3.1
-        with:
-          inputs: falcosecurity/falco:${{ inputs.tag }}
-          images: falcosecurity/falco:aarch64-${{ inputs.tag }},falcosecurity/falco:x86_64-${{ inputs.tag }}
-          push: true
-          
-      - name: Create and push falco manifest for ecr
-        uses: Noelware/docker-manifest-action@0.3.1
-        with:
-          inputs: public.ecr.aws/falcosecurity/falco:${{ inputs.tag }}
-          images: public.ecr.aws/falcosecurity/falco:aarch64-${{ inputs.tag }},public.ecr.aws/falcosecurity/falco:x86_64-${{ inputs.tag }}
-          push: true    
-      
-      - name: Create and push falco latest manifest
-        if: ${{ inputs.is_latest }}
-        uses: Noelware/docker-manifest-action@0.3.1
-        with:
-          inputs: falcosecurity/falco:latest
-          images: falcosecurity/falco:aarch64-latest,falcosecurity/falco:x86_64-latest
-          push: true
-          
-      - name: Create and push falco latest manifest for ecr
-        if: ${{ inputs.is_latest }}
-        uses: Noelware/docker-manifest-action@0.3.1
-        with:
-          inputs: public.ecr.aws/falcosecurity/falco:latest
-          images: public.ecr.aws/falcosecurity/falco:aarch64-latest,public.ecr.aws/falcosecurity/falco:x86_64-latest
-          push: true  
-          
-      - name: Create and push falco-driver-loader manifest
-        uses: Noelware/docker-manifest-action@0.3.1
-        with:
-          inputs: falcosecurity/falco-driver-loader:${{ inputs.tag }}
-          images: falcosecurity/falco-driver-loader:aarch64-${{ inputs.tag }},falcosecurity/falco-driver-loader:x86_64-${{ inputs.tag }}
-          push: true
-          
-      - name: Create and push falco-driver-loader manifest for ecr
-        uses: Noelware/docker-manifest-action@0.3.1
-        with:
-          inputs: public.ecr.aws/falcosecurity/falco-driver-loader:${{ inputs.tag }}
-          images: public.ecr.aws/falcosecurity/falco-driver-loader:aarch64-${{ inputs.tag }},public.ecr.aws/falcosecurity/falco-driver-loader:x86_64-${{ inputs.tag }}
-          push: true    
-      
-      - name: Create and push falco-driver-loader latest manifest
-        if: ${{ inputs.is_latest }}
-        uses: Noelware/docker-manifest-action@0.3.1
-        with:
-          inputs: falcosecurity/falco-driver-loader:latest
-          images: falcosecurity/falco-driver-loader:aarch64-latest,falcosecurity/falco-driver-loader:x86_64-latest
-          push: true
-          
-      - name: Create and push falco-driver-loader latest manifest for ecr
-        if: ${{ inputs.is_latest }}
-        uses: Noelware/docker-manifest-action@0.3.1
-        with:
-          inputs: public.ecr.aws/falcosecurity/falco-driver-loader:latest
-          images: public.ecr.aws/falcosecurity/falco-driver-loader:aarch64-latest,public.ecr.aws/falcosecurity/falco-driver-loader:x86_64-latest
-          push: true      
+
+      - name: Publish images to ECR
+        run: |
+          crane copy docker.io/falcosecurity/falco-no-driver:${{ inputs.tag }} public.ecr.aws/falcosecurity/falco-no-driver:${{ inputs.tag }}
+          crane copy docker.io/falcosecurity/falco:${{ inputs.tag }} public.ecr.aws/falcosecurity/falco:${{ inputs.tag }}
+          crane copy docker.io/falcosecurity/falco-driver-loader:${{ inputs.tag }} public.ecr.aws/falcosecurity/falco-driver-loader:${{ inputs.tag }}
+          crane tag public.ecr.aws/falcosecurity/falco-no-driver:${{ inputs.tag }} public.ecr.aws/falcosecurity/falco:${{ inputs.tag }}-slim
+
+      - name: Tag latest on Docker Hub and ECR
+        if: inputs.is_latest
+        run: |
+          crane tag docker.io/falcosecurity/falco-no-driver:${{ inputs.tag }} latest
+          crane tag docker.io/falcosecurity/falco:${{ inputs.tag }} latest
+          crane tag docker.io/falcosecurity/falco-driver-loader:${{ inputs.tag }} latest
+          crane tag docker.io/falcosecurity/falco:${{ inputs.tag }}-slim latest-slim
+
+          crane tag public.ecr.aws/falcosecurity/falco-no-driver:${{ inputs.tag }} latest
+          crane tag public.ecr.aws/falcosecurity/falco:${{ inputs.tag }} latest
+          crane tag public.ecr.aws/falcosecurity/falco-driver-loader:${{ inputs.tag }} latest
+          crane tag public.ecr.aws/falcosecurity/falco:${{ inputs.tag }}-slim latest-slim


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug
/kind cleanup

/area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This is a refactor and fix of the container image publishing process. There are two major changes:
1. Images with arch-specific tags are pushed to Docker Hub (e.g. `:x86_64-0.35.0`). This is done because in order to create a multiarch (`index`, `manifest.list`) manifest easily we need manifests with the referenced digests already published. It is probably possible to do it without (buildx can do something similar) but it may involve a local registry or some more complicated process. I think this is fine for now.
2. Instead of building images multiple times and then publishing all of them, this one only builds one version (`docker.io/falcosecurity/falco`) and then adds any additional tags or registries (ECR, latest tags...). This simplifies things especially when the next PR will be published, which is related to signatures with cosign.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Note that the arch specific tags are not pushed to ECR. We can change this behavior

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
