### PR TITLE
new(falco): print system info when Falco starts

### DIFF
--- a/userspace/falco/CMakeLists.txt
+++ b/userspace/falco/CMakeLists.txt
@@ -36,6 +36,7 @@ set(
   app/actions/print_generated_gvisor_config.cpp
   app/actions/print_help.cpp
   app/actions/print_ignored_events.cpp
+  app/actions/print_kernel_version.cpp
   app/actions/print_plugin_info.cpp
   app/actions/print_support.cpp
   app/actions/print_syscall_events.cpp

--- a/userspace/falco/app/actions/actions.h
+++ b/userspace/falco/app/actions/actions.h
@@ -41,6 +41,7 @@ falco::app::run_result load_rules_files(falco::app::state& s);
 falco::app::run_result print_generated_gvisor_config(falco::app::state& s);
 falco::app::run_result print_help(falco::app::state& s);
 falco::app::run_result print_ignored_events(falco::app::state& s);
+falco::app::run_result print_kernel_version(falco::app::state& s);
 falco::app::run_result print_page_size(falco::app::state& s);
 falco::app::run_result print_plugin_info(falco::app::state& s);
 falco::app::run_result print_support(falco::app::state& s);

--- a/userspace/falco/app/actions/print_kernel_version.cpp
+++ b/userspace/falco/app/actions/print_kernel_version.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "actions.h"
+#include "helpers.h"
+#include "../app.h"
+#include <fstream>
+#include <sstream>
+#include <errno.h>
+
+using namespace falco::app;
+using namespace falco::app::actions;
+
+falco::app::run_result falco::app::actions::print_kernel_version(falco::app::state& s)
+{
+#ifdef __linux__
+	// We print this info only when a kernel driver is injected
+	if(s.is_modern_ebpf() || s.is_ebpf() || s.is_kmod())
+	{
+		std::ifstream input_file("/proc/version");
+		if(!input_file.is_open())
+		{
+			// We don't want to fail, we just need to log something
+			falco_logger::log(falco_logger::level::INFO, "Cannot read under '/proc/version' (err_message: '" + std::string(strerror(errno)) + "', err_code: " + std::to_string(errno) + "). No info provided, go on.");
+			return run_result::ok();
+		}
+
+		std::stringstream buffer;
+		buffer << input_file.rdbuf();
+		std::string contents(buffer.str());
+		falco_logger::log(falco_logger::level::INFO, "System info: " + contents);
+	}
+#endif
+	return run_result::ok();
+}

--- a/userspace/falco/app/app.cpp
+++ b/userspace/falco/app/app.cpp
@@ -62,6 +62,7 @@ bool falco::app::run(falco::app::state& s, bool& restart, std::string& errstr)
 	std::list<app_action> run_steps = {
 		falco::app::actions::load_config,
 		falco::app::actions::print_help,
+		falco::app::actions::print_kernel_version,
 		falco::app::actions::print_version,
 		falco::app::actions::print_page_size,
 		falco::app::actions::print_generated_gvisor_config,

--- a/userspace/falco/app/state.h
+++ b/userspace/falco/app/state.h
@@ -155,6 +155,11 @@ struct state
         return config->m_engine_mode == engine_kind_t::GVISOR;
     }
 
+    inline bool is_kmod() const
+    {
+        return config->m_engine_mode == engine_kind_t::KMOD;
+    }
+
     inline bool is_ebpf() const
     {
         return config->m_engine_mode == engine_kind_t::EBPF;


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR helps maintainers in triaging issues and users in reporting effective info on issues. The idea is to print the content of `/proc/version` in the Falco startup messages @FedeDP 

```
Mon Nov 27 15:48:06 2023: Falco version: 0.37.0-155+6095d10 (x86_64)
Mon Nov 27 15:48:06 2023: Falco initialized with configuration file: ../falco.yaml
Mon Nov 27 15:48:06 2023: System info: Linux version 6.2.0-37-generic (buildd@bos03-amd64-055) (x86_64-linux-gnu-gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38) #38~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov  2 18:01:13 UTC 2
Mon Nov 27 15:48:06 2023: Loading rules from file ../rules/falco_rules.yaml
Mon Nov 27 15:48:06 2023: The chosen syscall buffer dimension is: 8388608 bytes (8 MBs)
Mon Nov 27 15:48:06 2023: Starting health webserver with threadiness 8, listening on 0.0.0.0:8765
Mon Nov 27 15:48:06 2023: Loaded event sources: syscall
Mon Nov 27 15:48:06 2023: Enabled event sources: syscall
Mon Nov 27 15:48:06 2023: Opening 'syscall' source with BPF probe. BPF probe path: /root/.falco/falco-bpf.o
```

In case we are not able to read under `/proc/version` we provide a log but we don't fail


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new(falco): print system info when Falco starts
```
