### PR TITLE
update(ci): minimize retention days for build-only CI artifacts

### DIFF
--- a/.github/workflows/reusable_build_docker.yaml
+++ b/.github/workflows/reusable_build_docker.yaml
@@ -71,3 +71,4 @@ jobs:
         with:
           name: falco-images
           path: /tmp/falco-*.tar
+          retention-days: 1

--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -36,6 +36,7 @@ jobs:
         with:
           name: bpf_probe_${{ inputs.arch }}.skel.h
           path: skeleton-build/skel_dir/bpf_probe.skel.h
+          retention-days: 1
           
   build-packages:
     # See https://github.com/actions/runner/issues/409#issuecomment-1158849936


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

Github Actions have a default retention period of 90 days. However, some of our artifacts are used at build-time only to pass around artifacts between different CI jobs, thus we don't need them after the workflow is finished. In particular, `falco-images` weights ~4GB, which is a big waste of storage.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
