### PR TITLE
Relocate tools on Flatcar in BPF mode

### DIFF
--- a/scripts/falco-driver-loader
+++ b/scripts/falco-driver-loader
@@ -486,6 +486,12 @@ load_bpf_probe_compile() {
 		make modules_prepare > /dev/null
 	}
 
+	if [ "${TARGET_ID}" == "flatcar" ]; then
+		KERNEL_RELEASE=${DRIVER_KERNEL_RELEASE}
+		echo "* Flatcar detected (version ${VERSION_ID}); relocating kernel tools"
+		flatcar_relocate_tools
+	fi
+
 	if [ "${TARGET_ID}" == "cos" ]; then
 		echo "* COS detected (build ${BUILD_ID}), using COS kernel headers"
 


### PR DESCRIPTION
In https://github.com/falcosecurity/falco/pull/2043 we've added logic for relocating tools on Flatcar when running falco-driver-loader in kmod mode. This logic is relevant for BPF mode, too, which is currently broken on Flatcar. Call flatcar_relocate_tools in BPF mode, too.

cc: @jepio

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

In #2043 we've added logic which ensures driver compilation works on Flatcar Container Linux. This logic was added for kmod only, and therefore BPF driver compilation is currently broken for Flatcar. This PR invokes the same logic in BPF mode, too, which fixes the problem.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
