### PR TITLE
fix(userspace/falco): report plugin deps rules issues in any case

### DIFF
--- a/userspace/falco/app/actions/load_rules_files.cpp
+++ b/userspace/falco/app/actions/load_rules_files.cpp
@@ -87,7 +87,7 @@ falco::app::run_result falco::app::actions::load_rules_files(falco::app::state& 
 
 	// note: we have an egg-and-chicken problem here. We would like to check
 	// plugin requirements before loading any rule, so that we avoid having
-	// all the "unkwown field XXX" errors caused when a plugin is required but
+	// all the "unknown field XXX" errors caused when a plugin is required but
 	// not loaded. On the other hand, we can't check the requirements before
 	// loading the rules file, because that's where the plugin dependencies
 	// are specified. This issue is visible only for dependencies over extractor


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

We have an egg-and-chicken problem here. We would like to check plugin requirements before loading any rule, so that we avoid having all the "unkwown field XXX" errors caused when a plugin is required but not loaded. On the other hand, we can't check the requirements before loading the rules file, because that's where the plugin dependencies are specified. This issue is visible only for dependencies over extractor plugins, due to the fact that if a source plugin is not loaded, its source will be unknown for the engine and so it will skip loading all of the rules to that source, to finally end up here and return a fatal error due to plugin dependency not satisfied being the actual problem.

The long-term solution would be to pass information about all the loaded plugins to the falco engine before or when loading a rules file, so that plugin version checks can be performed properly by the engine, just like it does for the engine version requirement. On the other hand, This also requires refactoring a big chunk of the API and code of the engine responsible of loading rules.

Since we're close to releasing Falco v0.35, the chosen workaround is to first collect any error from the engine, then checking if there is also a version dependency not being satisfied, and give that failure cause priority in case we encounter it. This is indeed not perfect, but suits us for the time being. The non-covered corner case is when the `required_plugin_versions` YAML block is defined after the first rule definition (which is wrong anyways but currently allowed by the engine), in which case Falco would stop at the first error (which behavior we'll still want to change in the near future), not collect the plugin deps info, and the version checks will pass with success wrongly due to no requirement definition being read by the engine yet.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/falco): report plugin deps rules issues in any case
```
