### PR TITLE
fix(userspace/engine): cache latest rules compilation output

### DIFF
--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -40,6 +40,7 @@ limitations under the License.
 #include "falco_load_result.h"
 #include "filter_details_resolver.h"
 #include "rule_loader_reader.h"
+#include "rule_loader_compiler.h"
 
 //
 // This class acts as the primary interface between a program and the
@@ -346,6 +347,8 @@ private:
 	uint16_t m_next_ruleset_id;
 	std::map<std::string, uint16_t> m_known_rulesets;
 	falco_common::priority_type m_min_priority;
+
+	std::unique_ptr<rule_loader::compiler::compile_output> m_last_compile_output;
 
 	//
 	// Here's how the sampling ratio and multiplier influence


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This fixes a performance regression introduced in `falco -L` since the latest release, caused by the fact that we re-compile the whole set of loaded rules twice. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/engine): cache latest rules compilation output
```
