### PR TITLE
chore(falco.yaml): use HOME env var for ebpf probe path.

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -318,7 +318,7 @@ engine:
     drop_failed_exit: false
   ebpf:
     # path to the elf file to load.
-    probe: /root/.falco/falco-bpf.o
+    probe: ${HOME}/.falco/falco-bpf.o
     buf_size_preset: 4
     drop_failed_exit: false
   modern_ebpf:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

Since #2918 is now merged, we can freely use env var.
This is more correct since eg: `falcoctl` will copy built drivers there: https://github.com/falcosecurity/falcoctl/blob/main/pkg/driver/type/bpf.go#L55.
Most of the time, both falcoctl and Falco will run as root, thus the env var will resolve to the current `/root/.falco/falco-bpf.o`.
But if user decides to eg: have a Falco user with reduced privileges, she/he will still be able to let falcoctl install its ebpf probe and then Falco would start without issues.

Example output without and with `sudo`:
```
Wed Dec 13 17:10:40 2023: Opening 'syscall' source with BPF probe. BPF probe path: /home/federico/.falco/falco-bpf.o
Wed Dec 13 17:10:52 2023: Opening 'syscall' source with BPF probe. BPF probe path: /root/.falco/falco-bpf.o
```

Also, this was already the default behavior when `FALCO_BPF_PROBE=""` env var was passed: https://github.com/falcosecurity/falco/blob/cbbcb611532e0439851616a19b1844628afd5a1d/userspace/falco/app/actions/helpers_inspector.cpp#L114

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
