### PR TITLE
cleanup(falco): remove `init` in the configuration constructor

### DIFF
--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -78,7 +78,6 @@ falco_configuration::falco_configuration():
 	m_metrics_convert_memory_to_mb(true),
 	m_metrics_include_empty_values(false)
 {
-	init({});
 }
 
 void falco_configuration::init(const std::vector<std::string>& cmdline_options)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This `init({});` in the falco_configuration constructor is unnecessary since when we call the action `load_config`, if we don't have a config file, we will call the same `init` we have just removed. This cleanup avoids calling `falco_configuration::init` 2 times

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
