### PR TITLE
cleanup(falco): remove decode_uri as it is no longer used

### DIFF
--- a/unit_tests/engine/test_falco_utils.cpp
+++ b/unit_tests/engine/test_falco_utils.cpp
@@ -72,22 +72,3 @@ TEST(FalcoUtils, parse_prometheus_interval)
 	 */
 	ASSERT_EQ(falco::utils::parse_prometheus_interval("200"), 0UL);
 }
-
-TEST(FalcoUtils, decode_url)
-{
-	ASSERT_EQ(
-		falco::utils::decode_uri("https://www.example.com?key1=value+1&key2=value%40%21%242&key3=value%253", true),
-		"https://www.example.com?key1=value 1&key2=value@!$2&key3=value%3");
-	
-	ASSERT_EQ(
-		falco::utils::decode_uri("https://download.falco.org/?prefix=driver/3.0.1%2Bdriver/x86_64/", true),
-		"https://download.falco.org/?prefix=driver/3.0.1+driver/x86_64/");
-
-	ASSERT_EQ(
-		falco::utils::decode_uri("https://example.com/hello%20world", true),
-		"https://example.com/hello world");
-
-	ASSERT_EQ(
-		falco::utils::decode_uri("https://example.com/helloworld", true),
-		"https://example.com/helloworld");
-}

--- a/userspace/engine/falco_utils.cpp
+++ b/userspace/engine/falco_utils.cpp
@@ -20,7 +20,6 @@ limitations under the License.
 #include <cstring>
 #include <iomanip>
 
-#include "falco_common.h"
 #include "falco_utils.h"
 #include "utils.h"
 
@@ -159,80 +158,6 @@ void readfile(const std::string& filename, std::string& data)
 	}
 
 	return;
-}
-
-// URI-decodes the given string by replacing percent-encoded
-// characters with the actual character. Returns the decoded string.
-//
-// When plus_as_space is true, non-encoded plus signs in the query are decoded as spaces.
-// (http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1)
-std::string decode_uri(const std::string& str, bool plus_as_space)
-{
-	std::string decoded_str;
-	bool in_query = false;
-	std::string::const_iterator it  = str.begin();
-	std::string::const_iterator end = str.end();
-	while(it != end)
-	{
-		char c = *it++;
-		if(c == '?')
-		{
-			in_query = true;
-		}
-		// spaces may be encoded as plus signs in the query
-		if(in_query && plus_as_space && c == '+')
-		{
-			c = ' ';
-		}
-		else if(c == '%')
-		{
-			if (it == end)
-			{
-				throw falco_exception("URI encoding: no hex digit following percent sign in " + str);
-			}
-			char hi = *it++;
-			if (it == end)
-			{
-				throw falco_exception("URI encoding: two hex digits must follow percent sign in " + str);
-			}
-			char lo = *it++;
-			if (hi >= '0' && hi <= '9')
-			{
-				c = hi - '0';
-			}
-			else if (hi >= 'A' && hi <= 'F')
-			{
-				c = hi - 'A' + 10;
-			}
-			else if (hi >= 'a' && hi <= 'f')
-			{
-				c = hi - 'a' + 10;
-			}
-			else
-			{
-				throw falco_exception("URI encoding: not a hex digit found in " + str);
-			}
-			c *= 16;
-			if (lo >= '0' && lo <= '9')
-			{
-				c += lo - '0';
-			}
-			else if (lo >= 'A' && lo <= 'F')
-			{
-				c += lo - 'A' + 10;
-			}
-			else if (lo >= 'a' && lo <= 'f')
-			{
-				c += lo - 'a' + 10;
-			}
-			else
-			{
-				throw falco_exception("URI encoding: not a hex digit");
-			}
-		}
-		decoded_str += c;
-	}
-	return decoded_str;
 }
 
 namespace network

--- a/userspace/engine/falco_utils.h
+++ b/userspace/engine/falco_utils.h
@@ -52,8 +52,6 @@ void readfile(const std::string& filename, std::string& data);
 
 uint32_t hardware_concurrency();
 
-std::string decode_uri(const std::string& str, bool plus_as_space);
-
 namespace network
 {
 static const std::string UNIX_SCHEME("unix://");


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

For all the fans of "wax on, wax off" out there, I'm going to basically revert https://github.com/falcosecurity/falco/pull/2912 because the only calling function needed to be removed but I didn't realize. Less unreachable code to worry about.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
