### PR TITLE
new(falco): update the Falco base image to debian 12

### DIFF
--- a/.github/workflows/reusable_build_docker.yaml
+++ b/.github/workflows/reusable_build_docker.yaml
@@ -65,7 +65,15 @@ jobs:
             --build-arg TARGETARCH=${TARGETARCH} \
             .
             docker save docker.io/falcosecurity/falco-driver-loader:${{ inputs.arch }}-${{ inputs.tag }} --output /tmp/falco-driver-loader-${{ inputs.arch }}.tar
-            
+
+      - name: Build falco-driver-loader-legacy image
+        run: |
+          cd ${{ github.workspace }}/docker/driver-loader/
+          docker build -t docker.io/falcosecurity/falco-driver-loader-legacy:${{ inputs.arch }}-${{ inputs.tag }} \
+            --build-arg TARGETARCH=${TARGETARCH} \
+            .
+            docker save docker.io/falcosecurity/falco-driver-loader-legacy:${{ inputs.arch }}-${{ inputs.tag }} --output /tmp/falco-driver-loader-legacy-${{ inputs.arch }}.tar
+
       - name: Upload images tarballs
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/reusable_publish_docker.yaml
+++ b/.github/workflows/reusable_publish_docker.yaml
@@ -70,6 +70,8 @@ jobs:
           docker push docker.io/falcosecurity/falco:x86_64-${{ inputs.tag }}
           docker push docker.io/falcosecurity/falco-driver-loader:aarch64-${{ inputs.tag }}
           docker push docker.io/falcosecurity/falco-driver-loader:x86_64-${{ inputs.tag }}
+          docker push docker.io/falcosecurity/falco-driver-loader-legacy:aarch64-${{ inputs.tag }}
+          docker push docker.io/falcosecurity/falco-driver-loader-legacy:x86_64-${{ inputs.tag }}
 
       - name: Create no-driver manifest on Docker Hub
         uses: Noelware/docker-manifest-action@0.3.1
@@ -96,18 +98,27 @@ jobs:
           images: docker.io/falcosecurity/falco-driver-loader:aarch64-${{ inputs.tag }},docker.io/falcosecurity/falco-driver-loader:x86_64-${{ inputs.tag }}
           push: true
 
+      - name: Create falco-driver-loader-legacy manifest on Docker Hub
+        uses: Noelware/docker-manifest-action@0.3.1
+        with:
+          inputs: docker.io/falcosecurity/falco-driver-loader-legacy:${{ inputs.tag }}
+          images: docker.io/falcosecurity/falco-driver-loader-legacy:aarch64-${{ inputs.tag }},docker.io/falcosecurity/falco-driver-loader-legacy:x86_64-${{ inputs.tag }}
+          push: true
+
       - name: Get Digests for images
         id: digests
         run: |
           echo "falco-no-driver=$(crane digest docker.io/falcosecurity/falco-no-driver:${{ inputs.tag }})" >> $GITHUB_OUTPUT
           echo "falco=$(crane digest docker.io/falcosecurity/falco:${{ inputs.tag }})" >> $GITHUB_OUTPUT
           echo "falco-driver-loader=$(crane digest docker.io/falcosecurity/falco-driver-loader:${{ inputs.tag }})" >> $GITHUB_OUTPUT
+          echo "falco-driver-loader-legacy=$(crane digest docker.io/falcosecurity/falco-driver-loader-legacy:${{ inputs.tag }})" >> $GITHUB_OUTPUT
 
       - name: Publish images to ECR
         run: |
           crane copy docker.io/falcosecurity/falco-no-driver:${{ inputs.tag }} public.ecr.aws/falcosecurity/falco-no-driver:${{ inputs.tag }}
           crane copy docker.io/falcosecurity/falco:${{ inputs.tag }} public.ecr.aws/falcosecurity/falco:${{ inputs.tag }}
           crane copy docker.io/falcosecurity/falco-driver-loader:${{ inputs.tag }} public.ecr.aws/falcosecurity/falco-driver-loader:${{ inputs.tag }}
