### PR TITLE
update(cmake): support building libs and driver from forks

### DIFF
--- a/cmake/modules/driver-repo/CMakeLists.txt
+++ b/cmake/modules/driver-repo/CMakeLists.txt
@@ -15,11 +15,12 @@ cmake_minimum_required(VERSION 3.5.1)
 project(driver-repo NONE)
 
 include(ExternalProject)
+message(STATUS "Driver repository: ${DRIVER_REPO}")
 message(STATUS "Driver version: ${DRIVER_VERSION}")
 
 ExternalProject_Add(
   driver
-  URL "https://github.com/falcosecurity/libs/archive/${DRIVER_VERSION}.tar.gz"
+  URL "https://github.com/${DRIVER_REPO}/archive/${DRIVER_VERSION}.tar.gz"
   URL_HASH "${DRIVER_CHECKSUM}"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""

--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -20,6 +20,13 @@ if(DRIVER_SOURCE_DIR)
   set(DRIVER_VERSION "0.0.0-local")
   message(STATUS "Using local version for driver: '${DRIVER_SOURCE_DIR}'")
 else()
+  # DRIVER_REPO accepts a repository name (<org name>/<repo name>) alternative to the falcosecurity/libs repository.
+  # In case you want to test against a fork of falcosecurity/libs just pass the variable -
+  # ie., `cmake -DDRIVER_REPO=<your-gh-handle>/libs ..` 
+  if (NOT DRIVER_REPO)
+    set(DRIVER_REPO "falcosecurity/libs")
+  endif()
+
   # DRIVER_VERSION accepts a git reference (branch name, commit hash, or tag) to the falcosecurity/libs repository
   # which contains the driver source code under the `/driver` directory.
   # The chosen driver version must be compatible with the given FALCOSECURITY_LIBS_VERSION.
@@ -31,7 +38,11 @@ else()
   endif()
 
   # cd /path/to/build && cmake /path/to/source
-  execute_process(COMMAND "${CMAKE_COMMAND}" -DDRIVER_VERSION=${DRIVER_VERSION} -DDRIVER_CHECKSUM=${DRIVER_CHECKSUM}
+  execute_process(COMMAND "${CMAKE_COMMAND}"
+      -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
+      -DDRIVER_REPO=${DRIVER_REPO}
+      -DDRIVER_VERSION=${DRIVER_VERSION}
+      -DDRIVER_CHECKSUM=${DRIVER_CHECKSUM}
     ${DRIVER_CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${DRIVER_CMAKE_WORKING_DIR})
 
   # cmake --build .

--- a/cmake/modules/falcosecurity-libs-repo/CMakeLists.txt
+++ b/cmake/modules/falcosecurity-libs-repo/CMakeLists.txt
@@ -15,11 +15,12 @@ cmake_minimum_required(VERSION 3.5.1)
 project(falcosecurity-libs-repo NONE)
 
 include(ExternalProject)
+message(STATUS "Libs repository: ${FALCOSECURITY_LIBS_REPO}")
 message(STATUS "Libs version: ${FALCOSECURITY_LIBS_VERSION}")
 
 ExternalProject_Add(
   falcosecurity-libs
-  URL "https://github.com/falcosecurity/libs/archive/${FALCOSECURITY_LIBS_VERSION}.tar.gz"
+  URL "https://github.com/${FALCOSECURITY_LIBS_REPO}/archive/${FALCOSECURITY_LIBS_VERSION}.tar.gz"
   URL_HASH "${FALCOSECURITY_LIBS_CHECKSUM}"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -23,6 +23,13 @@ if(FALCOSECURITY_LIBS_SOURCE_DIR)
   set(FALCOSECURITY_LIBS_VERSION "0.0.0-local")
   message(STATUS "Using local version of falcosecurity/libs: '${FALCOSECURITY_LIBS_SOURCE_DIR}'")
 else()
+  # FALCOSECURITY_LIBS_REPO accepts a repository name (<org name>/<repo name>) alternative to the falcosecurity/libs repository.
+  # In case you want to test against a fork of falcosecurity/libs just pass the variable -
+  # ie., `cmake -DFALCOSECURITY_LIBS_REPO=<your-gh-handle>/libs ..` 
+  if (NOT FALCOSECURITY_LIBS_REPO)
+    set(FALCOSECURITY_LIBS_REPO "falcosecurity/libs")
+  endif()
+
   # FALCOSECURITY_LIBS_VERSION accepts a git reference (branch name, commit hash, or tag) to the falcosecurity/libs repository.
   # In case you want to test against another falcosecurity/libs version (or branch, or commit) just pass the variable -
   # ie., `cmake -DFALCOSECURITY_LIBS_VERSION=dev ..` 
@@ -34,6 +41,7 @@ else()
   # cd /path/to/build && cmake /path/to/source
   execute_process(COMMAND "${CMAKE_COMMAND}"
       -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
+      -DFALCOSECURITY_LIBS_REPO=${FALCOSECURITY_LIBS_REPO}
       -DFALCOSECURITY_LIBS_VERSION=${FALCOSECURITY_LIBS_VERSION}
       -DFALCOSECURITY_LIBS_CHECKSUM=${FALCOSECURITY_LIBS_CHECKSUM}
     ${FALCOSECURITY_LIBS_CMAKE_SOURCE_DIR} WORKING_DIRECTORY ${FALCOSECURITY_LIBS_CMAKE_WORKING_DIR})


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Whoever of us ever tried to build Falco with their own libs fork when testing changes in libs, had to hack a patch like this one. So for sake of completeness I'll propose supporting this natively in our cmake files. Example of how this could be used:

```
cmake -DFALCOSECURITY_LIBS_REPO=jasondellaluce/falco-libs ..
make falco -j4
...
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(cmake): support building libs and driver from forks
```
