### PR TITLE
cleanup(actions): now modern bpf support `-A` flag

### DIFF
--- a/userspace/falco/app/actions/load_rules_files.cpp
+++ b/userspace/falco/app/actions/load_rules_files.cpp
@@ -116,14 +116,6 @@ falco::app::run_result falco::app::actions::load_rules_files(falco::app::state& 
 		s.engine->enable_rule_by_tag(s.options.enabled_rule_tags, true);
 	}
 
-	if(s.options.all_events && s.options.modern_bpf)
-	{
-		/* Right now the modern BPF probe doesn't support the -A flag, we implemented just 
-		 * the "simple set" syscalls.
-		 */
-		falco_logger::log(LOG_INFO, "The '-A' flag has no effect with the modern BPF probe, no further syscalls will be added\n");
-	}
-
 	if (s.options.describe_all_rules)
 	{
 		s.engine->describe_rule(NULL);


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

The `-A` flag is now supported with the modern bpf probe

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
cleanup(actions): now modern bpf support `-A` flag
```
