### PR TITLE
fix(userspace): switch to timer_settime API for stats writer.

### DIFF
--- a/userspace/falco/stats_writer.cpp
+++ b/userspace/falco/stats_writer.cpp
@@ -50,7 +50,7 @@ bool stats_writer::init_ticker(uint32_t interval_msec, std::string &err)
 		err = std::string("Could not set up signal handler for periodic timer: ") + strerror(errno);
 		return false;
 	}
-
+	
 	timer_t timerid;
 	struct sigevent sev = {};
 	/* Create the timer */
@@ -69,11 +69,6 @@ bool stats_writer::init_ticker(uint32_t interval_msec, std::string &err)
 		err = std::string("Could not set up periodic timer: ") + strerror(errno);
 		return false;
 	}
-	//if (setitimer(ITIMER_REAL, &timer, NULL) == -1)
-	//{
-	//	err = std::string("Could not set up periodic timer: ") + strerror(errno);
-	//	return false;
-	//}
 
 	return true;
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Switched to use `timer_settime` API in stats writer, as `setitimer` seems to have issues when built from our CI (glibc/gcc bugs?)

**Which issue(s) this PR fixes**:

Fixes #2645 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace): switch to timer_settime API for stats writer.
```
