### PR TITLE
wip: cleanup(config): new json_output_properties flags and output options consolidation

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -240,7 +240,28 @@ priority: debug
 # programs to process and consume the data. By default, this option is disabled.
 json_output: false
 
-# [Stable] `json_include_output_property`
+# [Experimental] `json_output_properties`
+#
+# Customize the verbosity of JSON log lines.
+# The fields `rule` and `time` are not configurable. The fields `desc` and
+# `condition` cannot be included in the logs.
+# The `output` field represents the resolved output values as a string line,
+# while `output_fields` represents a formatted sub JSON containing fields
+# according to the rules' `output` definition.
+#
+# It is not recommended to include tags in order to save space and 
+# reduce logging volume. In addition, likely you only need either `output`
+# or `output_fields`. If you only have syscall rules, you can also skip
+# including the `source` field.
+json_output_properties:
+  output: true
+  priority: true
+  tags: true
+  hostname: true
+  source: true
+  output_fields: true
+
+# [Deprecation Notice for Falco 0.37] `json_include_output_property`
 #
 # When using JSON output in Falco, you have the option to include the "output"
 # property itself in the generated JSON output. The "output" property provides
@@ -249,7 +270,7 @@ json_output: false
 # case.
 json_include_output_property: true
 
-# [Stable] `json_include_tags_property`
+# [Deprecation Notice for Falco 0.37] `json_include_tags_property`
 #
 # When using JSON output in Falco, you have the option to include the "tags"
 # field of the rules in the generated JSON output. The "tags" field provides

--- a/userspace/engine/formats.cpp
+++ b/userspace/engine/formats.cpp
@@ -22,12 +22,8 @@ limitations under the License.
 #include "banned.h" // This raises a compilation error when certain functions are used
 
 falco_formats::falco_formats(std::shared_ptr<const falco_engine> engine,
-			     bool json_include_output_property,
-			     bool json_include_tags_property,
 				 uint32_t json_output_flags)
 	: m_falco_engine(engine),
-	m_json_include_output_property(json_include_output_property),
-	m_json_include_tags_property(json_include_tags_property),
 	m_json_output_flags(json_output_flags)
 {
 }
