### PR TITLE
fix(userspace/engine): solve description of macro-only rules

### DIFF
--- a/userspace/engine/filter_details_resolver.cpp
+++ b/userspace/engine/filter_details_resolver.cpp
@@ -41,6 +41,8 @@ void filter_details::reset()
 void filter_details_resolver::run(ast::expr* filter, filter_details& details)
 {
 	visitor v(details);
+	// note: we may have ASTs composed on only one macro ref
+	v.m_expect_macro = true;
 	filter->accept(&v);
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

When using `falco -L -o json_output=true`, we have a minor bug in which macro dependencies are not found for rules in which the condition is composed by only one macro reference.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/engine): solve description of macro-only rules
```
