### PR TITLE
fix(scripts): support debian kernel flavors other than normal in falco-driver-loader

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -151,11 +151,17 @@ get_target_id() {
 		# Real kernel release is embedded inside the kernel version.
 		# Moreover, kernel arch, when present, is attached to the former,
 		# therefore make sure to properly take it and attach it to the latter.
+		# Moreover, we support 3 flavors for debian kernels: cloud, rt and normal.
+		# KERNEL-RELEASE will have a `-rt`, or `-cloud` if we are in one of these flavors.
+		# Manage it to download the correct driver.
+		#
+		# Example: KERNEL_RELEASE="5.10.0-0.deb10.22-rt-amd64" and `uname -v`="5.10.178-3"
+		# should lead to: KERNEL_RELEASE="5.10.178-3-rt-amd64"
 		TARGET_ID=$(echo "${OS_ID}" | tr '[:upper:]' '[:lower:]')
 		local ARCH_extra=""
-		if [[ $KERNEL_RELEASE =~ -(amd64|arm64) ]];
+		if [[ $KERNEL_RELEASE =~ -?(rt-|cloud-|)(amd64|arm64) ]];
 		then
-			ARCH_extra="-${BASH_REMATCH[1]}"
+			ARCH_extra="-${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
 		fi
 		if [[ $(uname -v) =~ ([0-9]+\.[0-9]+\.[0-9]+\-[0-9]+) ]];
 		then


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

Support debian `rt` and `cloud` flavors.
See https://github.com/falcosecurity/falco/issues/2625 issue for more info.
Basically, kernel-crawler is going to be fixed to properly output flavored debian kernels, see https://github.com/falcosecurity/kernel-crawler/pull/147.
For Falco 0.35.0, we are only supporting the normal (ie: the one without suffix) kernel flavor; with this patch we will support `rt` and `cloud` too.

**Which issue(s) this PR fixes**:

Fixes #2625

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(scripts): fixed falco-driver-loader to manage debian kernel rt and cloud flavors.
```
