### PR TITLE
feat: support parsing of system environment variables in yaml

### DIFF
--- a/unit_tests/falco/test_configuration.cpp
+++ b/unit_tests/falco/test_configuration.cpp
@@ -88,16 +88,88 @@ TEST(Configuration, modify_yaml_fields)
 {
 	std::string key = "base_value.subvalue.subvalue2.boolean";
 	yaml_helper conf;
-	
+
     /* Get original value */
     conf.load_from_string(sample_yaml);
 	ASSERT_EQ(conf.get_scalar<bool>(key, false), true);
-	
+
     /* Modify the original value */
     conf.set_scalar<bool>(key, false);
 	ASSERT_EQ(conf.get_scalar<bool>(key, true), false);
-	
+
     /* Modify it again */
     conf.set_scalar<bool>(key, true);
 	ASSERT_EQ(conf.get_scalar<bool>(key, false), true);
+}
+
+TEST(Configuration, configuration_environment_variables)
+{
+    // Set an environment variable for testing purposes
+    std::string env_var_value = "envVarValue";
+    std::string env_var_name = "ENV_VAR";
+    std::string default_value = "default";
+    setenv(env_var_name.c_str(), env_var_value.c_str(), 1);
+    yaml_helper conf;
+
+    std::string sample_yaml =
+        "base_value:\n"
+        "    id: $ENV_VAR\n"
+        "    name: '${ENV_VAR}'\n"
+        "    string: my_string\n"
+        "    invalid: $${ENV_VAR}\n"
+		"    invalid_env: $$ENV_VAR\n"
+        "    escaped: \"${ENV_VAR}\"\n"
+        "    subvalue:\n"
+        "        subvalue2:\n"
+        "            boolean: ${UNSED_XX_X_X_VAR}\n"
+        "base_value_2:\n"
+        "    sample_list:\n"
+        "        - ${ENV_VAR}\n"
+        "        - ' ${ENV_VAR}'\n"
+        "        - $UNSED_XX_X_X_VAR\n";
+    conf.load_from_string(sample_yaml);
+
+    /* Check if the base values are defined */
+    ASSERT_TRUE(conf.is_defined("base_value"));
+    ASSERT_TRUE(conf.is_defined("base_value_2"));
+    ASSERT_FALSE(conf.is_defined("unknown_base_value"));
+
+    /* Test fetching of a regular string without any environment variable */
+    std::string base_value_string = conf.get_scalar<std::string>("base_value.string", default_value);
+    ASSERT_EQ(base_value_string, "my_string");
+
+    /* Test fetching of escaped environment variable format. Should return the string as-is after stripping the leading `$` */
+    std::string base_value_invalid = conf.get_scalar<std::string>("base_value.invalid", default_value);
+    ASSERT_EQ(base_value_invalid, "${ENV_VAR}");
+
+	/* Test fetching of invalid escaped environment variable format. Should return the string as-is */
+    std::string base_value_invalid_env = conf.get_scalar<std::string>("base_value.invalid_env", default_value);
+    ASSERT_EQ(base_value_invalid_env, "$$ENV_VAR");
+
+    /* Test fetching of strings that contain environment variables */
+    std::string base_value_id = conf.get_scalar<std::string>("base_value.id", default_value);
+    ASSERT_EQ(base_value_id, "$ENV_VAR"); // Does not follow the `${VAR}` format, so it should be treated as a regular string
+
+    std::string base_value_name = conf.get_scalar<std::string>("base_value.name", default_value);
+    ASSERT_EQ(base_value_name, env_var_value); // Proper environment variable format
+
+    std::string base_value_escaped = conf.get_scalar<std::string>("base_value.escaped", default_value);
+    ASSERT_EQ(base_value_escaped, env_var_value); // Environment variable within quotes
+
+    /* Test fetching of an undefined environment variable. Expected to return the default value.*/
+    std::string unknown_boolean = conf.get_scalar<std::string>("base_value.subvalue.subvalue2.boolean", default_value);
+    ASSERT_EQ(unknown_boolean, default_value);
+
+    /* Test fetching of environment variables from a list */
+    std::string base_value_2_list_0 = conf.get_scalar<std::string>("base_value_2.sample_list[0]", default_value);
+    ASSERT_EQ(base_value_2_list_0, env_var_value); // Proper environment variable format
+
+    std::string base_value_2_list_1 = conf.get_scalar<std::string>("base_value_2.sample_list[1]", default_value);
+    ASSERT_EQ(base_value_2_list_1, " ${ENV_VAR}"); // Environment variable preceded by a space, hence treated as a regular string
+
+    std::string base_value_2_list_2 = conf.get_scalar<std::string>("base_value_2.sample_list[2]", default_value);
+    ASSERT_EQ(base_value_2_list_2, "$UNSED_XX_X_X_VAR"); // Does not follow the `${VAR}` format, so should be treated as a regular string
+
+    /* Clear the set environment variable after testing */
+    unsetenv(env_var_name.c_str());
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine
/area tests

**What this PR does / why we need it**:

In order to allow the user to supply environment variables in standard
ways performed in other applications the get_scalar function has been
extended to support defining an environment variable in the format
`${FOO}`. Environment variables can be escaped via defining as `$${FOO}`. 
As this handles some additional complexity, a unit test has been  added 
to cover this new functionality

**Which issue(s) this PR fixes**:
Fixes  #2561

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
feat: support parsing of system environment variables in yaml
```
