### PR TITLE
fix: restore Falco MINIMAL_BUILD and deprecate `userspace` option

### DIFF
--- a/userspace/falco/app/actions/helpers_inspector.cpp
+++ b/userspace/falco/app/actions/helpers_inspector.cpp
@@ -91,7 +91,7 @@ falco::app::run_result falco::app::actions::open_live_inspector(
 			//
 			// Falco uses a ptrace(2) based userspace implementation.
 			// Regardless of the implementation, the underlying method remains the same.
-			falco_logger::log(LOG_INFO, "Opening '" + source + "' source with udig\n");
+			falco_logger::log(LOG_WARNING, "The udig engine is deprecated and will be removed in Falco 0.37. Opening '" + source + "' source with udig\n");
 			inspector->open_udig();
 		}
 		else if(s.is_gvisor_enabled()) /* gvisor engine. */

--- a/userspace/falco/app/options.cpp
+++ b/userspace/falco/app/options.cpp
@@ -220,7 +220,7 @@ void options::define(cxxopts::Options& opts)
 		("t",                             "Only run those rules with a tag=<tag>. This option can be passed multiple times. Can not be mixed with -T/-D.", cxxopts::value<std::vector<std::string>>(), "<tag>")
 		("U,unbuffered",                  "Turn off output buffering to configured outputs. This causes every single line emitted by falco to be flushed which generates higher CPU usage but is useful when piping those outputs into another process or into a script.", cxxopts::value(unbuffered_outputs)->default_value("false"))
 #if !defined(_WIN32) && !defined(__EMSCRIPTEN__) && !defined(MINIMAL_BUILD)
-		("u,userspace",                   "Parse events from userspace. To be used in conjunction with the ptrace(2) based driver (pdig)", cxxopts::value(userspace)->default_value("false"))
+		("u,userspace",                   "[DEPRECATED, will be removed in Falco 0.37] Parse events from userspace. To be used in conjunction with the ptrace(2) based driver (pdig)", cxxopts::value(userspace)->default_value("false"))
 #endif
 		("V,validate",                    "Read the contents of the specified rules(s) file and exit. This option can be passed multiple times to validate multiple files.", cxxopts::value(validate_rules_filenames), "<rules_file>")
 		("v",                             "Verbose output.", cxxopts::value(verbose)->default_value("false"))

--- a/userspace/falco/app/options.cpp
+++ b/userspace/falco/app/options.cpp
@@ -36,6 +36,7 @@ options::options()
 	  list_plugins(false),
 	  list_syscall_events(false),
 	  markdown(false),
+	  userspace(false),
 	  modern_bpf(false),
 	  dry_run(false),
 	  nodriver(false)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR fixes the minimal build on Falco master that was broken and deprecates the `--userspace` option since it is no longer maintained 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:



```release-note
fix: restore Falco MINIMAL_BUILD and deprecate `userspace` option
```
