### PR TITLE
feat: add jq and curl to falco-no-driver docker image

### DIFF
--- a/docker/no-driver/Dockerfile
+++ b/docker/no-driver/Dockerfile
@@ -27,7 +27,8 @@ LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 LABEL usage="docker run -i -t --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro --name NAME IMAGE"
 # NOTE: for the "least privileged" use case, please refer to the official documentation
 
-RUN apt-get -y update && apt-get -y install ca-certificates
+RUN apt-get -y update && apt-get -y install ca-certificates curl jq \
+    && apt clean -y && rm -rf /var/lib/apt/lists/*
 
 ENV HOST_ROOT /host
 ENV HOME /root


### PR DESCRIPTION
To supoprt the use of outputs that are documented in the falco
examples (e.g. jq piped to curl) I would like to propose including
these tools in the falco-no-driver image. They add a very minimal
size and dependency to the image but would make things a lot easier
for users getting started.

Closes #2580

Signed-off-by: Daniel Wright <danielwright@bitgo.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature 

**Any specific area of the project related to this PR?**

/area build
/area ci

**What this PR does / why we need it**:
This PR adds the jq and curl packages to the falco-no-driver
Docker image. This will allow users who choose to use this
image to get up and running more quickly with the examples
listed in the documentation for outputs, such as the program
output.

**Which issue(s) this PR fixes**:

Fixes #2580

**Does this PR introduce a user-facing change?**:
Adds the curl and jq packages to the falco-no-driver docker image


```release-note
feat: add the curl and jq packages to the falco-no-driver docker image
```