+          crane copy docker.io/falcosecurity/falco-driver-loader-legacy:${{ inputs.tag }} public.ecr.aws/falcosecurity/falco-driver-loader-legacy:${{ inputs.tag }}
           crane copy public.ecr.aws/falcosecurity/falco-no-driver:${{ inputs.tag }} public.ecr.aws/falcosecurity/falco:${{ inputs.tag }}-slim
 
       - name: Tag latest on Docker Hub and ECR
@@ -116,11 +127,13 @@ jobs:
           crane tag docker.io/falcosecurity/falco-no-driver:${{ inputs.tag }} latest
           crane tag docker.io/falcosecurity/falco:${{ inputs.tag }} latest
           crane tag docker.io/falcosecurity/falco-driver-loader:${{ inputs.tag }} latest
+          crane tag docker.io/falcosecurity/falco-driver-loader-legacy:${{ inputs.tag }} latest
           crane tag docker.io/falcosecurity/falco:${{ inputs.tag }}-slim latest-slim
 
           crane tag public.ecr.aws/falcosecurity/falco-no-driver:${{ inputs.tag }} latest
           crane tag public.ecr.aws/falcosecurity/falco:${{ inputs.tag }} latest
           crane tag public.ecr.aws/falcosecurity/falco-driver-loader:${{ inputs.tag }} latest
+          crane tag public.ecr.aws/falcosecurity/falco-driver-loader-legacy:${{ inputs.tag }} latest
           crane tag public.ecr.aws/falcosecurity/falco:${{ inputs.tag }}-slim latest-slim
 
       - name: Setup Cosign
@@ -138,7 +151,9 @@ jobs:
           cosign sign docker.io/falcosecurity/falco-no-driver@${{ steps.digests.outputs.falco-no-driver }}
           cosign sign docker.io/falcosecurity/falco@${{ steps.digests.outputs.falco }}
           cosign sign docker.io/falcosecurity/falco-driver-loader@${{ steps.digests.outputs.falco-driver-loader }}
+          cosign sign docker.io/falcosecurity/falco-driver-loader-legacy@${{ steps.digests.outputs.falco-driver-loader-legacy }}
 
           cosign sign public.ecr.aws/falcosecurity/falco-no-driver@${{ steps.digests.outputs.falco-no-driver }}
           cosign sign public.ecr.aws/falcosecurity/falco@${{ steps.digests.outputs.falco }}
           cosign sign public.ecr.aws/falcosecurity/falco-driver-loader@${{ steps.digests.outputs.falco-driver-loader }}
+          cosign sign public.ecr.aws/falcosecurity/falco-driver-loader-legacy@${{ steps.digests.outputs.falco-driver-loader-legacy }}

