### PR TITLE
fix(userspace/falco): use resolved plugin name when opening a plugin

### DIFF
--- a/userspace/falco/app/actions/helpers_inspector.cpp
+++ b/userspace/falco/app/actions/helpers_inspector.cpp
@@ -63,7 +63,7 @@ falco::app::run_result falco::app::actions::open_live_inspector(
 				{
 					auto cfg = s.plugin_configs.at(p->name());
 					falco_logger::log(falco_logger::level::INFO, "Opening '" + source + "' source with plugin '" + cfg->m_name + "'");
-					inspector->open_plugin(cfg->m_name, cfg->m_open_params);
+					inspector->open_plugin(p->name(), cfg->m_open_params);
 					return run_result::ok();
 				}
 			}
@@ -81,7 +81,7 @@ falco::app::run_result falco::app::actions::open_live_inspector(
 				{
 					auto cfg = s.plugin_configs.at(p->name());
 					falco_logger::log(falco_logger::level::INFO, "Opening '" + source + "' source with plugin '" + cfg->m_name + "'");
-					inspector->open_plugin(cfg->m_name, cfg->m_open_params);
+					inspector->open_plugin(p->name(), cfg->m_open_params);
 					return run_result::ok();
 				}
 			}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Previously, to enable a plugin users needed to know the plugin name, ie: the name exposed by the `plugin_get_name` plugin API.
Now, we automatically use the plugin name internally, while externally we satisfy the name given by the user in the `plugins` section.
Basically, user can now write:
```
load_plugins: [dummyFOO]

plugins:
  - name: dummyFOO
    library_path: libdummy.so
    init_config:
    jitter: 10
    open_params: "100"
```

And getting its dummyFOO plugin loaded correctly, while previously we would've failed, unless the `load_plugins` contained the real plugin name (in this case `dummy`).

From a UX PoV, i think the user shall know nothing about real plugin name; she/he should just have the `.so` of the plugin to be loaded and use the desired name in the config (like, in the example above, `dummyFOO`).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
