### PR TITLE
fix(userspace): workaround glibc bug that segfaults instead of returning EINVAL in timer_delete()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Released on 2023-09-26
 
 
 * new(falco-driver-loader): --source-only now prints the values as env vars [[#2353](https://github.com/falcosecurity/falco/pull/2353)] - [@steakunderscore](https://github.com/steakunderscore)
-* new(docker): allow passing options to falco-driver-loader from the driver loader cointainer [[#2781](https://github.com/falcosecurity/falco/pull/2781)] - [@LucaGuerra](https://github.com/LucaGuerra)
+* new(docker): allow passing options to falco-driver-loader from the driver loader container [[#2781](https://github.com/falcosecurity/falco/pull/2781)] - [@LucaGuerra](https://github.com/LucaGuerra)
 * new(docker): add experimental falco-distroless image based on Wolfi [[#2768](https://github.com/falcosecurity/falco/pull/2768)] - [@LucaGuerra](https://github.com/LucaGuerra)
 * new: the legacy falco image is available as driver-loader-legacy [[#2718](https://github.com/falcosecurity/falco/pull/2718)] - [@LucaGuerra](https://github.com/LucaGuerra)
 * new: added option to enable/disable echoing of server answer to stdout (disabled by default) when using HTTP output [[#2602](https://github.com/falcosecurity/falco/pull/2602)] - [@FedeDP](https://github.com/FedeDP)
@@ -1086,7 +1086,7 @@ Released on 2021-01-18
 ### Minor Changes
 
 * build: bump b64 to v2.0.0.1 [[#1441](https://github.com/falcosecurity/falco/pull/1441)] - [@fntlnz](https://github.com/fntlnz)
-* rules(macro container_started): re-use `spawned_process` macro inside `container_started` macro [[#1449](https://github.com/falcosecurity/falco/pull/1449)] - [@leodido](https://github.com/leodido)
+* rules(macro container_started): reuse `spawned_process` macro inside `container_started` macro [[#1449](https://github.com/falcosecurity/falco/pull/1449)] - [@leodido](https://github.com/leodido)
 * docs: reach out documentation [[#1472](https://github.com/falcosecurity/falco/pull/1472)] - [@fntlnz](https://github.com/fntlnz)
 * docs: Broken outputs.proto link [[#1493](https://github.com/falcosecurity/falco/pull/1493)] - [@deepskyblue86](https://github.com/deepskyblue86)
 * docs(README.md): correct broken links [[#1506](https://github.com/falcosecurity/falco/pull/1506)] - [@leogr](https://github.com/leogr)

--- a/proposals/20221129-artifacts-distribution.md
+++ b/proposals/20221129-artifacts-distribution.md
@@ -69,7 +69,7 @@ The allowed publishing channels are:
 Both channels are equivalent and may publish the same artifacts. However, for historical reasons and to avoid confusion, the **`docker.io` registry should only be used for container images** and not for other kinds of artifacts (e.g., plugins, rules, etc.).
 
 
-Mirrors are allowed and encouraged if they facilitate artifacts consumption by our users. This proposal reccomends to enable mirrors on the major public OCI registry, such as [Amazon ECR](https://gallery.ecr.aws/) (which is already implentend in our infra at the time of writing).
+Mirrors are allowed and encouraged if they facilitate artifacts consumption by our users. This proposal recommends to enable mirrors on the major public OCI registry, such as [Amazon ECR](https://gallery.ecr.aws/) (which is already implentend in our infra at the time of writing).
 
 
 Official **channels and mirrors must be listed at [falco.org](https://falco.org/)**. 

--- a/userspace/falco/atomic_signal_handler.h
+++ b/userspace/falco/atomic_signal_handler.h
@@ -87,9 +87,9 @@ namespace falco
         /**
          * @brief If a signal is triggered, performs an handler action.
          * The action function will be invoked exactly once among all the
-         * simultaneus calls. The action will not be performed if the
+         * simultaneous calls. The action will not be performed if the
          * signal is not triggered, or if the triggered has already been
-         * handled. When an action is being performed, all the simultaneus
+         * handled. When an action is being performed, all the simultaneous
          * callers will wait and be blocked up until its execution is finished.
          * If the handler action throws an exception, it will be considered
          * performed. After the first handler has been performed, every

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -36,7 +36,7 @@ limitations under the License.
 
 	All methods in this class are thread-safe. The output framework supports
 	a multi-producer model where messages are stored in a queue and consumed
-	by each configured output asynchrounously.
+	by each configured output asynchronously.
 */
 class falco_outputs
 {

--- a/userspace/falco/stats_writer.cpp
+++ b/userspace/falco/stats_writer.cpp
@@ -62,7 +62,11 @@ bool stats_writer::init_ticker(uint32_t interval_msec, std::string &err)
 	// delete any previously set timer
 	if (s_timerid)
 	{
-		timer_delete(s_timerid);
+		if (timer_delete(s_timerid) == -1)
+		{
+			err = std::string("Failed to delete existing timer: ") + strerror(errno);
+			return false;
+		}
 	}
 	if (timer_create(CLOCK_MONOTONIC, &sev, &s_timerid) == -1) {
 		err = std::string("Could not create periodic timer: ") + strerror(errno);

--- a/userspace/falco/stats_writer.cpp
+++ b/userspace/falco/stats_writer.cpp
@@ -60,7 +60,10 @@ bool stats_writer::init_ticker(uint32_t interval_msec, std::string &err)
 	sev.sigev_value.sival_ptr = &s_timerid;
 #ifndef __EMSCRIPTEN__
 	// delete any previously set timer
-	timer_delete(s_timerid);
+	if (s_timerid)
+	{
+		timer_delete(s_timerid);
+	}
 	if (timer_create(CLOCK_MONOTONIC, &sev, &s_timerid) == -1) {
 		err = std::string("Could not create periodic timer: ") + strerror(errno);
 		return false;
@@ -134,7 +137,11 @@ stats_writer::~stats_writer()
 		}
 		// delete timerID and reset timer
 #ifndef __EMSCRIPTEN__
-		timer_delete(s_timerid);
+		if (s_timerid)
+		{
+			timer_delete(s_timerid);
+			s_timerid = nullptr;
+		}
 #endif
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Workarounds glibc bug: See https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1940296.

**Which issue(s) this PR fixes**:

Fixes #2850 

**Special notes for your reviewer**:

This also fixes some `codespell` related issues.

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(userspace/falco): workaround glibc bug https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1940296. 
```
