### PR TITLE
fix(userspace/falco): solve live multi-source issues when loading more than two sources

### DIFF
--- a/userspace/falco/app/actions/helpers_generic.cpp
+++ b/userspace/falco/app/actions/helpers_generic.cpp
@@ -39,8 +39,17 @@ bool falco::app::actions::check_rules_plugin_requirements(falco::app::state& s, 
 
 void falco::app::actions::print_enabled_event_sources(falco::app::state& s)
 {
-	/* Print all enabled sources. */
+	/* Print all loaded sources. */
 	std::string str;
+	for (const auto &src : s.loaded_sources)
+	{
+		str += str.empty() ? "" : ", ";
+		str += src;
+	}
+	falco_logger::log(LOG_INFO, "Loaded event sources: " + str);
+
+	/* Print all enabled sources. */
+	str.clear();
 	for (const auto &src : s.enabled_sources)
 	{
 		str += str.empty() ? "" : ", ";

--- a/userspace/falco/app/actions/init_inspectors.cpp
+++ b/userspace/falco/app/actions/init_inspectors.cpp
@@ -187,6 +187,23 @@ falco::app::run_result falco::app::actions::init_inspectors(falco::app::state& s
 		{
 			return run_result::fatal(err);
 		}
+
+		// in live mode, each inspector should have registered at most two event sources:
+		// the "syscall" on, loaded at default at index 0, and optionally another
+		// one defined by a plugin, at index 0
+		if (!s.is_capture_mode())
+		{
+			const auto& sources = src_info->inspector->event_sources();
+			if (sources.size() == 0 || sources.size() > 2 || sources[0] != falco_common::syscall_source)
+			{
+				std::string err;
+				for (const auto &s : sources)
+				{
+					err += (err.empty() ? "" : ", ") + s;
+				}
+				return run_result::fatal("Illegal sources setup in live inspector for source '" + src + "': " + err);
+			}
+		}
 	}
 
 	// check if some plugin remains unused


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This fixes #2652, which caused Falco to fail when loading more than two simultaneous event sources for live event captures. The flaw was on a wrongly-implemented safety check, that caused Falco to fail even on legit situations.

**Which issue(s) this PR fixes**:

Fixes #2652

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/falco): solve live multi-source issues when loading more than two sources
```
