### PR TITLE
fix(ci): use normal docker to build docker images, instead of buildx.

### DIFF
--- a/.github/workflows/reusable_build_docker.yaml
+++ b/.github/workflows/reusable_build_docker.yaml
@@ -39,7 +39,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}/docker/no-driver/
           docker build -t docker.io/falcosecurity/falco-no-driver:${{ inputs.arch }}-${{ inputs.tag }} \
-            --build-arg VERSION_BUCKET=bin${{ inputs.bucket_suffix }} 
+            --build-arg VERSION_BUCKET=bin${{ inputs.bucket_suffix }} \
             --build-arg FALCO_VERSION=${{ inputs.version }} \
             --output type=docker,dest=/tmp/falco-no-driver-${{ inputs.arch }}.tar \
             .
@@ -48,7 +48,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}/docker/falco/
           docker build -t docker.io/falcosecurity/falco:${{ inputs.arch }}-${{ inputs.tag }} \
-            --build-arg VERSION_BUCKET=deb${{ inputs.bucket_suffix }} 
+            --build-arg VERSION_BUCKET=deb${{ inputs.bucket_suffix }} \
             --build-arg FALCO_VERSION=${{ inputs.version }} \
             --output type=docker,dest=/tmp/falco-${{ inputs.arch }}.tar \
             .
@@ -62,7 +62,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}/docker/driver-loader/
           docker build -t docker.io/falcosecurity/falco-driver-loader:${{ inputs.arch }}-${{ inputs.tag }} \
-            --build-arg FALCO_IMAGE_TAG=${{ inputs.arch }}-${{ inputs.tag }}
+            --build-arg FALCO_IMAGE_TAG=${{ inputs.arch }}-${{ inputs.tag }} \
             --output type=docker,dest=/tmp/falco-driver-loader-${{ inputs.arch }}.tar \
             .
             

--- a/.github/workflows/reusable_build_docker.yaml
+++ b/.github/workflows/reusable_build_docker.yaml
@@ -36,26 +36,22 @@ jobs:
         uses: docker/setup-buildx-action@v2
           
       - name: Build no-driver image
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ github.workspace }}/docker/no-driver/
-          build-args: |
-            VERSION_BUCKET=bin${{ inputs.bucket_suffix }}
-            FALCO_VERSION=${{ inputs.version }}
-          tags: |
-            docker.io/falcosecurity/falco-no-driver:${{ inputs.arch }}-${{ inputs.tag }}
-          outputs: type=docker,dest=/tmp/falco-no-driver-${{ inputs.arch }}.tar
+        run: |
+          cd ${{ github.workspace }}/docker/no-driver/
+          docker build -t docker.io/falcosecurity/falco-no-driver:${{ inputs.arch }}-${{ inputs.tag }} \
+            --build-arg VERSION_BUCKET=bin${{ inputs.bucket_suffix }} 
+            --build-arg FALCO_VERSION=${{ inputs.version }} \
+            --output type=docker,dest=/tmp/falco-no-driver-${{ inputs.arch }}.tar \
+            .
             
       - name: Build falco image
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ github.workspace }}/docker/falco/
-          build-args: |
-            VERSION_BUCKET=deb${{ inputs.bucket_suffix }}
-            FALCO_VERSION=${{ inputs.version }}
-          tags: |
-            docker.io/falcosecurity/falco:${{ inputs.arch }}-${{ inputs.tag }}
-          outputs: type=docker,dest=/tmp/falco-${{ inputs.arch }}.tar
+        run: |
+          cd ${{ github.workspace }}/docker/falco/
+          docker build -t docker.io/falcosecurity/falco:${{ inputs.arch }}-${{ inputs.tag }} \
+            --build-arg VERSION_BUCKET=deb${{ inputs.bucket_suffix }} 
+            --build-arg FALCO_VERSION=${{ inputs.version }} \
+            --output type=docker,dest=/tmp/falco-${{ inputs.arch }}.tar \
+            .
 
       # The falcosecurity/falco image is required for the driver-loader image, so we need to load it
       - name: Load the falcosecurity/falco image
@@ -63,14 +59,12 @@ jobs:
           docker load --input /tmp/falco-${{ inputs.arch }}.tar
 
       - name: Build falco-driver-loader image
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ github.workspace }}/docker/driver-loader/
-          build-args: |
-            FALCO_IMAGE_TAG=${{ inputs.arch }}-${{ inputs.tag }}
-          tags: |
-            docker.io/falcosecurity/falco-driver-loader:${{ inputs.arch }}-${{ inputs.tag }}
-          outputs: type=docker,dest=/tmp/falco-driver-loader-${{ inputs.arch }}.tar  
+        run: |
+          cd ${{ github.workspace }}/docker/driver-loader/
+          docker build -t docker.io/falcosecurity/falco-driver-loader:${{ inputs.arch }}-${{ inputs.tag }} \
+            --build-arg FALCO_IMAGE_TAG=${{ inputs.arch }}-${{ inputs.tag }}
+            --output type=docker,dest=/tmp/falco-driver-loader-${{ inputs.arch }}.tar \
+            .
             
       - name: Upload images tarballs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

We are being hit by https://github.com/docker/buildx/issues/1758.
Avoid using buildx (we aren't using any feature btw)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Refs  #2501 

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
