### PR TITLE
feat: add image source OCI label to docker images

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -3,6 +3,7 @@ FROM centos:7
 LABEL name="falcosecurity/falco-builder"
 LABEL usage="docker run -v $PWD/..:/source -v $PWD/build:/build falcosecurity/falco-builder cmake"
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
 
 ARG BUILD_TYPE=release
 ARG BUILD_DRIVER=OFF

--- a/docker/builder/modern-falco-builder.Dockerfile
+++ b/docker/builder/modern-falco-builder.Dockerfile
@@ -34,6 +34,8 @@ RUN make all -j${MAKE_JOBS}
 
 FROM scratch AS export-stage
 
+LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
+
 ARG DEST_BUILD_DIR="/build"
 
 COPY --from=build-stage /build/release/falco-*.tar.gz /packages/

--- a/docker/driver-loader/Dockerfile
+++ b/docker/driver-loader/Dockerfile
@@ -2,6 +2,7 @@ ARG FALCO_IMAGE_TAG=latest
 FROM docker.io/falcosecurity/falco:${FALCO_IMAGE_TAG}
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
 
 LABEL usage="docker run -i -t --privileged -v /root/.falco:/root/.falco -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc:ro --name NAME IMAGE"
 

--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:buster
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
 
 LABEL usage="docker run -i -t --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc --name NAME IMAGE"
 

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:buster
 
 LABEL usage="docker run -i -t -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --name NAME IMAGE"
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
 
 ARG TARGETARCH
 

--- a/docker/no-driver/Dockerfile
+++ b/docker/no-driver/Dockerfile
@@ -23,6 +23,7 @@ RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /falco/
 FROM debian:11-slim
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
 
 LABEL usage="docker run -i -t --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro --name NAME IMAGE"
 # NOTE: for the "least privileged" use case, please refer to the official documentation

--- a/docker/tester/Dockerfile
+++ b/docker/tester/Dockerfile
@@ -3,6 +3,7 @@ FROM fedora:31
 LABEL name="falcosecurity/falco-tester"
 LABEL usage="docker run -v /boot:/boot:ro -v /var/run/docker.sock:/var/run/docker.sock -v $PWD/..:/source -v $PWD/build:/build --name <name> falcosecurity/falco-tester test"
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
 
 ARG TARGETARCH
 

--- a/docker/ubi/Dockerfile
+++ b/docker/ubi/Dockerfile
@@ -15,6 +15,7 @@ LABEL "description"="Falco is a security policy engine that monitors system call
 LABEL "io.k8s.display-name"="Falco"
 LABEL "io.k8s.description"="Falco is a security policy engine that monitors system calls and cloud events, and fires alerts when security policies are violated."
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
 LABEL usage="docker run -i -t --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc --name NAME IMAGE"
 
 


### PR DESCRIPTION
Closes #2591

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build
/area CI

**What this PR does / why we need it**:

This PR changes nothing from a functional perspective. It adds
the standard image source label from the Open Containers label
spec. More info can be found [here](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys).

This will allow tools such as renovate to take advantage of changelogs
when the falco repository is updated.

**Which issue(s) this PR fixes**:

Fixes #2591

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
feat: add image source OCI label to docker images
```
