### PR TITLE
fix(userspace/falco): properly delete metrics timer upon leaving.

### DIFF
--- a/userspace/falco/app/restart_handler.cpp
+++ b/userspace/falco/app/restart_handler.cpp
@@ -31,8 +31,9 @@ limitations under the License.
 
 falco::app::restart_handler::~restart_handler()
 {
-    close(m_inotify_fd);
     stop();
+    close(m_inotify_fd);
+    m_inotify_fd = -1;
 }
 
 void falco::app::restart_handler::trigger()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Properly deletes metrics related timer upon leaving.

**Which issue(s) this PR fixes**:

Fixes #2757 

**Special notes for your reviewer**:

How i tested the fix:
* set metrics enabled and interval 15s
* start Falco
* immediately (before 15s elapses) change interval to eg: 2m
* wait 
* you will receive just one stats after 2min (otherwise you would've received one after 15s since Falco started)

Did the same also playing a bit with the interval values, like restarting Falco 4-5 times in a row updating `metrics.interval` config value.
Everything was sane.

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/falco): cleanup metrics timer upon leaving.
```