--- a/docker/driver-loader-legacy/Dockerfile
+++ b/docker/driver-loader-legacy/Dockerfile
@@ -1,0 +1,130 @@
+FROM debian:buster
+
+LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
+
+LABEL usage="docker run -i -t --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc --name NAME IMAGE"
+
+ARG TARGETARCH
+
+ARG FALCO_VERSION=latest
+ARG VERSION_BUCKET=deb
+ENV VERSION_BUCKET=${VERSION_BUCKET}
+
+ENV FALCO_VERSION=${FALCO_VERSION}
+ENV HOST_ROOT /host
+ENV HOME /root
+
+RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+	bash-completion \
+	bc \
+	bison \
+	clang-7 \
+	ca-certificates \
+	curl \
+	dkms \
+	flex \
+	gnupg2 \
+	gcc \
+	jq \
+	libc6-dev \
+	libelf-dev \
+	libssl-dev \
+	llvm-7 \
+	netcat \
+	patchelf \
+	xz-utils \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN if [ "$TARGETARCH" = "amd64" ]; \
+    then apt-get install -y --no-install-recommends libmpx2; \
+    fi
+
+# gcc 6 is no longer included in debian stable, but we need it to
+# build kernel modules on the default debian-based ami used by
+# kops. So grab copies we've saved from debian snapshots with the
+# prefix https://snapshot.debian.org/archive/debian/20170517T033514Z
+# or so.
+
+RUN if [ "$TARGETARCH" = "amd64" ]; then curl -L -o libcilkrts5_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libcilkrts5_6.3.0-18_${TARGETARCH}.deb; fi; \
+    curl -L -o cpp-6_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/cpp-6_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o gcc-6-base_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-6-base_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o gcc-6_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-6_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o libasan3_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libasan3_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o libubsan0_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libubsan0_6.3.0-18_${TARGETARCH}.deb \
+	&& curl -L -o libmpfr4_3.1.3-2_${TARGETARCH}.deb https://download.falco.org/dependencies/libmpfr4_3.1.3-2_${TARGETARCH}.deb \
+	&& curl -L -o libisl15_0.18-1_${TARGETARCH}.deb https://download.falco.org/dependencies/libisl15_0.18-1_${TARGETARCH}.deb \
+	&& dpkg -i cpp-6_6.3.0-18_${TARGETARCH}.deb gcc-6-base_6.3.0-18_${TARGETARCH}.deb gcc-6_6.3.0-18_${TARGETARCH}.deb libasan3_6.3.0-18_${TARGETARCH}.deb; \
+    if [ "$TARGETARCH" = "amd64" ]; then dpkg -i libcilkrts5_6.3.0-18_${TARGETARCH}.deb; fi; \
+    dpkg -i libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb libubsan0_6.3.0-18_${TARGETARCH}.deb libmpfr4_3.1.3-2_${TARGETARCH}.deb libisl15_0.18-1_${TARGETARCH}.deb \
+	&& rm -f cpp-6_6.3.0-18_${TARGETARCH}.deb gcc-6-base_6.3.0-18_${TARGETARCH}.deb gcc-6_6.3.0-18_${TARGETARCH}.deb libasan3_6.3.0-18_${TARGETARCH}.deb libcilkrts5_6.3.0-18_${TARGETARCH}.deb libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb libubsan0_6.3.0-18_${TARGETARCH}.deb libmpfr4_3.1.3-2_${TARGETARCH}.deb libisl15_0.18-1_${TARGETARCH}.deb
+
+# gcc 5 is no longer included in debian stable, but we need it to
+# build centos kernels, which are 3.x based and explicitly want a gcc
+# version 3, 4, or 5 compiler. So grab copies we've saved from debian
+# snapshots with the prefix https://snapshot.debian.org/archive/debian/20190122T000000Z.
+
+RUN if [ "$TARGETARCH" = "amd64" ]; then curl -L -o libmpx0_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/libmpx0_5.5.0-12_${TARGETARCH}.deb; fi; \
+    curl -L -o cpp-5_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/cpp-5_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o gcc-5-base_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-5-base_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o gcc-5_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-5_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o libasan2_5.5.0-12_${TARGETARCH}.deb	https://download.falco.org/dependencies/libasan2_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb \
+	&& curl -L -o libisl15_0.18-4_${TARGETARCH}.deb https://download.falco.org/dependencies/libisl15_0.18-4_${TARGETARCH}.deb \
+	&& dpkg -i cpp-5_5.5.0-12_${TARGETARCH}.deb gcc-5-base_5.5.0-12_${TARGETARCH}.deb gcc-5_5.5.0-12_${TARGETARCH}.deb libasan2_5.5.0-12_${TARGETARCH}.deb; \
+    if [ "$TARGETARCH" = "amd64" ]; then dpkg -i libmpx0_5.5.0-12_${TARGETARCH}.deb; fi; \
+    dpkg -i libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb libisl15_0.18-4_${TARGETARCH}.deb \
+	&& rm -f cpp-5_5.5.0-12_${TARGETARCH}.deb gcc-5-base_5.5.0-12_${TARGETARCH}.deb gcc-5_5.5.0-12_${TARGETARCH}.deb libasan2_5.5.0-12_${TARGETARCH}.deb libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb libisl15_0.18-4_${TARGETARCH}.deb libmpx0_5.5.0-12_${TARGETARCH}.deb
+
+# Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
+# default to gcc-5.
+RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-5 /usr/bin/gcc
+
+RUN rm -rf /usr/bin/clang \
+	&& rm -rf /usr/bin/llc \
+	&& ln -s /usr/bin/clang-7 /usr/bin/clang \
+	&& ln -s /usr/bin/llc-7 /usr/bin/llc
+
+RUN curl -s https://falco.org/repo/falcosecurity-packages.asc | apt-key add - \
+	&& echo "deb https://download.falco.org/packages/${VERSION_BUCKET} stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list \
+	&& apt-get update -y \
+	&& if [ "$FALCO_VERSION" = "latest" ]; then apt-get install -y --no-install-recommends falco; else apt-get install -y --no-install-recommends falco=${FALCO_VERSION}; fi \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Change the falco config within the container to enable ISO 8601
+# output.
+RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/falco/falco.yaml > /etc/falco/falco.yaml.new \
+	&& mv /etc/falco/falco.yaml.new /etc/falco/falco.yaml
+
+# Some base images have an empty /lib/modules by default
+# If it's not empty, docker build will fail instead of
+# silently overwriting the existing directory
+RUN rm -df /lib/modules \
+	&& ln -s $HOST_ROOT/lib/modules /lib/modules
+
+# debian:stable head contains binutils 2.31, which generates
+# binaries that are incompatible with kernels < 4.16. So manually
+# forcibly install binutils 2.30-22 instead.
+
+RUN if [ "$TARGETARCH" = "amd64" ] ; then \
+    curl -L -o binutils-x86-64-linux-gnu_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils-x86-64-linux-gnu_2.30-22_${TARGETARCH}.deb; \
+    else  \
+    curl -L -o  binutils-aarch64-linux-gnu_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils-aarch64-linux-gnu_2.30-22_${TARGETARCH}.deb; \
+    fi
+
+RUN curl -L -o binutils_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils_2.30-22_${TARGETARCH}.deb \
+	&& curl -L -o libbinutils_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/libbinutils_2.30-22_${TARGETARCH}.deb \
+	&& curl -L -o binutils-common_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils-common_2.30-22_${TARGETARCH}.deb \
+	&& dpkg -i *binutils*.deb \
+	&& rm -f *binutils*.deb
+
+COPY ./docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["/usr/bin/falco"]

