### PR TITLE
chore(unit_test,userspace): allow env var to get expanded in yaml even when part of a string

### DIFF
--- a/unit_tests/falco/test_configuration.cpp
+++ b/unit_tests/falco/test_configuration.cpp
@@ -128,6 +128,10 @@ TEST(Configuration, configuration_environment_variables)
     std::string int_env_var_name = "ENV_VAR_INT";
     SET_ENV_VAR(int_env_var_name.c_str(), int_env_var_value.c_str());
 
+    std::string empty_env_var_value = "";
+    std::string empty_env_var_name = "ENV_VAR_EMPTY";
+    SET_ENV_VAR(empty_env_var_name.c_str(), empty_env_var_value.c_str());
+
     std::string default_value = "default";
     std::string env_var_sample_yaml =
         "base_value:\n"
@@ -153,7 +157,8 @@ TEST(Configuration, configuration_environment_variables)
 	"    - /${ENV_VAR}/${ENV_VAR}${ENV_VAR}/foo\n"
 	"    - ${ENV_VAR_EMBEDDED}/foo\n"
 	"is_test: ${ENV_VAR_BOOL}\n"
-	"num_test: ${ENV_VAR_INT}\n";
+	"num_test: ${ENV_VAR_INT}\n"
+	"empty_test: ${ENV_VAR_EMPTY}\n";
 
     yaml_helper conf;
     conf.load_from_string(env_var_sample_yaml);
@@ -198,7 +203,7 @@ TEST(Configuration, configuration_environment_variables)
     ASSERT_EQ(base_value_2_list_1, " " + env_var_value); // Environment variable preceded by a space, still extracted env var with leading space
 
     auto base_value_2_list_2 = conf.get_scalar<std::string>("base_value_2.sample_list[2]", default_value);
-    ASSERT_EQ(base_value_2_list_2, env_var_value + " "); // Environment variable proceeded by a space, still extracted env var with trailing space
+    ASSERT_EQ(base_value_2_list_2, env_var_value + " "); // Environment variable followed by a space, still extracted env var with trailing space
 
     auto base_value_2_list_3 = conf.get_scalar<std::string>("base_value_2.sample_list[3]", default_value);
     ASSERT_EQ(base_value_2_list_3, "$UNSED_XX_X_X_VAR"); // Does not follow the `${VAR}` format, so should be treated as a regular string
@@ -232,11 +237,16 @@ TEST(Configuration, configuration_environment_variables)
     auto integer = conf.get_scalar<int32_t>("num_test", -1);
     ASSERT_EQ(integer, 12);
 
+    // An env var that resolves to an empty string returns default value
+    auto empty_default_str = conf.get_scalar<std::string>("empty_test", "test");
+    ASSERT_EQ(empty_default_str, "test");
+
     /* Clear the set environment variables after testing */
     SET_ENV_VAR(env_var_name.c_str(), "");
     SET_ENV_VAR(embedded_env_var_name.c_str(), "");
     SET_ENV_VAR(bool_env_var_name.c_str(), "");
     SET_ENV_VAR(int_env_var_name.c_str(), "");
+    SET_ENV_VAR(empty_env_var_name.c_str(), "");
 }
 
 TEST(Configuration, configuration_webserver_ip)

--- a/unit_tests/falco/test_configuration.cpp
+++ b/unit_tests/falco/test_configuration.cpp
@@ -114,11 +114,14 @@ TEST(Configuration, configuration_environment_variables)
     // Set an environment variable for testing purposes
     std::string env_var_value = "envVarValue";
     std::string env_var_name = "ENV_VAR";
-    std::string default_value = "default";
     SET_ENV_VAR(env_var_name.c_str(), env_var_value.c_str());
-    yaml_helper conf;
 
