### PR TITLE
fix(userspace/engine): support appending to unknown sources

### DIFF
--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -568,12 +568,12 @@ void falco_engine::describe_rule(std::string *rule, bool json) const
 		output["lists"] = lists_array;
 
 		json_str = writer.write(output);
-	} 
+	}
 	else
 	{
 		// build json information for just the specified rule
 		auto ri = m_rule_collector.rules().at(*rule);
-		if(ri == nullptr)
+		if(ri == nullptr || ri->unknown_source)
 		{
 			throw falco_exception("Rule \"" + *rule + "\" is not loaded");
 		}

--- a/userspace/engine/rule_loader.cpp
+++ b/userspace/engine/rule_loader.cpp
@@ -547,8 +547,8 @@ rule_loader::rule_exception_info::rule_exception_info(context &ctx)
 
 rule_loader::rule_info::rule_info(context &ctx)
 	: ctx(ctx), cond_ctx(ctx), output_ctx(ctx), index(0), visibility(0),
-	  priority(falco_common::PRIORITY_DEBUG), enabled(true),
-	  warn_evttypes(true), skip_if_unknown_filter(false)
+	  unknown_source(false), priority(falco_common::PRIORITY_DEBUG),
+	  enabled(true), warn_evttypes(true), skip_if_unknown_filter(false)
 {
 }
 

--- a/userspace/engine/rule_loader.h
+++ b/userspace/engine/rule_loader.h
@@ -449,6 +449,7 @@ namespace rule_loader
 		context output_ctx;
 		size_t index;
 		size_t visibility;
+		bool unknown_source;
 		std::string name;
 		std::string cond;
 		std::string source;

--- a/userspace/engine/rule_loader_compiler.cpp
+++ b/userspace/engine/rule_loader_compiler.cpp
@@ -388,17 +388,22 @@ void rule_loader::compiler::compile_rule_infos(
 	filter_warning_resolver warn_resolver;
 	for (auto &r : col.rules())
 	{
+		// skip the rule if it has an unknown source
+		if (r.unknown_source)
+		{
+			continue;
+		}
+
 		// skip the rule if below the minimum priority
 		if (r.priority > cfg.min_priority)
 		{
 			continue;
 		}
 
+		// note: this should not be nullptr if the source is not unknown
 		auto source = cfg.sources.at(r.source);
-		// note: this is not supposed to happen
-
 		THROW(!source,
-		      std::string("Unknown source ") + r.source,
+		      std::string("Unknown source at compile-time") + r.source,
 		      r.ctx);
 
 		// build filter AST by parsing the condition, building exceptions,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

In case we have a rule using an unknown source (e.g. when its plugin is not leaded), we have a bug that prevents appending to that rule. For example:

```yaml
- rule: Rule1
  desc: NoDesc
  condition: evt.type=open
  priority: INFO
  output: Never
  source: mysource

- rule: Rule1
  append: true
  condition: or evt.type=openat
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/engine): support appending to unknown sources
```
