### PR TITLE
chore: bump libs to the latest tag 0.13.2

### DIFF
--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -35,8 +35,8 @@ else()
   # In case you want to test against another falcosecurity/libs version (or branch, or commit) just pass the variable -
   # ie., `cmake -DFALCOSECURITY_LIBS_VERSION=dev ..` 
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "0.13.2-rc1")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=2f5155bb81ee8d65ec76c20d55ebbfa1a196893fdee4450d63bcf873dfcbb90d")
+    set(FALCOSECURITY_LIBS_VERSION "0.13.2")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=442810cc09a63406053ec3506ca16b59b5f5514ab08d478632f65beac6f167b5")
   endif()
 
   # cd /path/to/build && cmake /path/to/source


### PR DESCRIPTION
**What type of PR is this?**

/kind release

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This PR bumps libs to the latest available tag `0.13.2`. We need to open the PR directly against the release branch because Falco master doesn't work anymore with `0.13.2`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
