### PR TITLE
update(userspace/engine): make rule_matching strategy stateless 

### DIFF
--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -106,11 +106,6 @@ public:
 	// Only load rules having this priority or more severe.
 	void set_min_priority(falco_common::priority_type priority);
 
-	// Whether or not continuing to evaluate rules for other potential matches 
-	// even if a match already occurred. This option can be set to avoid shadowing
-	// of rules.
-	void set_rule_matching(falco_common::rule_matching rule_matching);
-
 	//
 	// Return the ruleset id corresponding to this ruleset name,
 	// creating a new one if necessary. If you provide any ruleset
@@ -194,14 +189,16 @@ public:
 	// event source is not thread-safe of its own, so invoking this method
 	// concurrently with the same source_idx would inherently cause data races
 	// and lead to undefined behavior.
-	std::unique_ptr<std::vector<rule_result>> process_event(std::size_t source_idx, gen_event *ev, uint16_t ruleset_id);
+	std::unique_ptr<std::vector<rule_result>> process_event(std::size_t source_idx,
+		gen_event *ev, uint16_t ruleset_id, falco_common::rule_matching strategy);
 
 	//
 	// Wrapper assuming the default ruleset.
 	//
 	// This inherits the same thread-safety guarantees.
 	//
-	std::unique_ptr<std::vector<rule_result>> process_event(std::size_t source_idx, gen_event *ev);
+	std::unique_ptr<std::vector<rule_result>> process_event(std::size_t source_idx,
+		gen_event *ev, falco_common::rule_matching strategy);
 
 	//
 	// Configure the engine to support events with the provided
@@ -325,7 +322,6 @@ private:
 	uint16_t m_next_ruleset_id;
 	std::map<std::string, uint16_t> m_known_rulesets;
 	falco_common::priority_type m_min_priority;
-	falco_common::rule_matching m_rule_matching;
 
 	//
 	// Here's how the sampling ratio and multiplier influence

--- a/userspace/falco/app/actions/init_falco_engine.cpp
+++ b/userspace/falco/app/actions/init_falco_engine.cpp
@@ -120,7 +120,6 @@ falco::app::run_result falco::app::actions::init_falco_engine(falco::app::state&
 
 	configure_output_format(s);
 	s.engine->set_min_priority(s.config->m_min_priority);
-	s.engine->set_rule_matching(s.config->m_rule_matching);
 
 	return run_result::ok();
 }

--- a/userspace/falco/app/actions/process_events.cpp
+++ b/userspace/falco/app/actions/process_events.cpp
@@ -330,7 +330,7 @@ static falco::app::run_result do_inspect(
 		// engine, which will match the event against the set
 		// of rules. If a match is found, pass the event to
 		// the outputs.
-		auto res = s.engine->process_event(source_engine_idx, ev);
+		auto res = s.engine->process_event(source_engine_idx, ev, s.config->m_rule_matching);
 		if(res != nullptr)
 		{
 			for(auto& rule_res : *res.get())


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Since `process_event` could be called by multiple threads, passing the `rule_matching` strategy to the engine at each call rather than storing state inside it is better for thread safety.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