@@ -98,11 +94,11 @@ std::string falco_formats::format_event(gen_event *evt, const std::string &rule,
 		{
 			event["hostname"] = hostname;
 		}
-		if(m_json_output_flags & CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT && m_json_include_output_property)
+		if(m_json_output_flags & CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT && m_json_output_flags & CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT_OLD_OPTION)
 		{
 			event["output"] = line;
 		}
-		if(m_json_output_flags & CONFIG_JSON_OUTPUT_PROPERTIES_TAGS && m_json_include_tags_property)
+		if(m_json_output_flags & CONFIG_JSON_OUTPUT_PROPERTIES_TAGS && m_json_output_flags & CONFIG_JSON_OUTPUT_PROPERTIES_TAGS_OLD_OPTION)
 		{
 			if (tags.size() == 0)
 			{

--- a/userspace/engine/formats.h
+++ b/userspace/engine/formats.h
@@ -25,8 +25,6 @@ class falco_formats
 {
 public:
 	falco_formats(std::shared_ptr<const falco_engine> engine,
-		      bool json_include_output_property,
-		      bool json_include_tags_property,
 			  uint32_t json_output_flags);
 	virtual ~falco_formats();
 
@@ -39,7 +37,5 @@ public:
 
 protected:
 	std::shared_ptr<const falco_engine> m_falco_engine;
-	bool m_json_include_output_property;
-	bool m_json_include_tags_property;
 	uint32_t m_json_output_flags;
 };

--- a/userspace/engine/formats.h
+++ b/userspace/engine/formats.h
@@ -26,7 +26,8 @@ class falco_formats
 public:
 	falco_formats(std::shared_ptr<const falco_engine> engine,
 		      bool json_include_output_property,
-		      bool json_include_tags_property);
+		      bool json_include_tags_property,
+			  uint32_t json_output_flags);
 	virtual ~falco_formats();
 
 	std::string format_event(gen_event *evt, const std::string &rule, const std::string &source,
@@ -40,4 +41,5 @@ protected:
 	std::shared_ptr<const falco_engine> m_falco_engine;
 	bool m_json_include_output_property;
 	bool m_json_include_tags_property;
+	uint32_t m_json_output_flags;
 };

--- a/userspace/falco/app/actions/init_outputs.cpp
+++ b/userspace/falco/app/actions/init_outputs.cpp
@@ -61,6 +61,7 @@ falco::app::run_result falco::app::actions::init_outputs(falco::app::state& s)
 		s.config->m_json_output,
 		s.config->m_json_include_output_property,
 		s.config->m_json_include_tags_property,
+		s.config->m_json_output_flags,
 		s.config->m_output_timeout,
 		s.config->m_buffered_outputs,
 		s.config->m_time_format_iso_8601,

--- a/userspace/falco/app/actions/init_outputs.cpp
+++ b/userspace/falco/app/actions/init_outputs.cpp
@@ -59,8 +59,6 @@ falco::app::run_result falco::app::actions::init_outputs(falco::app::state& s)
 		s.engine,
 		s.config->m_outputs,
 		s.config->m_json_output,
-		s.config->m_json_include_output_property,
-		s.config->m_json_include_tags_property,
 		s.config->m_json_output_flags,
 		s.config->m_output_timeout,
 		s.config->m_buffered_outputs,

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -28,6 +28,7 @@ limitations under the License.
 #include "falco_utils.h"
 
 #include "configuration.h"
+#include "configuration_aux.h"
 #include "logger.h"
 #include "banned.h" // This raises a compilation error when certain functions are used
 
@@ -35,6 +36,10 @@ falco_configuration::falco_configuration():
 	m_json_output(false),
 	m_json_include_output_property(true),
 	m_json_include_tags_property(true),
+	m_json_output_flags(CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT \
+			| CONFIG_JSON_OUTPUT_PROPERTIES_PRIORITY | CONFIG_JSON_OUTPUT_PROPERTIES_TAGS \
+			| CONFIG_JSON_OUTPUT_PROPERTIES_HOSTNAME | CONFIG_JSON_OUTPUT_PROPERTIES_SOURCE \
+			| CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT_FIELDS),
 	m_notifications_rate(0),
 	m_notifications_max_burst(1000),
 	m_watch_config_files(true),
@@ -119,8 +124,38 @@ void falco_configuration::load_yaml(const std::string& config_name, const yaml_h
 	}
 
 	m_json_output = config.get_scalar<bool>("json_output", false);
+	// todo: deprecate `m_json_include_output_property` and `m_json_include_tags_property` for Falco 0.37
 	m_json_include_output_property = config.get_scalar<bool>("json_include_output_property", true);
 	m_json_include_tags_property = config.get_scalar<bool>("json_include_tags_property", true);
+
+	m_json_output_flags = 0;
+	if(config.get_scalar<bool>("json_output", false))
+	{
+		if(config.get_scalar<bool>("json_output_properties.output", true))
+		{
+			m_json_output_flags |= CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT;
+		}
+		if(config.get_scalar<bool>("json_output_properties.priority", true))
+		{
+			m_json_output_flags |= CONFIG_JSON_OUTPUT_PROPERTIES_PRIORITY;
+		}
+		if(config.get_scalar<bool>("json_output_properties.tags", true))
+		{
+			m_json_output_flags |= CONFIG_JSON_OUTPUT_PROPERTIES_TAGS;
+		}
+		if(config.get_scalar<bool>("json_output_properties.hostname", true))
+		{
+			m_json_output_flags |= CONFIG_JSON_OUTPUT_PROPERTIES_HOSTNAME;
+		}
+		if(config.get_scalar<bool>("json_output_properties.source", true))
+		{
+			m_json_output_flags |= CONFIG_JSON_OUTPUT_PROPERTIES_SOURCE;
+		}
+		if(config.get_scalar<bool>("json_output_properties.output_fields", true))
+		{
+			m_json_output_flags |= CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT_FIELDS;
+		}
+	}
 
 	m_outputs.clear();
 	falco::outputs::config file_output;

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -34,12 +34,11 @@ limitations under the License.
 
 falco_configuration::falco_configuration():
 	m_json_output(false),
-	m_json_include_output_property(true),
-	m_json_include_tags_property(true),
 	m_json_output_flags(CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT \
 			| CONFIG_JSON_OUTPUT_PROPERTIES_PRIORITY | CONFIG_JSON_OUTPUT_PROPERTIES_TAGS \
 			| CONFIG_JSON_OUTPUT_PROPERTIES_HOSTNAME | CONFIG_JSON_OUTPUT_PROPERTIES_SOURCE \
-			| CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT_FIELDS),
+			| CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT_FIELDS | CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT_OLD_OPTION \
+			| CONFIG_JSON_OUTPUT_PROPERTIES_TAGS_OLD_OPTION),
 	m_notifications_rate(0),
 	m_notifications_max_burst(1000),
 	m_watch_config_files(true),
@@ -124,12 +123,8 @@ void falco_configuration::load_yaml(const std::string& config_name, const yaml_h
 	}
 
 	m_json_output = config.get_scalar<bool>("json_output", false);
-	// todo: deprecate `m_json_include_output_property` and `m_json_include_tags_property` for Falco 0.37
-	m_json_include_output_property = config.get_scalar<bool>("json_include_output_property", true);
-	m_json_include_tags_property = config.get_scalar<bool>("json_include_tags_property", true);
-
 	m_json_output_flags = 0;
-	if(config.get_scalar<bool>("json_output", false))
+	if(m_json_output)
 	{
 		if(config.get_scalar<bool>("json_output_properties.output", true))
 		{
@@ -154,6 +149,15 @@ void falco_configuration::load_yaml(const std::string& config_name, const yaml_h
 		if(config.get_scalar<bool>("json_output_properties.output_fields", true))
 		{
 			m_json_output_flags |= CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT_FIELDS;
+		}
+		// todo: deprecate `json_include_output_property` and `json_include_tags_property` for Falco 0.37
+		if(config.get_scalar<bool>("json_include_output_property", true))
+		{
+			m_json_output_flags |= CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT_OLD_OPTION;
+		}
+		if(config.get_scalar<bool>("json_include_tags_property", true))
+		{
+			m_json_output_flags |= CONFIG_JSON_OUTPUT_PROPERTIES_TAGS_OLD_OPTION;
 		}
 	}
 

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -59,8 +59,6 @@ public:
 	// List of loaded rule folders
 	std::list<std::string> m_loaded_rules_folders;
 	bool m_json_output;
-	bool m_json_include_output_property;
-	bool m_json_include_tags_property;
 	uint32_t m_json_output_flags;
 	std::string m_log_level;
 	std::vector<falco::outputs::config> m_outputs;

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -61,6 +61,7 @@ public:
 	bool m_json_output;
 	bool m_json_include_output_property;
 	bool m_json_include_tags_property;
+	uint32_t m_json_output_flags;
 	std::string m_log_level;
 	std::vector<falco::outputs::config> m_outputs;
 	uint32_t m_notifications_rate;

--- a/userspace/falco/configuration_aux.h
+++ b/userspace/falco/configuration_aux.h
@@ -25,3 +25,5 @@ limitations under the License.
 #define CONFIG_JSON_OUTPUT_PROPERTIES_HOSTNAME (1 << 3)
 #define CONFIG_JSON_OUTPUT_PROPERTIES_SOURCE (1 << 4)
 #define CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT_FIELDS (1 << 5)
+#define CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT_OLD_OPTION (1 << 6) // todo: deprecate for Falco 0.37
+#define CONFIG_JSON_OUTPUT_PROPERTIES_TAGS_OLD_OPTION (1 << 7) // todo: deprecate for Falco 0.37

--- a/userspace/falco/configuration_aux.h
+++ b/userspace/falco/configuration_aux.h
@@ -1,0 +1,27 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+//
+// json_output_properties flags
+//
+#define CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT (1 << 0)
+#define CONFIG_JSON_OUTPUT_PROPERTIES_PRIORITY (1 << 1)
+#define CONFIG_JSON_OUTPUT_PROPERTIES_TAGS (1 << 2)
+#define CONFIG_JSON_OUTPUT_PROPERTIES_HOSTNAME (1 << 3)
+#define CONFIG_JSON_OUTPUT_PROPERTIES_SOURCE (1 << 4)
+#define CONFIG_JSON_OUTPUT_PROPERTIES_OUTPUT_FIELDS (1 << 5)

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -45,12 +45,13 @@ falco_outputs::falco_outputs(
 	bool json_output,
 	bool json_include_output_property,
 	bool json_include_tags_property,
+	uint32_t json_output_flags,
 	uint32_t timeout,
 	bool buffered,
 	bool time_format_iso_8601,
 	const std::string& hostname)
 {
-	m_formats.reset(new falco_formats(engine, json_include_output_property, json_include_tags_property));
+	m_formats.reset(new falco_formats(engine, json_include_output_property, json_include_tags_property, json_output_flags));
 
 	m_json_output = json_output;
 

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -43,15 +43,13 @@ falco_outputs::falco_outputs(
 	std::shared_ptr<falco_engine> engine,
 	const std::vector<falco::outputs::config>& outputs,
 	bool json_output,
-	bool json_include_output_property,
-	bool json_include_tags_property,
 	uint32_t json_output_flags,
 	uint32_t timeout,
 	bool buffered,
 	bool time_format_iso_8601,
 	const std::string& hostname)
 {
-	m_formats.reset(new falco_formats(engine, json_include_output_property, json_include_tags_property, json_output_flags));
+	m_formats.reset(new falco_formats(engine, json_output_flags));
 
 	m_json_output = json_output;
 

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -44,6 +44,7 @@ public:
 		bool json_output,
 		bool json_include_output_property,
 		bool json_include_tags_property,
+		uint32_t json_output_flags,
 		uint32_t timeout,
 		bool buffered,
 		bool time_format_iso_8601,

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -42,8 +42,6 @@ public:
 		std::shared_ptr<falco_engine> engine,
 		const std::vector<falco::outputs::config>& outputs,
 		bool json_output,
-		bool json_include_output_property,
-		bool json_include_tags_property,
 		uint32_t json_output_flags,
 		uint32_t timeout,
 		bool buffered,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Redesign JSON log output fields options and expose configuration for most fields to give adopters more options to tailor the space of the log while maintaining backward compatibility.

This feature was requested by the community, CC @misterjulien

@jasondellaluce could get the python tests to run locally, but most of them failed meaning I am a bit unclear re how to add new tests to this PR , marking it as wip in the interim. Hoping you could give some pointers, thank you!

**Which issue(s) this PR fixes**:

https://github.com/falcosecurity/falco/issues/2628


<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
cleanup(config): new json_output_properties flags and output options consolidation
```
