### PR TITLE
fix(stats): always initialize m_output field

### DIFF
--- a/userspace/falco/stats_writer.cpp
+++ b/userspace/falco/stats_writer.cpp
@@ -91,6 +91,11 @@ stats_writer::stats_writer(
 	m_config = config;
 	if (config->m_metrics_enabled)
 	{
+		/* m_outputs should always be initialized because we use it
+		 * to extract output-queue stats in both cases: rule output and file output.
+		 */
+		m_outputs = outputs;
+
 		if (!config->m_metrics_output_file.empty())
 		{
 			m_file_output.exceptions(std::ofstream::failbit | std::ofstream::badbit);
@@ -100,7 +105,6 @@ stats_writer::stats_writer(
 
 		if (config->m_metrics_stats_rule_enabled)
 		{
-			m_outputs = outputs;
 			m_initialized = true;
 		}
 	}
@@ -159,7 +163,6 @@ inline void stats_writer::push(const stats_writer::msg& m)
 void stats_writer::worker() noexcept
 {
 	stats_writer::msg m;
-	nlohmann::json jmsg;
 	bool use_outputs = m_config->m_metrics_stats_rule_enabled;
 	bool use_file = !m_config->m_metrics_output_file.empty();
 	auto tick = stats_writer::get_ticker();
@@ -198,6 +201,7 @@ void stats_writer::worker() noexcept
 
 				if (use_file)
 				{
+					nlohmann::json jmsg;
 					jmsg["sample"] = m_total_samples;
 					jmsg["output_fields"] = m.output_fields;
 					m_file_output << jmsg.dump() << std::endl;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

When running Falco with these changes in the default config:

```yaml
# todo: syscall_counters_enabled option
metrics:
  enabled: true
  interval: 5s
  # Typically, in production, you only use `output_rule` or `output_file`, but not both. 
  # However, if you have a very unique use case, you can use both together.
  output_rule: false
  output_file: ./falco_stats.json
  resource_utilization_enabled: true
  kernel_event_counters_enabled: true
  libbpf_stats_enabled: true
  convert_memory_to_mb: true
  include_empty_values: false
```

it crashes with a segfault. The reason was that the `m_output` field of the stats writer was not initialized, but we tried to use it anyway in the collection stats phase

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
