### PR TITLE
fix(userspace/falco): clearing full output queue

### DIFF
--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -294,7 +294,7 @@ inline void falco_outputs::push(const ctrl_msg& cmsg)
 		case falco_common::RECOVERY_EMPTY:
 			m_outputs_queue_num_drops += m_queue.size() + 1;
 			falco_logger::log(LOG_ERR, "Output queue out of memory. Drop event plus events in queue due to emptying the queue; continue on ...");
-			m_queue.empty();
+			m_queue.clear();
 			break;
 		case falco_common::RECOVERY_CONTINUE:
 			m_outputs_queue_num_drops++;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Invoking `empty` in the concurrent queue will do nothing if not generating a warning for an unchecked ret value.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

cc @incertum 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
