### PR TITLE
update(userspace/engine): modularize rule compiler, fix and enrich rule descriptions

### DIFF
--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -800,7 +800,7 @@ void falco_engine::get_json_details(
 	out["details"]["condition_compiled"] = libsinsp::filter::ast::as_string(m.condition.get());
 
 	// Compute the plugins that are actually used by this macro.
-	// Note: macros have no specidic source, we need to set an empty list of used
+	// Note: macros have no specific source, we need to set an empty list of used
 	// plugins because we can't be certain about their actual usage. For example,
 	// if a macro uses a plugin's field, we can't be sure which plugin actually
 	// is used until we resolve the macro ref in a rule providing a source for

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -819,6 +819,19 @@ void falco_engine::get_json_used_plugins(
 	const std::unordered_set<std::string>& fields,
 	const std::vector<std::shared_ptr<sinsp_plugin>>& plugins) const
 {
+	// note: condition and output fields may have an argument, so
+	// we need to isolate the field names
+	std::unordered_set<std::string> fieldnames;
+	for (auto f: fields)
+	{
+		auto argpos = f.find('[');
+		if (argpos != std::string::npos)
+		{
+			f = f.substr(0, argpos);
+		}
+		fieldnames.insert(f);
+	}
+
 	out = Json::arrayValue;	
 	for (const auto& p : plugins)
 	{
@@ -846,7 +859,7 @@ void falco_engine::get_json_used_plugins(
 			{
 				for (const auto &f : p->fields())
 				{
-					if (!used && fields.find(f.m_name) != fields.end())
+					if (!used && fieldnames.find(f.m_name) != fieldnames.end())
 					{
 						out.append(p->name());
 						used = true;

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -306,21 +306,22 @@ private:
 	void get_json_details(
 		Json::Value& out,
 		const falco_rule& r,
-		const rule_loader::rule_info& ri,
+		const rule_loader::rule_info& info,
 		const std::vector<std::shared_ptr<sinsp_plugin>>& plugins) const;
 	void get_json_details(
 		Json::Value& out,
-		const rule_loader::macro_info& m) const;
+		const falco_macro& m,
+		const rule_loader::macro_info& info,
+		const std::vector<std::shared_ptr<sinsp_plugin>>& plugins) const;
 	void get_json_details(
 		Json::Value& out,
-		const rule_loader::list_info& l) const;
-	void get_json_filter_details(
-		Json::Value& out,
-		const filter_details& details) const;
+		const falco_list& l,
+		const rule_loader::list_info& info,
+		const std::vector<std::shared_ptr<sinsp_plugin>>& plugins) const;
 	void get_json_evt_types(
 		Json::Value& out,
 		const std::string& source,
-		const filter_details& details) const;
+		libsinsp::filter::ast::expr* ast) const;
 	void get_json_used_plugins(
 		Json::Value& out,
 		const std::string& source,

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -125,7 +125,7 @@ public:
 	// Print details on the given rule. If rule is NULL, print
 	// details on all rules.
 	//
-	void describe_rule(std::string *rule, bool json) const;
+	void describe_rule(std::string *rule, const std::vector<std::shared_ptr<sinsp_plugin>>& plugins, bool json) const;
 
 	//
 	// Print statistics on how many events matched each rule.
@@ -303,18 +303,30 @@ private:
 	inline bool should_drop_evt() const;
 
 	// Retrieve json details from rules, macros, lists
-	void get_json_details(const falco_rule& r,
-					const rule_loader::rule_info& ri,
-					sinsp* insp,
-					Json::Value& rule) const;
-	void get_json_details(const rule_loader::macro_info& m,
-					Json::Value& macro) const;
-	void get_json_details(const rule_loader::list_info& l,
-					Json::Value& list) const;
-	void get_json_details(libsinsp::filter::ast::expr* ast,
-					Json::Value& output) const;
-	void get_json_evt_types(libsinsp::filter::ast::expr* ast,
-					Json::Value& output) const;
+	void get_json_details(
+		Json::Value& out,
+		const falco_rule& r,
+		const rule_loader::rule_info& ri,
+		const std::vector<std::shared_ptr<sinsp_plugin>>& plugins) const;
+	void get_json_details(
+		Json::Value& out,
+		const rule_loader::macro_info& m,
+		const std::vector<std::shared_ptr<sinsp_plugin>>& plugins) const;
+	void get_json_details(
+		Json::Value& out,
+		const rule_loader::list_info& l) const;
+	void get_json_details(
+		Json::Value& out,
+		libsinsp::filter::ast::expr* ast) const;
+	void get_json_evt_types(
+		Json::Value& out,
+		libsinsp::filter::ast::expr* ast) const;
+	void get_json_used_plugins(
+		Json::Value& out,
+		const std::string& source,
+		const std::unordered_set<std::string>& evttypes,
+		const std::unordered_set<std::string>& fields,
+		const std::vector<std::shared_ptr<sinsp_plugin>>& plugins) const;
 
 	rule_loader::collector m_rule_collector;
 	indexed_vector<falco_rule> m_rules;

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -310,17 +310,17 @@ private:
 		const std::vector<std::shared_ptr<sinsp_plugin>>& plugins) const;
 	void get_json_details(
 		Json::Value& out,
-		const rule_loader::macro_info& m,
-		const std::vector<std::shared_ptr<sinsp_plugin>>& plugins) const;
+		const rule_loader::macro_info& m) const;
 	void get_json_details(
 		Json::Value& out,
 		const rule_loader::list_info& l) const;
-	void get_json_details(
+	void get_json_filter_details(
 		Json::Value& out,
-		libsinsp::filter::ast::expr* ast) const;
+		const filter_details& details) const;
 	void get_json_evt_types(
 		Json::Value& out,
-		libsinsp::filter::ast::expr* ast) const;
+		const std::string& source,
+		const filter_details& details) const;
 	void get_json_used_plugins(
 		Json::Value& out,
 		const std::string& source,

--- a/userspace/engine/falco_rule.h
+++ b/userspace/engine/falco_rule.h
@@ -21,6 +21,46 @@ limitations under the License.
 #include <string>
 #include "falco_common.h"
 
+#include <filter/ast.h>
+
+/*!
+	\brief Represents a list in the Falco Engine.
+	The rule ID must be unique across all the lists loaded in the engine.
+*/
+struct falco_list
+{
+	falco_list(): used(false), id(0) { }
+	falco_list(falco_list&&) = default;
+	falco_list& operator = (falco_list&&) = default;
+	falco_list(const falco_list&) = default;
+	falco_list& operator = (const falco_list&) = default;
+	~falco_list() = default;
+
+	bool used;
+	std::size_t id;
+	std::string name;
+	std::vector<std::string> items;
+};
+
+/*!
+	\brief Represents a macro in the Falco Engine.
+	The rule ID must be unique across all the macros loaded in the engine.
+*/
+struct falco_macro
+{
+	falco_macro(): used(false), id(0) { }
+	falco_macro(falco_macro&&) = default;
+	falco_macro& operator = (falco_macro&&) = default;
+	falco_macro(const falco_macro&) = default;
+	falco_macro& operator = (const falco_macro&) = default;
+	~falco_macro() = default;
+
+	bool used;
+	std::size_t id;
+	std::string name;
+	std::shared_ptr<libsinsp::filter::ast::expr> condition;
+};
+
 /*!
 	\brief Represents a rule in the Falco Engine.
 	The rule ID must be unique across all the rules loaded in the engine.
@@ -32,6 +72,7 @@ struct falco_rule
 	falco_rule& operator = (falco_rule&&) = default;
 	falco_rule(const falco_rule&) = default;
 	falco_rule& operator = (const falco_rule&) = default;
+	~falco_rule() = default;
 
 	std::size_t id;
 	std::string source;
@@ -41,4 +82,5 @@ struct falco_rule
 	std::set<std::string> tags;
 	std::set<std::string> exception_fields;
 	falco_common::priority_type priority;
+	std::shared_ptr<libsinsp::filter::ast::expr> condition;
 };

--- a/userspace/engine/filter_details_resolver.cpp
+++ b/userspace/engine/filter_details_resolver.cpp
@@ -19,6 +19,16 @@ limitations under the License.
 
 using namespace libsinsp::filter;
 
+std::string get_field_name(const std::string& name, const std::string& arg)
+{
+	std::string fld = name;
+	if (!arg.empty())
+	{
+		fld += "[" + arg + "]";
+	}
+	return fld;
+}
+
 void filter_details::reset()
 {
 	fields.clear();
@@ -86,7 +96,7 @@ void filter_details_resolver::visitor::visit(ast::list_expr* e)
 void filter_details_resolver::visitor::visit(ast::binary_check_expr* e)
 {
 	m_expect_macro = false;
-	m_details.fields.insert(e->field);
+	m_details.fields.insert(get_field_name(e->field, e->arg));
 	m_details.operators.insert(e->op);
 	if (e->field == "evt.type" || e->field == "evt.asynctype")
 	{
@@ -105,7 +115,7 @@ void filter_details_resolver::visitor::visit(ast::binary_check_expr* e)
 void filter_details_resolver::visitor::visit(ast::unary_check_expr* e)
 {
 	m_expect_macro = false;
-	m_details.fields.insert(e->field);
+	m_details.fields.insert(get_field_name(e->field, e->arg));
 	m_details.operators.insert(e->op);
 }
 

--- a/userspace/engine/filter_details_resolver.h
+++ b/userspace/engine/filter_details_resolver.h
@@ -60,7 +60,8 @@ private:
 		visitor(filter_details& details) : 
 			m_details(details),
 			m_expect_list(false),
-			m_expect_macro(false) {}
+			m_expect_macro(false),
+			m_expect_evtname(false) {}
 		visitor(visitor&&) = default;
 		visitor& operator = (visitor&&) = default;
 		visitor(const visitor&) = delete;

--- a/userspace/engine/filter_details_resolver.h
+++ b/userspace/engine/filter_details_resolver.h
@@ -33,6 +33,7 @@ struct filter_details
 	std::unordered_set<std::string> macros;
 	std::unordered_set<std::string> operators;
 	std::unordered_set<std::string> lists;
+	std::unordered_set<std::string> evtnames;
 
 	void reset();
 };
@@ -76,5 +77,6 @@ private:
 		filter_details& m_details;
 		bool m_expect_list;
 		bool m_expect_macro;
+		bool m_expect_evtname;
 	};
 };

--- a/userspace/engine/rule_loader.cpp
+++ b/userspace/engine/rule_loader.cpp
@@ -532,12 +532,12 @@ rule_loader::plugin_version_info::plugin_version_info(context &ctx)
 }
 
 rule_loader::list_info::list_info(context &ctx)
-	: ctx(ctx), used(false), index(0), visibility(0)
+	: ctx(ctx), index(0), visibility(0)
 {
 }
 
 rule_loader::macro_info::macro_info(context &ctx)
-	: ctx(ctx), cond_ctx(ctx), used(false), index(0), visibility(0)
+	: ctx(ctx), cond_ctx(ctx), index(0), visibility(0)
 {
 }
 

--- a/userspace/engine/rule_loader.h
+++ b/userspace/engine/rule_loader.h
@@ -273,8 +273,7 @@ namespace rule_loader
 			const indexed_vector<falco_source>& srcs,
 			const std::string& name)
 				: content(cont), sources(srcs), name(name),
-				  default_ruleset_id(0), replace_output_container_info(false),
-				  min_priority(falco_common::PRIORITY_DEBUG)
+				  output_extra(), replace_output_container_info(false)
 			{
 				res.reset(new result(name));
 			}
@@ -283,14 +282,15 @@ namespace rule_loader
 		configuration(const configuration&) = delete;
 		configuration& operator = (const configuration&) = delete;
 
+		// inputs
 		const std::string& content;
 		const indexed_vector<falco_source>& sources;
 		std::string name;
-		std::unique_ptr<result> res;
 		std::string output_extra;
-		uint16_t default_ruleset_id;
 		bool replace_output_container_info;
-		falco_common::priority_type min_priority;
+
+		// outputs
+		std::unique_ptr<result> res;
 	};
 
 	/*!
@@ -359,7 +359,6 @@ namespace rule_loader
 		list_info& operator = (const list_info&) = default;
 
 		context ctx;
-		bool used;
 		size_t index;
 		size_t visibility;
 		std::string name;
@@ -380,12 +379,10 @@ namespace rule_loader
 
 		context ctx;
 		context cond_ctx;
-		bool used;
 		size_t index;
 		size_t visibility;
 		std::string name;
 		std::string cond;
-		std::shared_ptr<libsinsp::filter::ast::expr> cond_ast;
 	};
 
 	/*!

--- a/userspace/engine/rule_loader_compiler.cpp
+++ b/userspace/engine/rule_loader_compiler.cpp
@@ -485,7 +485,7 @@ void rule_loader::compiler::compile_rule_infos(
 				r.output_ctx);
 		}
 
-		// validate the rule's condiiton: we compile it into a sinsp filter
+		// validate the rule's condition: we compile it into a sinsp filter
 		// on-the-fly and we throw an exception with details on failure
 		sinsp_filter_compiler compiler(cfg.sources.at(r.source)->filter_factory, rule.condition.get());
 		try

--- a/userspace/engine/rule_loader_compiler.h
+++ b/userspace/engine/rule_loader_compiler.h
@@ -31,6 +31,23 @@ namespace rule_loader
 class compiler
 {
 public:
+	/*!
+		\brief The output of a compilation.
+	*/
+	struct compile_output
+	{
+		compile_output() = default;
+		virtual ~compile_output() = default;
+		compile_output(compile_output&&) = default;
+		compile_output& operator = (compile_output&&) = default;
+		compile_output(const compile_output&) = default;
+		compile_output& operator = (const compile_output&) = default;
+
+		indexed_vector<falco_list> lists;
+		indexed_vector<falco_macro> macros;
+		indexed_vector<falco_rule> rules;
+	};
+
 	compiler() = default;
 	virtual ~compiler() = default;
 	compiler(compiler&&) = default;
@@ -44,25 +61,25 @@ public:
 	virtual void compile(
 		configuration& cfg,
 		const collector& col,
-		indexed_vector<falco_rule>& out) const;
+		compile_output& out) const;
 
 private:
 	void compile_list_infos(
 		configuration& cfg,
 		const collector& col,
-		indexed_vector<list_info>& out) const;
+		indexed_vector<falco_list>& out) const;
 
 	void compile_macros_infos(
 		configuration& cfg,
 		const collector& col,
-		indexed_vector<list_info>& lists,
-		indexed_vector<macro_info>& out) const;
+		indexed_vector<falco_list>& lists,
+		indexed_vector<falco_macro>& out) const;
 
 	void compile_rule_infos(
 		configuration& cfg,
 		const collector& col,
-		indexed_vector<list_info>& lists,
-		indexed_vector<macro_info>& macros,
+		indexed_vector<falco_list>& lists,
+		indexed_vector<falco_macro>& macros,
 		indexed_vector<falco_rule>& out) const;
 };
 

