### PR TITLE
fix(userspace/falco): don't hang on terminating error when multi sourcing

### DIFF
--- a/userspace/falco/app/actions/process_events.cpp
+++ b/userspace/falco/app/actions/process_events.cpp
@@ -532,14 +532,6 @@ falco::app::run_result falco::app::actions::process_events(falco::app::state& s)
 		size_t closed_count = 0;
 		while (closed_count < ctxs.size())
 		{
-			// This is shared across all running event source threads an
-			// keeps the main thread sleepy until one of the parallel
-			// threads terminates and invokes release(). At that point,
-			// we know that at least one thread finished running and we can
-			// attempt joining it. Not that this also works when only one
-			// event source is enabled, in which we have no additional threads.
-			termination_sem.acquire();
-
 			if (!res.success && !termination_forced)
 			{
 				falco_logger::log(LOG_INFO, "An error occurred in an event source, forcing termination...\n");
@@ -547,6 +539,14 @@ falco::app::run_result falco::app::actions::process_events(falco::app::state& s)
 				falco::app::g_terminate_signal.handle([&](){});
 				termination_forced = true;
 			}
+
+			// This is shared across all running event source threads an
+			// keeps the main thread sleepy until one of the parallel
+			// threads terminates and invokes release(). At that point,
+			// we know that at least one thread finished running and we can
+			// attempt joining it. Not that this also works when only one
+			// event source is enabled, in which we have no additional threads.
+			termination_sem.acquire();
 
 			for (auto &ctx : ctxs)
 			{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

When in multi-source mode, any failure of one event source should cause the others to be forcefully terminated too. This PR solves a bug that caused Falco to hang on a semaphore when the `syscall` source was the one terminating with error.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/falco): don't hang on terminating error when multi sourcing
```
