### PR TITLE
cleanup: remove unused `--pidfile` option from systemd units

### DIFF
--- a/scripts/systemd/falco-bpf.service
+++ b/scripts/systemd/falco-bpf.service
@@ -8,7 +8,7 @@ Wants=falcoctl-artifact-follow.service
 Type=simple
 User=root
 Environment=FALCO_BPF_PROBE=
-ExecStart=/usr/bin/falco --pidfile=/var/run/falco.pid
+ExecStart=/usr/bin/falco
 UMask=0077
 TimeoutSec=30
 RestartSec=15s

--- a/scripts/systemd/falco-custom.service
+++ b/scripts/systemd/falco-custom.service
@@ -7,7 +7,7 @@ Wants=falcoctl-artifact-follow.service
 [Service]
 Type=simple
 User=%u
-ExecStart=/usr/bin/falco --pidfile=/var/run/falco.pid
+ExecStart=/usr/bin/falco
 UMask=0077
 TimeoutSec=30
 RestartSec=15s

--- a/scripts/systemd/falco-kmod.service
+++ b/scripts/systemd/falco-kmod.service
@@ -9,7 +9,7 @@ Wants=falcoctl-artifact-follow.service
 [Service]
 Type=simple
 User=root
-ExecStart=/usr/bin/falco --pidfile=/var/run/falco.pid
+ExecStart=/usr/bin/falco
 UMask=0077
 TimeoutSec=30
 RestartSec=15s

--- a/scripts/systemd/falco-modern-bpf.service
+++ b/scripts/systemd/falco-modern-bpf.service
@@ -7,7 +7,7 @@ Wants=falcoctl-artifact-follow.service
 [Service]
 Type=simple
 User=root
-ExecStart=/usr/bin/falco --pidfile=/var/run/falco.pid --modern-bpf
+ExecStart=/usr/bin/falco --modern-bpf
 UMask=0077
 TimeoutSec=30
 RestartSec=15s


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

This PR https://github.com/falcosecurity/falco/pull/2677 highlighted that we don't need this `--pidfile` option in our systemd units. At this point, I'm not even sure we want to keep this option at all @leogr @incertum...BTW In this PR I've just removed its usage in our systemd unit

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