--- a/userspace/falco/app/actions/load_rules_files.cpp
+++ b/userspace/falco/app/actions/load_rules_files.cpp
@@ -157,13 +157,15 @@ falco::app::run_result falco::app::actions::load_rules_files(falco::app::state& 
 
 	if (s.options.describe_all_rules)
 	{
-		s.engine->describe_rule(NULL, s.config->m_json_output);
+		const auto& plugins = s.offline_inspector->get_plugin_manager()->plugins();
+		s.engine->describe_rule(NULL, plugins, s.config->m_json_output);
 		return run_result::exit();
 	}
 
 	if (!s.options.describe_rule.empty())
 	{
-		s.engine->describe_rule(&(s.options.describe_rule), s.config->m_json_output);
+		const auto& plugins = s.offline_inspector->get_plugin_manager()->plugins();
+		s.engine->describe_rule(&(s.options.describe_rule), plugins, s.config->m_json_output);
 		return run_result::exit();
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This is focused on the rules description feature of the `-l` and `-L` options, in the specific case of the JSON output. The goal is to be more consistent and print more information, which can be used by our automation and for debugging purposes (some of these have been asked for a while). High-level changes:
- The rule loader compiler has been modularized even more. It will be fairly easier to write unit tests on it now.
- For each rule, macro, or list, now also print the plugins they used among the ones currently loaded
- For each list, now also prints the final "compiled" list of items (after resolving all list refs)
- For each macro, now also prints the final "compiled" condition (after resolving all list and macro refs)
- For each macro, now also prints the final "compiled" condition and output (after resolving all list, macro, and exceptions refs, and also the output substitutions such as the one of `container.info`)
- Details of each YAML elements now take in consideration all the referenced elements (lists, macros) instead of just the given described element. Doing otherwise makes no sense for some cases, which are: matching event types, condition and output fields, and used plugins

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(userspace/engine): modularize rule compiler, fix and enrich rule descriptions
```
