### PR TITLE
fix(gha): disable branch protection rule trigger for scorecard

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -4,14 +4,19 @@
 
 name: Scorecard supply-chain security
 on:
-  # For Branch-Protection check. Only the default branch is supported. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
-  branch_protection_rule:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
     # Weekly on Mondays at 00:00.
     - cron: '0 0 * * 1'
+
+  # The OSSF recommendation encourages to enable branch protection rules trigger
+  # to update the scorecard
+  # (https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection)
+  # but due to our GitHub org management this check is triggered too often and is
+  # therefore disabled.
+  # branch_protection_rule:
+  
   push:
     branches: [ "master" ]
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:


/area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

As per attached screenshot, which is not supposed to happen:
![image](https://github.com/falcosecurity/falco/assets/35580196/f1d5f22e-b89c-4a45-ac3a-20d30d1d9b76)

I'm not completely sure what triggers it (but 99% is test-infra checking if repos need to be updated) but I believe it's safe to disable it for now.

Thanks @Andreagit97 @FedeDP for the heads up and taking a look at our pipelines!

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
