### PR TITLE
[BREAKING CHANGE] cleanup(falco)!: remove `--userspace` support

### DIFF
--- a/userspace/falco/app/actions/helpers_inspector.cpp
+++ b/userspace/falco/app/actions/helpers_inspector.cpp
@@ -86,15 +86,6 @@ falco::app::run_result falco::app::actions::open_live_inspector(
 			falco_logger::log(LOG_INFO, "Opening '" + source + "' source with no driver\n");
 			inspector->open_nodriver();
 		}
-		else if (s.options.userspace) /* udig engine. */
-		{
-			// open_udig() is the underlying method used in the capture code to parse userspace events from the kernel.
-			//
-			// Falco uses a ptrace(2) based userspace implementation.
-			// Regardless of the implementation, the underlying method remains the same.
-			falco_logger::log(LOG_WARNING, "The udig engine is deprecated and will be removed in Falco 0.37. Opening '" + source + "' source with udig\n");
-			inspector->open_udig();
-		}
 		else if(s.is_gvisor_enabled()) /* gvisor engine. */
 		{
 			falco_logger::log(LOG_INFO, "Opening '" + source + "' source with gVisor. Configuration path: " + s.options.gvisor_config);

--- a/userspace/falco/app/options.cpp
+++ b/userspace/falco/app/options.cpp
@@ -37,7 +37,6 @@ options::options()
 	  list_plugins(false),
 	  list_syscall_events(false),
 	  markdown(false),
-	  userspace(false),
 	  modern_bpf(false),
 	  dry_run(false),
 	  nodriver(false)
@@ -148,14 +147,13 @@ bool options::parse(int argc, char **argv, std::string &errstr)
 
 	int open_modes = 0;
 	open_modes += !trace_filename.empty();
-	open_modes += userspace;
 	open_modes += !gvisor_config.empty();
 	open_modes += modern_bpf;
 	open_modes += getenv("FALCO_BPF_PROBE") != NULL;
 	open_modes += nodriver;
 	if (open_modes > 1)
 	{
-		errstr = std::string("You can not specify more than one of -e, -u (--userspace), -g (--gvisor-config), --modern-bpf, --nodriver, and the FALCO_BPF_PROBE env var");
+		errstr = std::string("You can not specify more than one of -e, -g (--gvisor-config), --modern-bpf, --nodriver, and the FALCO_BPF_PROBE env var");
 		return false;
 	}
 
@@ -220,9 +218,6 @@ void options::define(cxxopts::Options& opts)
 		("T",                             "Turn off any rules with a tag=<tag>. This option can be passed multiple times. This option can not be mixed with -t.", cxxopts::value<std::vector<std::string>>(), "<tag>")
 		("t",                             "Only enable those rules with a tag=<tag>. This option can be passed multiple times. This option can not be mixed with -T/-D.", cxxopts::value<std::vector<std::string>>(), "<tag>")
 		("U,unbuffered",                  "Turn off output buffering for configured outputs. This causes every single line emitted by Falco to be flushed, which generates higher CPU usage but is useful when piping those outputs into another process or a script.", cxxopts::value(unbuffered_outputs)->default_value("false"))
-#if !defined(_WIN32) && !defined(__EMSCRIPTEN__) && !defined(MINIMAL_BUILD)
-		("u,userspace",                   "[DEPRECATED: this option will be removed in Falco 0.37] Use a userspace driver to collect 'syscall' events. To be used in conjunction with the ptrace(2) based driver (pdig).", cxxopts::value(userspace)->default_value("false"))
-#endif
 		("V,validate",                    "Read the contents of the specified <rules_file> file(s), validate the loaded rules, and exit. This option can be passed multiple times to validate multiple files.", cxxopts::value(validate_rules_filenames), "<rules_file>")
 		("v",                             "Enable verbose output.", cxxopts::value(verbose)->default_value("false"))
 		("version",                       "Print version information and exit.", cxxopts::value(print_version_info)->default_value("false"))

--- a/userspace/falco/app/options.h
+++ b/userspace/falco/app/options.h
@@ -75,7 +75,6 @@ public:
 	std::set<std::string> disabled_rule_tags;
 	std::set<std::string> enabled_rule_tags;
 	bool unbuffered_outputs;
-	bool userspace;
 	std::vector<std::string> validate_rules_filenames;
 	bool verbose;
 	bool print_version_info;

--- a/userspace/falco/stats_writer.cpp
+++ b/userspace/falco/stats_writer.cpp
@@ -229,7 +229,7 @@ void stats_writer::collector::get_metrics_output_fields_wrapper(
 {
 	static const char* all_driver_engines[] = {
 		BPF_ENGINE, KMOD_ENGINE, MODERN_BPF_ENGINE,
-		SOURCE_PLUGIN_ENGINE, NODRIVER_ENGINE, UDIG_ENGINE, GVISOR_ENGINE };
+		SOURCE_PLUGIN_ENGINE, NODRIVER_ENGINE, GVISOR_ENGINE };
 	const scap_agent_info* agent_info = inspector->get_agent_info();
 	const scap_machine_info* machine_info = inspector->get_machine_info();
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR removes the deprecated `--userspace` option as described here https://github.com/falcosecurity/falco/issues/2763#issue-1877825551

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
cleanup(falco)!: remove `--userspace` support
```