-    std::string sample_yaml =
+    std::string embedded_env_var_value = "${ENV_VAR}";
+    std::string embedded_env_var_name = "ENV_VAR_EMBEDDED";
+    SET_ENV_VAR(embedded_env_var_name.c_str(), embedded_env_var_value.c_str());
+
+    std::string default_value = "default";
+    std::string env_var_sample_yaml =
         "base_value:\n"
         "    id: $ENV_VAR\n"
         "    name: '${ENV_VAR}'\n"
@@ -133,52 +136,81 @@ TEST(Configuration, configuration_environment_variables)
         "    sample_list:\n"
         "        - ${ENV_VAR}\n"
         "        - ' ${ENV_VAR}'\n"
-        "        - $UNSED_XX_X_X_VAR\n";
-    conf.load_from_string(sample_yaml);
+	"        - '${ENV_VAR} '\n"
+        "        - $UNSED_XX_X_X_VAR\n"
+        "paths:\n"
+	"    - ${ENV_VAR}/foo\n"
+	"    - $ENV_VAR/foo\n"
+	"    - /foo/${ENV_VAR}/\n"
+	"    - /${ENV_VAR}/${ENV_VAR}${ENV_VAR}/foo\n"
+	"    - ${ENV_VAR_EMBEDDED}/foo\n";
+    yaml_helper conf;
+    conf.load_from_string(env_var_sample_yaml);
 
     /* Check if the base values are defined */
     ASSERT_TRUE(conf.is_defined("base_value"));
     ASSERT_TRUE(conf.is_defined("base_value_2"));
+    ASSERT_TRUE(conf.is_defined("paths"));
     ASSERT_FALSE(conf.is_defined("unknown_base_value"));
 
     /* Test fetching of a regular string without any environment variable */
-    std::string base_value_string = conf.get_scalar<std::string>("base_value.string", default_value);
+    auto base_value_string = conf.get_scalar<std::string>("base_value.string", default_value);
     ASSERT_EQ(base_value_string, "my_string");
 
     /* Test fetching of escaped environment variable format. Should return the string as-is after stripping the leading `$` */
-    std::string base_value_invalid = conf.get_scalar<std::string>("base_value.invalid", default_value);
+    auto base_value_invalid = conf.get_scalar<std::string>("base_value.invalid", default_value);
     ASSERT_EQ(base_value_invalid, "${ENV_VAR}");
 
-	/* Test fetching of invalid escaped environment variable format. Should return the string as-is */
-    std::string base_value_invalid_env = conf.get_scalar<std::string>("base_value.invalid_env", default_value);
+    /* Test fetching of invalid escaped environment variable format. Should return the string as-is */
+    auto base_value_invalid_env = conf.get_scalar<std::string>("base_value.invalid_env", default_value);
     ASSERT_EQ(base_value_invalid_env, "$$ENV_VAR");
 
     /* Test fetching of strings that contain environment variables */
-    std::string base_value_id = conf.get_scalar<std::string>("base_value.id", default_value);
+    auto base_value_id = conf.get_scalar<std::string>("base_value.id", default_value);
     ASSERT_EQ(base_value_id, "$ENV_VAR"); // Does not follow the `${VAR}` format, so it should be treated as a regular string
 
-    std::string base_value_name = conf.get_scalar<std::string>("base_value.name", default_value);
+    auto base_value_name = conf.get_scalar<std::string>("base_value.name", default_value);
     ASSERT_EQ(base_value_name, env_var_value); // Proper environment variable format
 
-    std::string base_value_escaped = conf.get_scalar<std::string>("base_value.escaped", default_value);
+    auto base_value_escaped = conf.get_scalar<std::string>("base_value.escaped", default_value);
     ASSERT_EQ(base_value_escaped, env_var_value); // Environment variable within quotes
 
     /* Test fetching of an undefined environment variable. Expected to return the default value.*/
-    std::string unknown_boolean = conf.get_scalar<std::string>("base_value.subvalue.subvalue2.boolean", default_value);
+    auto unknown_boolean = conf.get_scalar<std::string>("base_value.subvalue.subvalue2.boolean", default_value);
     ASSERT_EQ(unknown_boolean, default_value);
 
     /* Test fetching of environment variables from a list */
