### PR TITLE
update(userspace/engine): align `%container.info` defaults with new rules style

### DIFF
--- a/userspace/engine/rule_loader_compiler.cpp
+++ b/userspace/engine/rule_loader_compiler.cpp
@@ -28,7 +28,7 @@ limitations under the License.
 #define THROW(cond, err, ctx)    { if ((cond)) { throw rule_loader::rule_load_exception(falco::load_result::LOAD_ERR_VALIDATE, (err), (ctx)); } }
 
 static std::string s_container_info_fmt = "%container.info";
-static std::string s_default_extra_fmt  = "%container.name (id=%container.id)";
+static std::string s_default_extra_fmt  = "container_id=%container.id container_name=%container.name";
 
 using namespace libsinsp::filter;
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine


**What this PR does / why we need it**:

This PR aims to align the `%container.info` default substitution (ie. when `-p` is not used) with the latest rules style.

**Special notes for your reviewer**:

/milestone 0.36.0

Once this gets merged, documentation needs to be updated :point_down: 
https://github.com/falcosecurity/falco-website/blob/master/content/en/docs/outputs/formatting.md?plain=1#L15

**Does this PR introduce a user-facing change?**:

```release-note
update!: default substitution for `%container.info` is now equal `container_id=%container.id container_name=%container.name`
```
