### PR TITLE
fix(userspace/falco): timer_delete() workaround due to bug in older GLIBC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Released on 2023-09-26
 
 
 * new(falco-driver-loader): --source-only now prints the values as env vars [[#2353](https://github.com/falcosecurity/falco/pull/2353)] - [@steakunderscore](https://github.com/steakunderscore)
-* new(docker): allow passing options to falco-driver-loader from the driver loader cointainer [[#2781](https://github.com/falcosecurity/falco/pull/2781)] - [@LucaGuerra](https://github.com/LucaGuerra)
+* new(docker): allow passing options to falco-driver-loader from the driver loader container [[#2781](https://github.com/falcosecurity/falco/pull/2781)] - [@LucaGuerra](https://github.com/LucaGuerra)
 * new(docker): add experimental falco-distroless image based on Wolfi [[#2768](https://github.com/falcosecurity/falco/pull/2768)] - [@LucaGuerra](https://github.com/LucaGuerra)
 * new: the legacy falco image is available as driver-loader-legacy [[#2718](https://github.com/falcosecurity/falco/pull/2718)] - [@LucaGuerra](https://github.com/LucaGuerra)
 * new: added option to enable/disable echoing of server answer to stdout (disabled by default) when using HTTP output [[#2602](https://github.com/falcosecurity/falco/pull/2602)] - [@FedeDP](https://github.com/FedeDP)
@@ -1086,7 +1086,7 @@ Released on 2021-01-18
 ### Minor Changes
 
 * build: bump b64 to v2.0.0.1 [[#1441](https://github.com/falcosecurity/falco/pull/1441)] - [@fntlnz](https://github.com/fntlnz)
-* rules(macro container_started): re-use `spawned_process` macro inside `container_started` macro [[#1449](https://github.com/falcosecurity/falco/pull/1449)] - [@leodido](https://github.com/leodido)
+* rules(macro container_started): reuse `spawned_process` macro inside `container_started` macro [[#1449](https://github.com/falcosecurity/falco/pull/1449)] - [@leodido](https://github.com/leodido)
 * docs: reach out documentation [[#1472](https://github.com/falcosecurity/falco/pull/1472)] - [@fntlnz](https://github.com/fntlnz)
 * docs: Broken outputs.proto link [[#1493](https://github.com/falcosecurity/falco/pull/1493)] - [@deepskyblue86](https://github.com/deepskyblue86)
 * docs(README.md): correct broken links [[#1506](https://github.com/falcosecurity/falco/pull/1506)] - [@leogr](https://github.com/leogr)

--- a/proposals/20221129-artifacts-distribution.md
+++ b/proposals/20221129-artifacts-distribution.md
@@ -69,7 +69,7 @@ The allowed publishing channels are:
 Both channels are equivalent and may publish the same artifacts. However, for historical reasons and to avoid confusion, the **`docker.io` registry should only be used for container images** and not for other kinds of artifacts (e.g., plugins, rules, etc.).
 
 
-Mirrors are allowed and encouraged if they facilitate artifacts consumption by our users. This proposal reccomends to enable mirrors on the major public OCI registry, such as [Amazon ECR](https://gallery.ecr.aws/) (which is already implentend in our infra at the time of writing).
+Mirrors are allowed and encouraged if they facilitate artifacts consumption by our users. This proposal recommends to enable mirrors on the major public OCI registry, such as [Amazon ECR](https://gallery.ecr.aws/) (which is already implentend in our infra at the time of writing).
 
 
 Official **channels and mirrors must be listed at [falco.org](https://falco.org/)**. 

--- a/userspace/falco/atomic_signal_handler.h
+++ b/userspace/falco/atomic_signal_handler.h
@@ -87,9 +87,9 @@ namespace falco
         /**
          * @brief If a signal is triggered, performs an handler action.
          * The action function will be invoked exactly once among all the
-         * simultaneus calls. The action will not be performed if the
+         * simultaneous calls. The action will not be performed if the
          * signal is not triggered, or if the triggered has already been
-         * handled. When an action is being performed, all the simultaneus
+         * handled. When an action is being performed, all the simultaneous
          * callers will wait and be blocked up until its execution is finished.
          * If the handler action throws an exception, it will be considered
          * performed. After the first handler has been performed, every

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -36,7 +36,7 @@ limitations under the License.
 
 	All methods in this class are thread-safe. The output framework supports
 	a multi-producer model where messages are stored in a queue and consumed
-	by each configured output asynchrounously.
+	by each configured output asynchronously.
 */
 class falco_outputs
 {

--- a/userspace/falco/stats_writer.cpp
+++ b/userspace/falco/stats_writer.cpp
@@ -156,6 +156,7 @@ stats_writer::~stats_writer()
 		if (s_timerid_exists)
 		{
 			timer_delete(s_timerid);
+			s_timerid_exists = false;
 		}
 #endif
 	}

--- a/userspace/falco/stats_writer.cpp
+++ b/userspace/falco/stats_writer.cpp
@@ -37,6 +37,8 @@ static timer_t s_timerid;
 // note: Workaround for older GLIBC versions (< 2.35), where calling timer_delete() 
 // with an invalid timer ID not returned by timer_create() causes a segfault because of 
 // a bug in GLIBC (https://sourceware.org/bugzilla/show_bug.cgi?id=28257).
+// Just performing a nullptr check is not enough as even after creating the timer, s_timerid
+// remains a nullptr somehow.
 bool s_timerid_exists = false;
 
 static void timer_handler(int signum)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Workaround for older GLIBC versions (< 2.35), where calling timer_delete() with an invalid timer ID not returned by timer_create() causes a segfault because of a bug in GLIBC (https://sourceware.org/bugzilla/show_bug.cgi?id=28257).

See also https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1940296.

Also verified it on:

```
[vagrant@centos7 ~]$ uname -r
5.14.15-1.el7.elrepo.x86_64
ldd --version
ldd (GNU libc) 2.17
[vagrant@amazonlinux2 ~]$ uname -r
4.14.314-237.533.amzn2.x86_64
ldd --version
ldd (GNU libc) 2.26
```

and discovered it via backtracing using gdb debugger.

Impact: High for adopters using the metrics feature on a system with impacted GLIBC version.

@FedeDP @Andreagit97 @jasondellaluce curious, would you have a better workaround idea? Also couldn't come up with a good unit testing idea other than adding a test to the falco testing repo https://github.com/falcosecurity/testing/pull/30.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2850

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(userspace/falco): timer_delete() workaround due to bug in older GLIBC
```
