### PR TITLE
fix: unquote quoted URL's to avoid libcurl errors

### DIFF
--- a/userspace/falco/outputs_http.cpp
+++ b/userspace/falco/outputs_http.cpp
@@ -38,9 +38,18 @@ void falco::outputs::output_http::output(const message *msg)
 
 		if(res == CURLE_OK)
 		{
-			res = curl_easy_setopt(curl, CURLOPT_URL, m_oc.options["url"].c_str());
+			// if the URL is quoted the quotes should be removed to satisfy libcurl expected format
+			std::string unquotedUrl = m_oc.options["url"];
+			if (!unquotedUrl.empty() && (
+				(unquotedUrl.front() == '\"' && unquotedUrl.back() == '\"') ||
+				(unquotedUrl.front() == '\'' && unquotedUrl.back() == '\'')
+			))
+			{
+				unquotedUrl = libsinsp::filter::unescape_str(unquotedUrl);
+			}
+			res = curl_easy_setopt(curl, CURLOPT_URL, unquotedUrl.c_str());
 		}
-		
+
 		if(res == CURLE_OK)
 		{
 			res = curl_easy_setopt(curl, CURLOPT_POSTFIELDS, msg->msg.c_str());
@@ -55,7 +64,7 @@ void falco::outputs::output_http::output(const message *msg)
 		{
 		   res = curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, -1L);
 		}
-		
+
 		if(res == CURLE_OK)
 		{
 			if(m_oc.options["insecure"] == std::string("true"))
@@ -81,7 +90,7 @@ void falco::outputs::output_http::output(const message *msg)
 				res = curl_easy_setopt(curl, CURLOPT_CAPATH, m_oc.options["ca_path"].c_str());
 			}
 		}
-		
+
   		if(res == CURLE_OK)
 		{
 			res = curl_easy_perform(curl);


### PR DESCRIPTION
This commit will unquote URL's allowing them to be supported by
libcurl and eliminate any errors when a valid (quoted) URL is supplied
by a user.

Closes #2579

Signed-off-by: Daniel Wright danielwright@bitgo.com

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:
As mentioned in the associated issue, I was setting up some
values which contained special character as the URL had a
secret token in it, and wanted to quote to avoid any ambiguity
or issues when adding to a manifest. I encountered a libcurl
error that my valid (quoted) string was invalid.

**Which issue(s) this PR fixes**:
Fixes #2579

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
N/A

```release-note
fix: unquote quoted URL's to avoid libcurl errors
```
