### PR TITLE
update(ci): use repo instead of master branch for reusable workflows

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -43,7 +43,7 @@ jobs:
 
   build-dev-packages:
     needs: [fetch-version]
-    uses: falcosecurity/falco/.github/workflows/reusable_build_packages.yaml@master
+    uses: ./.github/workflows/reusable_build_packages.yaml
     with:
       arch: x86_64
       version: ${{ needs.fetch-version.outputs.version }}
@@ -51,7 +51,7 @@ jobs:
   
   build-dev-packages-arm64:
     needs: [fetch-version]
-    uses: falcosecurity/falco/.github/workflows/reusable_build_packages.yaml@master
+    uses: ./.github/workflows/reusable_build_packages.yaml
     with:
       arch: aarch64
       version: ${{ needs.fetch-version.outputs.version }}
@@ -59,7 +59,7 @@ jobs:
     
   publish-dev-packages:
     needs: [fetch-version, build-dev-packages, build-dev-packages-arm64]
-    uses: falcosecurity/falco/.github/workflows/reusable_publish_packages.yaml@master
+    uses: ./.github/workflows/reusable_publish_packages.yaml
     with:
       bucket_suffix: '-dev'
       version: ${{ needs.fetch-version.outputs.version }}
@@ -67,7 +67,7 @@ jobs:
   
   build-dev-docker:
     needs: [fetch-version, publish-dev-packages]
-    uses: falcosecurity/falco/.github/workflows/reusable_build_docker.yaml@master
+    uses: ./.github/workflows/reusable_build_docker.yaml
     with:
       arch: x86_64
       bucket_suffix: '-dev'
@@ -77,7 +77,7 @@ jobs:
     
   build-dev-docker-arm64:
     needs: [fetch-version, publish-dev-packages]
-    uses: falcosecurity/falco/.github/workflows/reusable_build_docker.yaml@master
+    uses: ./.github/workflows/reusable_build_docker.yaml
     with:
       arch: aarch64
       bucket_suffix: '-dev'
@@ -87,7 +87,7 @@ jobs:
     
   publish-dev-docker:
     needs: [fetch-version, build-dev-docker, build-dev-docker-arm64]
-    uses: falcosecurity/falco/.github/workflows/reusable_publish_docker.yaml@master
+    uses: ./.github/workflows/reusable_publish_docker.yaml
     with:
       tag: master
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
 
   build-packages:
     needs: [release-settings]
-    uses: falcosecurity/falco/.github/workflows/reusable_build_packages.yaml@master
+    uses: ./.github/workflows/reusable_build_packages.yaml
     with:
       arch: x86_64
       version: ${{ github.event.release.tag_name }}
@@ -60,7 +60,7 @@ jobs:
 
   build-packages-arm64:
     needs: [release-settings]
-    uses: falcosecurity/falco/.github/workflows/reusable_build_packages.yaml@master
+    uses: ./.github/workflows/reusable_build_packages.yaml
     with:
       arch: aarch64
       version: ${{ github.event.release.tag_name }}
@@ -68,7 +68,7 @@ jobs:
     
   publish-packages:
     needs: [release-settings, build-packages, build-packages-arm64]
-    uses: falcosecurity/falco/.github/workflows/reusable_publish_packages.yaml@master
+    uses: ./.github/workflows/reusable_publish_packages.yaml
     with:
       bucket_suffix: ${{ needs.release-settings.outputs.bucket_suffix }}
       version: ${{ github.event.release.tag_name }}
@@ -77,7 +77,7 @@ jobs:
   # Both build-docker and its arm64 counterpart require build-packages because they use its output
   build-docker:
     needs: [release-settings, build-packages, publish-packages]
-    uses: falcosecurity/falco/.github/workflows/reusable_build_docker.yaml@master
+    uses: ./.github/workflows/reusable_build_docker.yaml
     with:
       arch: x86_64
       bucket_suffix: ${{ needs.release-settings.outputs.bucket_suffix }}
@@ -87,7 +87,7 @@ jobs:
     
   build-docker-arm64:
     needs: [release-settings, build-packages, publish-packages]
-    uses: falcosecurity/falco/.github/workflows/reusable_build_docker.yaml@master
+    uses: ./.github/workflows/reusable_build_docker.yaml
     with:
       arch: aarch64
       bucket_suffix: ${{ needs.release-settings.outputs.bucket_suffix }}
@@ -97,7 +97,7 @@ jobs:
 
   publish-docker:
     needs: [release-settings, build-docker, build-docker-arm64]
-    uses: falcosecurity/falco/.github/workflows/reusable_publish_docker.yaml@master
+    uses: ./.github/workflows/reusable_publish_docker.yaml
     secrets: inherit
     with:
       is_latest: ${{ needs.release-settings.outputs.is_latest == 'true' }}


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup
/area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Originally, the reusable workflows were pinned on the `master` branch. This is ok-ish but since we have a release model based on release branches this means that if a PR gets into master that modifies the release process (e.g. by changing some compilation option) we may break releases and have issues when we try to issue a patch release.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
