### PR TITLE
chore(docker/falco): add back some deps to falco docker image.

### DIFF
--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -19,17 +19,26 @@ RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
+	bc \
+	bison \
 	ca-certificates \
 	clang \
 	curl \
 	dkms \
+	dwarves \
+	flex \
 	gcc \
 	gcc-11 \
 	gnupg2 \
 	jq \
-	libelf1 \
+	libc6-dev \
+	libelf-dev \
+	libssl-dev \
 	llvm \
 	make \
+	netcat-openbsd \
+	patchelf \
+	xz-utils \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN curl -s https://falco.org/repo/falcosecurity-packages.asc | apt-key add - \


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

The PR adds back some deps that were removed in https://github.com/falcosecurity/falco/commit/c2b940f8c4e0d23a6acf24394b99c1814cb59e64 from the Falco "fat" image.

Those deps are needed to build drivers on some distros/kernel configs. 
I added back the ones that are provided by the `falco-driver-loader-legacy` image.
See relevant slack thread: https://kubernetes.slack.com/archives/CMWH3EH32/p1701249107807099

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
