### PR TITLE
[BREAKING CHANGE] cleanup(falco)!: remove `outputs.rate` and `outputs.max_burst` from Falco config

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -273,34 +273,6 @@ json_include_tags_property: true
 # output mechanism. By default, buffering is disabled (false).
 buffered_outputs: false
 
-# [Stable] `outputs`
-#
-# [DEPRECATED]
-# This config is deprecated and it will be removed in Falco 0.37
-#
-# A throttling mechanism, implemented as a token bucket, can be used to control
-# the rate of Falco outputs. Each event source has its own rate limiter,
-# ensuring that alerts from one source do not affect the throttling of others.
-# The following options control the mechanism:
-#  - rate: the number of tokens (i.e. right to send a notification) gained per
-#    second. When 0, the throttling mechanism is disabled. Defaults to 0.
-#  - max_burst: the maximum number of tokens outstanding. Defaults to 1000.
-#
-# For example, setting the rate to 1 allows Falco to send up to 1000
-# notifications initially, followed by 1 notification per second. The burst
-# capacity is fully restored after 1000 seconds of no activity.
-#
-# Throttling can be useful in various scenarios, such as preventing notification
-# floods, managing system load, controlling event processing, or complying with
-# rate limits imposed by external systems or APIs. It allows for better resource
-# utilization, avoids overwhelming downstream systems, and helps maintain a
-# balanced and controlled flow of notifications.
-#
-# With the default settings, the throttling mechanism is disabled.
-outputs:
-  rate: 0
-  max_burst: 1000
-
 # [Experimental] `rule_matching`
 #
 # The `rule_matching` configuration key's values are:

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -36,8 +36,6 @@ falco_configuration::falco_configuration():
 	m_json_output(false),
 	m_json_include_output_property(true),
 	m_json_include_tags_property(true),
-	m_notifications_rate(0),
-	m_notifications_max_burst(1000),
 	m_rule_matching(falco_common::rule_matching::FIRST),
 	m_watch_config_files(true),
 	m_buffered_outputs(false),
@@ -263,13 +261,6 @@ void falco_configuration::load_yaml(const std::string& config_name, const yaml_h
 	falco_logger::log_syslog = config.get_scalar<bool>("log_syslog", true);
 
 	m_output_timeout = config.get_scalar<uint32_t>("output_timeout", 2000);
-
-	m_notifications_rate = config.get_scalar<uint32_t>("outputs.rate", 0);
-	if(m_notifications_rate != 0)
-	{
-		falco_logger::log(LOG_WARNING, "'output.rate' config is deprecated and it will be removed in Falco 0.37\n");
-	}
-	m_notifications_max_burst = config.get_scalar<uint32_t>("outputs.max_burst", 1000);
 
 	std::string rule_matching = config.get_scalar<std::string>("rule_matching", "first");
 	if (!falco_common::parse_rule_matching(rule_matching, m_rule_matching))

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -65,8 +65,6 @@ public:
 	bool m_json_include_tags_property;
 	std::string m_log_level;
 	std::vector<falco::outputs::config> m_outputs;
-	uint32_t m_notifications_rate;
-	uint32_t m_notifications_max_burst;
 
 	falco_common::priority_type m_min_priority;
 	falco_common::rule_matching m_rule_matching;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR removes deprecated `outputs.rate` and `outputs.max_burst` from Falco config

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
cleanup(falco)!: remove `outputs.rate` and `outputs.max_burst` from Falco config
```
