### PR TITLE
chore(userspace/falco): always print invalid syscalls from custom set

### DIFF
--- a/userspace/falco/app/actions/configure_interesting_sets.cpp
+++ b/userspace/falco/app/actions/configure_interesting_sets.cpp
@@ -91,6 +91,7 @@ static void select_event_set(falco::app::state& s, const libsinsp::events::set<p
 	auto user_positive_sc_set = libsinsp::events::event_names_to_sc_set(user_positive_names);
 	auto user_negative_sc_set = libsinsp::events::event_names_to_sc_set(user_negative_names);
 
+	auto user_positive_sc_set_names = libsinsp::events::sc_set_to_event_names(user_positive_sc_set);
 	if (!user_positive_sc_set.empty())
 	{
 		// user overrides base event set
@@ -98,16 +99,15 @@ static void select_event_set(falco::app::state& s, const libsinsp::events::set<p
 
 		// we re-transform from sc_set to names to make
 		// sure that bad user inputs are ignored
-		auto user_positive_sc_set_names = libsinsp::events::sc_set_to_event_names(user_positive_sc_set);
 		falco_logger::log(LOG_DEBUG, "+(" + std::to_string(user_positive_sc_set_names.size())
 			+ ") syscalls added (base_syscalls override): "
 			+ concat_set_in_order(user_positive_sc_set_names) + "\n");
-		auto invalid_positive_sc_set_names = unordered_set_difference(user_positive_names, user_positive_sc_set_names);
-		if (!invalid_positive_sc_set_names.empty())
-		{
-			falco_logger::log(LOG_WARNING, "Invalid (positive) syscall names: warning (base_syscalls override): "
-				+ concat_set_in_order(invalid_positive_sc_set_names));
-		}
+	}
+	auto invalid_positive_sc_set_names = unordered_set_difference(user_positive_names, user_positive_sc_set_names);
+	if (!invalid_positive_sc_set_names.empty())
+	{
+		falco_logger::log(LOG_WARNING, "Invalid (positive) syscall names: warning (base_syscalls override): "
+			+ concat_set_in_order(invalid_positive_sc_set_names));
 	}
 
 	// selected events are the union of the rules events set and the
@@ -127,6 +127,7 @@ static void select_event_set(falco::app::state& s, const libsinsp::events::set<p
 		s.selected_sc_set = libsinsp::events::sinsp_repair_state_sc_set(rules_sc_set);
 	}
 
+	auto user_negative_sc_set_names = libsinsp::events::sc_set_to_event_names(user_negative_sc_set);
 	if (!user_negative_sc_set.empty())
 	{
 		/* Remove negative base_syscalls events. */
@@ -134,16 +135,15 @@ static void select_event_set(falco::app::state& s, const libsinsp::events::set<p
 
 		// we re-transform from sc_set to names to make
 		// sure that bad user inputs are ignored
-		auto user_negative_sc_set_names = libsinsp::events::sc_set_to_event_names(user_negative_sc_set);
 		falco_logger::log(LOG_DEBUG, "-(" + std::to_string(user_negative_sc_set_names.size())
 			+ ") syscalls removed (base_syscalls override): "
 			+ concat_set_in_order(user_negative_sc_set_names) + "\n");
-		auto invalid_negative_sc_set_names = unordered_set_difference(user_negative_names, user_negative_sc_set_names);
-		if (!invalid_negative_sc_set_names.empty())
-		{
-			falco_logger::log(LOG_WARNING, "Invalid (negative) syscall names: warning (base_syscalls override): "
-				+ concat_set_in_order(invalid_negative_sc_set_names));
-		}
+	}
+	auto invalid_negative_sc_set_names = unordered_set_difference(user_negative_names, user_negative_sc_set_names);
+	if (!invalid_negative_sc_set_names.empty())
+	{
+		falco_logger::log(LOG_WARNING, "Invalid (negative) syscall names: warning (base_syscalls override): "
+			+ concat_set_in_order(invalid_negative_sc_set_names));
 	}
 
 	/* Derive the diff between the additional syscalls added via libsinsp state


### PR DESCRIPTION
Co-authored-by: Roberto Scolaro <roberto.scolaro21@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

When we insert only one bad entry in the `base_syscall.custom_set` sequence (or a sequence of bad entries), Falco fails to output the "invalid syscalls" warning because it sees the custom set as empty, given that it crops the invalid values. This PR makes sure that the warning is always printed.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
chore(userspace/falco): always print invalid syscalls from custom set
```
