### PR TITLE
fix(ci): fixed publish deb packages with new debian bookworm

### DIFF
--- a/.github/workflows/reusable_publish_packages.yaml
+++ b/.github/workflows/reusable_publish_packages.yaml
@@ -117,7 +117,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt update -y
-          apt-get install apt-utils bzip2 gpg python python3-pip -y
+          apt-get install apt-utils bzip2 gpg python-is-python3 python3-pip -y
           pip install awscli
       
       # Configure AWS role; see https://github.com/falcosecurity/test-infra/pull/1102

--- a/.github/workflows/reusable_publish_packages.yaml
+++ b/.github/workflows/reusable_publish_packages.yaml
@@ -117,8 +117,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt update -y
-          apt-get install apt-utils bzip2 gpg python-is-python3 python3-pip -y
-          pip install awscli
+          apt-get install apt-utils bzip2 gpg awscli -y
       
       # Configure AWS role; see https://github.com/falcosecurity/test-infra/pull/1102
       # Note: master CI can only push dev packages as we have 2 different roles for master and release.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

New debian bookworm, release on 10th of June, dropped python2 package.
Instead, we need to install `python-is-python3` package that creates the symlink for `/usr/bin/python3` to `/usr/bin/python`.

**Which issue(s) this PR fixes**:

Fixes CI.

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