--- a/docker/driver-loader-legacy/docker-entrypoint.sh
+++ b/docker/driver-loader-legacy/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2020 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set the SKIP_DRIVER_LOADER variable to skip loading the driver
+
+if [[ -z "${SKIP_DRIVER_LOADER}" ]]; then
+    echo "* Setting up /usr/src links from host"
+
+    for i in "$HOST_ROOT/usr/src"/*
+    do
+        base=$(basename "$i")
+        ln -s "$i" "/usr/src/$base"
+    done
+
+    /usr/bin/falco-driver-loader
+fi
+
+exec "$@"

--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -19,37 +19,17 @@ RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
-	bash-completion \
-	bc \
-	bison \
 	ca-certificates \
 	clang \
-	cpio \
 	curl \
 	dkms \
-	dwarves \
-	flex \
 	gcc \
 	gcc-11 \
 	gnupg2 \
-	gpg \
 	jq \
-	libc6-dev \
-	libelf-dev \
-	libiberty-dev \
-	libncurses-dev \
-	libpci-dev \
-	libssl-dev \
-	libudev-dev \
+	libelf1 \
 	llvm \
-	lsb-release \
-	netcat-openbsd \
-	openssl \
-	rpm2cpio \
-	software-properties-common \
-	wget \
-	xz-utils \
-	zstd \
+	make \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN curl -s https://falco.org/repo/falcosecurity-packages.asc | apt-key add - \

--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
@@ -22,72 +22,35 @@ RUN apt-get update \
 	bash-completion \
 	bc \
 	bison \
-	clang-7 \
 	ca-certificates \
+	clang \
+	cpio \
 	curl \
 	dkms \
+	dwarves \
 	flex \
-	gnupg2 \
 	gcc \
+	gcc-11 \
+	gnupg2 \
+	gpg \
 	jq \
 	libc6-dev \
 	libelf-dev \
+	libiberty-dev \
+	libncurses-dev \
+	libpci-dev \
 	libssl-dev \
-	llvm-7 \
-	netcat \
-	patchelf \
+	libudev-dev \
+	llvm \
+	lsb-release \
+	netcat-openbsd \
+	openssl \
+	rpm2cpio \
+	software-properties-common \
+	wget \
 	xz-utils \
+	zstd \
 	&& rm -rf /var/lib/apt/lists/*
-
-RUN if [ "$TARGETARCH" = "amd64" ]; \
-    then apt-get install -y --no-install-recommends libmpx2; \
-    fi
-
-# gcc 6 is no longer included in debian stable, but we need it to
-# build kernel modules on the default debian-based ami used by
-# kops. So grab copies we've saved from debian snapshots with the
-# prefix https://snapshot.debian.org/archive/debian/20170517T033514Z
-# or so.
-
-RUN if [ "$TARGETARCH" = "amd64" ]; then curl -L -o libcilkrts5_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libcilkrts5_6.3.0-18_${TARGETARCH}.deb; fi; \
-    curl -L -o cpp-6_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/cpp-6_6.3.0-18_${TARGETARCH}.deb \
-	&& curl -L -o gcc-6-base_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-6-base_6.3.0-18_${TARGETARCH}.deb \
-	&& curl -L -o gcc-6_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-6_6.3.0-18_${TARGETARCH}.deb \
-	&& curl -L -o libasan3_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libasan3_6.3.0-18_${TARGETARCH}.deb \
-	&& curl -L -o libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb \
-	&& curl -L -o libubsan0_6.3.0-18_${TARGETARCH}.deb https://download.falco.org/dependencies/libubsan0_6.3.0-18_${TARGETARCH}.deb \
-	&& curl -L -o libmpfr4_3.1.3-2_${TARGETARCH}.deb https://download.falco.org/dependencies/libmpfr4_3.1.3-2_${TARGETARCH}.deb \
-	&& curl -L -o libisl15_0.18-1_${TARGETARCH}.deb https://download.falco.org/dependencies/libisl15_0.18-1_${TARGETARCH}.deb \
-	&& dpkg -i cpp-6_6.3.0-18_${TARGETARCH}.deb gcc-6-base_6.3.0-18_${TARGETARCH}.deb gcc-6_6.3.0-18_${TARGETARCH}.deb libasan3_6.3.0-18_${TARGETARCH}.deb; \
-    if [ "$TARGETARCH" = "amd64" ]; then dpkg -i libcilkrts5_6.3.0-18_${TARGETARCH}.deb; fi; \
-    dpkg -i libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb libubsan0_6.3.0-18_${TARGETARCH}.deb libmpfr4_3.1.3-2_${TARGETARCH}.deb libisl15_0.18-1_${TARGETARCH}.deb \
-	&& rm -f cpp-6_6.3.0-18_${TARGETARCH}.deb gcc-6-base_6.3.0-18_${TARGETARCH}.deb gcc-6_6.3.0-18_${TARGETARCH}.deb libasan3_6.3.0-18_${TARGETARCH}.deb libcilkrts5_6.3.0-18_${TARGETARCH}.deb libgcc-6-dev_6.3.0-18_${TARGETARCH}.deb libubsan0_6.3.0-18_${TARGETARCH}.deb libmpfr4_3.1.3-2_${TARGETARCH}.deb libisl15_0.18-1_${TARGETARCH}.deb
-
-# gcc 5 is no longer included in debian stable, but we need it to
-# build centos kernels, which are 3.x based and explicitly want a gcc
-# version 3, 4, or 5 compiler. So grab copies we've saved from debian
-# snapshots with the prefix https://snapshot.debian.org/archive/debian/20190122T000000Z.
-
-RUN if [ "$TARGETARCH" = "amd64" ]; then curl -L -o libmpx0_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/libmpx0_5.5.0-12_${TARGETARCH}.deb; fi; \
-    curl -L -o cpp-5_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/cpp-5_5.5.0-12_${TARGETARCH}.deb \
-	&& curl -L -o gcc-5-base_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-5-base_5.5.0-12_${TARGETARCH}.deb \
-	&& curl -L -o gcc-5_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/gcc-5_5.5.0-12_${TARGETARCH}.deb \
-	&& curl -L -o libasan2_5.5.0-12_${TARGETARCH}.deb	https://download.falco.org/dependencies/libasan2_5.5.0-12_${TARGETARCH}.deb \
-	&& curl -L -o libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb https://download.falco.org/dependencies/libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb \
-	&& curl -L -o libisl15_0.18-4_${TARGETARCH}.deb https://download.falco.org/dependencies/libisl15_0.18-4_${TARGETARCH}.deb \
-	&& dpkg -i cpp-5_5.5.0-12_${TARGETARCH}.deb gcc-5-base_5.5.0-12_${TARGETARCH}.deb gcc-5_5.5.0-12_${TARGETARCH}.deb libasan2_5.5.0-12_${TARGETARCH}.deb; \
-    if [ "$TARGETARCH" = "amd64" ]; then dpkg -i libmpx0_5.5.0-12_${TARGETARCH}.deb; fi; \
-    dpkg -i libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb libisl15_0.18-4_${TARGETARCH}.deb \
-	&& rm -f cpp-5_5.5.0-12_${TARGETARCH}.deb gcc-5-base_5.5.0-12_${TARGETARCH}.deb gcc-5_5.5.0-12_${TARGETARCH}.deb libasan2_5.5.0-12_${TARGETARCH}.deb libgcc-5-dev_5.5.0-12_${TARGETARCH}.deb libisl15_0.18-4_${TARGETARCH}.deb libmpx0_5.5.0-12_${TARGETARCH}.deb
-
-# Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
-# default to gcc-5.
-RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-5 /usr/bin/gcc
-
-RUN rm -rf /usr/bin/clang \
-	&& rm -rf /usr/bin/llc \
-	&& ln -s /usr/bin/clang-7 /usr/bin/clang \
-	&& ln -s /usr/bin/llc-7 /usr/bin/llc
 
 RUN curl -s https://falco.org/repo/falcosecurity-packages.asc | apt-key add - \
 	&& echo "deb https://download.falco.org/packages/${VERSION_BUCKET} stable main" | tee -a /etc/apt/sources.list.d/falcosecurity.list \
@@ -106,22 +69,6 @@ RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /etc/fa
 # silently overwriting the existing directory
 RUN rm -df /lib/modules \
 	&& ln -s $HOST_ROOT/lib/modules /lib/modules
-
-# debian:stable head contains binutils 2.31, which generates
-# binaries that are incompatible with kernels < 4.16. So manually
-# forcibly install binutils 2.30-22 instead.
-
-RUN if [ "$TARGETARCH" = "amd64" ] ; then \
-    curl -L -o binutils-x86-64-linux-gnu_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils-x86-64-linux-gnu_2.30-22_${TARGETARCH}.deb; \
-    else  \
-    curl -L -o  binutils-aarch64-linux-gnu_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils-aarch64-linux-gnu_2.30-22_${TARGETARCH}.deb; \
-    fi
-
-RUN curl -L -o binutils_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils_2.30-22_${TARGETARCH}.deb \
-	&& curl -L -o libbinutils_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/libbinutils_2.30-22_${TARGETARCH}.deb \
-	&& curl -L -o binutils-common_2.30-22_${TARGETARCH}.deb https://download.falco.org/dependencies/binutils-common_2.30-22_${TARGETARCH}.deb \
-	&& dpkg -i *binutils*.deb \
-	&& rm -f *binutils*.deb
 
 COPY ./docker-entrypoint.sh /
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature
/area build
/area CI

**What this PR does / why we need it**:

As per our discussion in https://github.com/falcosecurity/falco/issues/2489 and during yesterday's core maintainer call, I propose to:
* Upgrade the Falco base image with the one that seems to build the most kernels at the moment
* Still distribute the old one, marked as legacy, adding the necessary CI/CD job steps

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2489

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
update!: the Falco base image is now based on Debian 12 with gcc 11-12
new: the legacy falco image is available as driver-loader-legacy
```