-    std::string base_value_2_list_0 = conf.get_scalar<std::string>("base_value_2.sample_list[0]", default_value);
+    auto base_value_2_list_0 = conf.get_scalar<std::string>("base_value_2.sample_list[0]", default_value);
     ASSERT_EQ(base_value_2_list_0, env_var_value); // Proper environment variable format
 
-    std::string base_value_2_list_1 = conf.get_scalar<std::string>("base_value_2.sample_list[1]", default_value);
-    ASSERT_EQ(base_value_2_list_1, " ${ENV_VAR}"); // Environment variable preceded by a space, hence treated as a regular string
+    auto base_value_2_list_1 = conf.get_scalar<std::string>("base_value_2.sample_list[1]", default_value);
+    ASSERT_EQ(base_value_2_list_1, " " + env_var_value); // Environment variable preceded by a space, still extracted env var with leading space
 
-    std::string base_value_2_list_2 = conf.get_scalar<std::string>("base_value_2.sample_list[2]", default_value);
-    ASSERT_EQ(base_value_2_list_2, "$UNSED_XX_X_X_VAR"); // Does not follow the `${VAR}` format, so should be treated as a regular string
+    auto base_value_2_list_2 = conf.get_scalar<std::string>("base_value_2.sample_list[2]", default_value);
+    ASSERT_EQ(base_value_2_list_2, env_var_value + " "); // Environment variable proceeded by a space, still extracted env var with trailing space
+
+    auto base_value_2_list_3 = conf.get_scalar<std::string>("base_value_2.sample_list[3]", default_value);
+    ASSERT_EQ(base_value_2_list_3, "$UNSED_XX_X_X_VAR"); // Does not follow the `${VAR}` format, so should be treated as a regular string
+
+    /* Test expansion of environment variables within strings */
+    auto path_list_0 = conf.get_scalar<std::string>("paths[0]", default_value);
+    ASSERT_EQ(path_list_0, env_var_value + "/foo"); // Even if env var is part of bigger string, it gets expanded
+
+    auto path_list_1 = conf.get_scalar<std::string>("paths[1]", default_value);
+    ASSERT_EQ(path_list_1, "$ENV_VAR/foo"); // Does not follow the `${VAR}` format, so should be treated as a regular string
+
+    auto path_list_2 = conf.get_scalar<std::string>("paths[2]", default_value);
+    ASSERT_EQ(path_list_2, "/foo/" + env_var_value + "/"); // Even when env var is in the middle of a string. it gets expanded
+
+    auto path_list_3 = conf.get_scalar<std::string>("paths[3]", default_value);
+    ASSERT_EQ(path_list_3, "/" + env_var_value + "/" + env_var_value + env_var_value + "/foo"); // Even when the string contains multiple env vars they are correctly expanded
+
+    auto path_list_4 = conf.get_scalar<std::string>("paths[4]", default_value);
+    ASSERT_EQ(path_list_4, env_var_value + "/foo"); // Even when the env var contains another env var, it gets correctly double-expanded
 
     /* Clear the set environment variable after testing */
-    SET_ENV_VAR(env_var_name.c_str(), env_var_value.c_str());
+    SET_ENV_VAR(env_var_name.c_str(), "");
+    SET_ENV_VAR(embedded_env_var_name.c_str(), "");
 }
 
 TEST(Configuration, configuration_webserver_ip)

--- a/userspace/falco/yaml_helper.h
+++ b/userspace/falco/yaml_helper.h
@@ -93,7 +93,7 @@ public:
 				}
 				std::stringstream ss(str);
 				T result;
-				if (ss >> result) return result;
+				if (ss >> std::boolalpha >> result) return result;
 				return default_value;
 			};
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Moreover, support env variable embedding another env variable.

Basically, this PR would allow us to use eg:
```
engine:
  ebpf:
    probe: /${HOME}/.falco/falco-bpf.o
```
in #2413.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new(userspace): support env variable expansion in all yaml, even inside strings.
```
