### PR TITLE
update(userspace/falco): introduce new engine_version_semver key in v…

### DIFF
--- a/userspace/falco/versions_info.cpp
+++ b/userspace/falco/versions_info.cpp
@@ -72,7 +72,12 @@ nlohmann::json falco::versions_info::as_json() const
     version_info["driver_api_version"] = driver_api_version;
     version_info["driver_schema_version"] = driver_schema_version;
     version_info["default_driver_version"] = default_driver_version;
-    version_info["engine_version"] = engine_version;
+    // note: the 'engine_version' key below must be removed in the next major bump (0.x.y -> 1.0.0)
+    // the two keys are kept for existing tooling that relies on the old key
+    // (falcoctl will match old rules artifacts configs by using this key, and the new ones using 
+    // the engine_version_semver key)
+    version_info["engine_version"] = std::to_string(FALCO_ENGINE_VERSION_MINOR);
+    version_info["engine_version_semver"] = engine_version;
     for (const auto& pv : plugin_versions)
     {
         version_info["plugin_versions"][pv.first] = pv.second;


### PR DESCRIPTION
…ersions endpoint

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
With this PR we introduce a new key in the Falco `/versions` endpoint. This key will be used by `falcoctl` to match new artifact configs containing a full semver string for representing the required engine version.

The rationale for this change is the following:
- Falco is already able to read `engine_version` both as numeric valuer or semver string
- Rules repositories must be updated to use a full semver string for `required_engine_version` (already did it for Falco rules, will need this also for plugin rules). This will require a ***major*** bump for each artifact
- New artifact config layers will contains the new `engine_version_semver` key
- Let's also point out that `falcoctl` is already "keys agnostic". It just starts processing and matching keys starting from the config layer, and as long as it finds the same key in the `/versions` endpoint, we are fine.

With this being said, we end up in this situation (example for falco rules, will be the same for plugin rules):

| Falco version      | Rules and CI versions | Outcome |
| ----------- | ----------- | --------------|
| < 0.37| <= 2.0.0|  Nothing changed, will work as before |
| < 0.37| > 2.0.0|  If you upgrade only the rules, falcoctl will find two different keys and will not be able to match them, causing an error in falcoctl, not upgrading the rules. Also, if you manually start Falco with the new rules (on host, maybe) Falco will not start. I think this is perfectly fine, cause the rule will have a new major, so you must update Falco as well (would be the same if the engine version was only bumped, even if it was numeric)|
| >= 0.37| <= 2.0.0| Falco is updated. You can continue to follow 2.x.y rules, because it is able to read both a numeric engine version and a semver one. If you want, you can also follow the new rules (3.0.0)(see below) |
| >= 0.37| >2.0.0| Everything is new, so it will work as expected by matching the new key|

PRs for updating the config layers are coming soon!

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
update add `engine_version_semver` key in `/versions` endpoint
```
