### PR TITLE
update(docker): use debian 12 slim for falco no driver

### DIFF
--- a/docker/no-driver/Dockerfile
+++ b/docker/no-driver/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as ubuntu
+FROM debian:12 as builder
 
 ARG FALCO_VERSION
 ARG VERSION_BUCKET=bin
@@ -20,7 +20,7 @@ RUN curl -L -o falco.tar.gz \
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /falco/etc/falco/falco.yaml > /falco/etc/falco/falco.yaml.new \
     && mv /falco/etc/falco/falco.yaml.new /falco/etc/falco/falco.yaml
 
-FROM debian:11-slim
+FROM debian:12-slim
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
@@ -34,6 +34,6 @@ RUN apt-get -y update && apt-get -y install ca-certificates curl jq \
 ENV HOST_ROOT /host
 ENV HOME /root
 
-COPY --from=ubuntu /falco /
+COPY --from=builder /falco /
 
 CMD ["/usr/bin/falco", "-o", "time_format_iso_8601=true"]


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature
/area build

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Since we're updating the large image to Debian 12 I believe it makes sense to update the nodriver one as well. It's also slightly smaller (about ~30MB smaller).

I tested it with the *modern eBPF* probe and the (previously installed) kernel module.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
update(docker): the Falco no-driver image is now based on Debian 12
```
