### PR TITLE
update(rule_loader): deprecate the `append` flag in falco rules

### DIFF
--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -563,14 +563,14 @@ TEST_F(engine_loader_test, rule_append_after_rule_definition)
 	ASSERT_EQ(get_compiled_rule_condition("test_rule"),"(evt.type in (open, openat) and proc.name = cat)");
 }
 
-TEST_F(engine_loader_test, list_override_append_typo)
+TEST_F(engine_loader_test, list_override_append_wrong_key)
 {
 	// todo: maybe we want to manage some non-existent keys
-	// Please note the typo in `override` in the first list definition.
+	// Please note how the non-existent key 'non-existent keys' is ignored.
     std::string rules_content = R"END(
 - list: dev_creation_binaries
   items: ["csi-provisioner", "csi-attacher"]
-  overridde:
+  override_written_wrong:
     items: append
 
 - list: dev_creation_binaries
@@ -584,7 +584,7 @@ TEST_F(engine_loader_test, list_override_append_typo)
 
 )END";
 
-	// Since there is a typo in the first list definition the `override` is not
+	// Since there is a wrong key in the first list definition the `override` is not
 	// considered. so in this situation, we are defining the list 2 times. The 
 	// second one overrides the first one.
 	ASSERT_TRUE(load_rules(rules_content, "rules.yaml"));

--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -202,7 +202,6 @@ TEST_F(engine_loader_test, rule_override_append)
 	 	"legit rule description with append");
 }
 
-
 TEST_F(engine_loader_test, rule_append)
 {
     std::string rules_content = R"END(
@@ -227,7 +226,6 @@ TEST_F(engine_loader_test, rule_append)
 	ASSERT_EQ(rule_description["rules"][0]["details"]["condition_compiled"].template get<std::string>(),
 	 	"(evt.type = open and proc.name = cat)");
 }
-
 
 TEST_F(engine_loader_test, rule_override_replace)
 {
@@ -318,7 +316,7 @@ TEST_F(engine_loader_test, rule_incorrect_override_type)
 	std::string rule_name = "failing_rule";
 
 	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
-	ASSERT_EQ(m_load_result_json["errors"][0]["message"], "Key 'priority' cannot be appended to, use 'replace' instead");
+	ASSERT_TRUE(check_error_message("Key 'priority' cannot be appended to, use 'replace' instead"));
 	ASSERT_TRUE(std::string(m_load_result_json["errors"][0]["context"]["snippet"]).find("priority: append") != std::string::npos);
 }
 
@@ -347,7 +345,7 @@ TEST_F(engine_loader_test, rule_incorrect_append_override)
 	// We should have at least one warning because the 'append' flag is deprecated.
 	ASSERT_TRUE(check_warning_message(WARNING_APPEND_MESSAGE));
 	
-	ASSERT_TRUE(std::string(m_load_result_json["errors"][0]["message"]).find(OVERRIDE_APPEND_ERROR_MESSAGE) != std::string::npos);
+	ASSERT_TRUE(check_error_message(OVERRIDE_APPEND_ERROR_MESSAGE));
 }
 
 TEST_F(engine_loader_test, rule_override_without_rule)
@@ -364,7 +362,7 @@ TEST_F(engine_loader_test, rule_override_without_rule)
 	std::string rule_name = "failing_rule";
 
 	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
-	ASSERT_TRUE(std::string(m_load_result_json["errors"][0]["message"]).find("no rule by that name already exists") != std::string::npos);
+	ASSERT_TRUE(check_error_message("no rule by that name already exists"));
 }
 
 TEST_F(engine_loader_test, rule_override_without_field)
@@ -386,7 +384,7 @@ TEST_F(engine_loader_test, rule_override_without_field)
 	std::string rule_name = "failing_rule";
 
 	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
-	ASSERT_EQ(m_load_result_json["errors"][0]["message"], "An append override for 'condition' was specified but 'condition' is not defined");
+	ASSERT_TRUE(check_error_message("An append override for 'condition' was specified but 'condition' is not defined"));
 }
 
 TEST_F(engine_loader_test, rule_override_extra_field)
@@ -410,7 +408,7 @@ TEST_F(engine_loader_test, rule_override_extra_field)
 	std::string rule_name = "failing_rule";
 
 	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
-	ASSERT_TRUE(std::string(m_load_result_json["errors"][0]["message"]).find("Unexpected key 'priority'") != std::string::npos);
+	ASSERT_TRUE(check_error_message("Unexpected key 'priority'"));
 }
 
 TEST_F(engine_loader_test, missing_enabled_key_with_override)

--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -3,6 +3,7 @@
 #include "falco_engine.h"
 #include "rule_loader_reader.h"
 #include "rule_loader_compiler.h"
+#include "rule_loading_messages.h"
 
 class engine_loader_test : public ::testing::Test {
 protected:
@@ -370,7 +371,7 @@ TEST_F(engine_loader_test, macro_override_append_before_macro_definition)
 
 	// We cannot define a macro override before the macro definition.
 	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
-	ASSERT_TRUE(check_error_message("Macro has 'append' key but no macro by that name already exists"));
+	ASSERT_TRUE(check_error_message(ERROR_NO_PREVIOUS_MACRO));
 }
 
 TEST_F(engine_loader_test, macro_append_before_macro_definition)
@@ -394,7 +395,7 @@ TEST_F(engine_loader_test, macro_append_before_macro_definition)
 
 	// We cannot define a macro override before the macro definition.
 	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
-	ASSERT_TRUE(check_error_message("Macro has 'append' key but no macro by that name already exists"));
+	ASSERT_TRUE(check_error_message(ERROR_NO_PREVIOUS_MACRO));
 }
 
 TEST_F(engine_loader_test, macro_override_append_after_macro_definition)
@@ -469,7 +470,7 @@ TEST_F(engine_loader_test, rule_override_append_before_rule_definition)
 )END";
 
 	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
-	ASSERT_TRUE(check_error_message("Rule has 'append' key but no rule by that name already exists"));
+	ASSERT_TRUE(check_error_message(ERROR_NO_PREVIOUS_RULE));
 }
 
 TEST_F(engine_loader_test, rule_append_before_rule_definition)
@@ -488,7 +489,7 @@ TEST_F(engine_loader_test, rule_append_before_rule_definition)
 )END";
 
 	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
-	ASSERT_TRUE(check_error_message("Rule has 'append' key but no rule by that name already exists"));
+	ASSERT_TRUE(check_error_message(ERROR_NO_PREVIOUS_RULE));
 }
 
 TEST_F(engine_loader_test, rule_override_append_after_rule_definition)
@@ -590,7 +591,7 @@ TEST_F(engine_loader_test, list_override_append_before_list_definition)
 
 	// We cannot define a list override before the list definition.
 	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
-	ASSERT_TRUE(check_error_message("List has 'append' key but no list by that name already exists"));
+	ASSERT_TRUE(check_error_message(ERROR_NO_PREVIOUS_LIST));
 }
 
 TEST_F(engine_loader_test, list_append_before_list_definition)
@@ -613,7 +614,7 @@ TEST_F(engine_loader_test, list_append_before_list_definition)
 
 	// We cannot define a list append before the list definition.
 	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
-	ASSERT_TRUE(check_error_message("List has 'append' key but no list by that name already exists"));
+	ASSERT_TRUE(check_error_message(ERROR_NO_PREVIOUS_LIST));
 }
 
 TEST_F(engine_loader_test, list_override_append_after_list_definition)

--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -283,7 +283,7 @@ TEST_F(engine_loader_test, rule_incorrect_append_override)
 	std::string rule_name = "failing_rule";
 
 	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
-	ASSERT_TRUE(std::string(m_load_result_json["errors"][0]["message"]).find("'override' and 'append: true' cannot be used together") != std::string::npos);
+	ASSERT_TRUE(std::string(m_load_result_json["errors"][0]["message"]).find(OVERRIDE_APPEND_ERROR_MESSAGE) != std::string::npos);
 }
 
 TEST_F(engine_loader_test, rule_override_without_rule)

--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -583,7 +583,7 @@ TEST_F(engine_loader_test, required_engine_version_not_semver)
 )END";
 
 	ASSERT_TRUE(load_rules(rules_content, "rules.yaml"));
-	ASSERT_TRUE(check_warning_message(WARNING_ENGINE_VERSION_NOT_SEMVER));
+	ASSERT_FALSE(has_warnings());
 }
 
 TEST_F(engine_loader_test, required_engine_version_invalid)

--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -190,7 +190,7 @@ TEST_F(engine_loader_test, rule_override_append)
 	ASSERT_TRUE(load_rules(rules_content, "legit_rules.yaml")) << m_load_result_string;
 
 	// Here we don't use the deprecated `append` flag, so we don't expect the warning.
-	ASSERT_FALSE(check_warning_message(WARNING_APPEND_MESSAGE));
+	ASSERT_FALSE(check_warning_message(WARNING_APPEND));
 
 	auto rule_description = m_engine->describe_rule(&rule_name, {});
 	ASSERT_EQ(rule_description["rules"][0]["info"]["condition"].template get<std::string>(),
@@ -221,7 +221,7 @@ TEST_F(engine_loader_test, rule_append)
 	ASSERT_TRUE(load_rules(rules_content, "legit_rules.yaml")) << m_load_result_string;
 
 	// We should have at least one warning because the 'append' flag is deprecated.
-	ASSERT_TRUE(check_warning_message(WARNING_APPEND_MESSAGE));
+	ASSERT_TRUE(check_warning_message(WARNING_APPEND));
 
 	auto rule_description = m_engine->describe_rule(&rule_name, {});
 	ASSERT_EQ(rule_description["rules"][0]["details"]["condition_compiled"].template get<std::string>(),
@@ -344,9 +344,9 @@ TEST_F(engine_loader_test, rule_incorrect_append_override)
 	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
 	
 	// We should have at least one warning because the 'append' flag is deprecated.
-	ASSERT_TRUE(check_warning_message(WARNING_APPEND_MESSAGE));
+	ASSERT_TRUE(check_warning_message(WARNING_APPEND));
 	
-	ASSERT_TRUE(check_error_message(OVERRIDE_APPEND_ERROR_MESSAGE));
+	ASSERT_TRUE(check_error_message(ERROR_OVERRIDE_APPEND));
 }
 
 TEST_F(engine_loader_test, macro_override_append_before_macro_definition)
@@ -872,7 +872,7 @@ TEST_F(engine_loader_test, rule_enabled_warning)
 )END";
 
 	ASSERT_TRUE(load_rules(rules_content, "rules.yaml"));
-	ASSERT_TRUE(check_warning_message(WARNING_ENABLED_MESSAGE));
+	ASSERT_TRUE(check_warning_message(WARNING_ENABLED));
 	// The rule should be enabled at the end.
 	EXPECT_EQ(num_rules_for_ruleset(), 1);
 }

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -491,7 +491,7 @@ nlohmann::json falco_engine::describe_rule(std::string *rule, const std::vector<
 	// output of rules, macros, and lists.
 	if (m_last_compile_output == nullptr)
 	{
-		throw falco_exception("rules most be loaded before describing them");
+		throw falco_exception("rules must be loaded before describing them");
 	}
 
 	// use collected and compiled info to print a json output

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -74,15 +74,8 @@ public:
 	void list_fields(std::string &source, bool verbose, bool names_only, bool markdown) const;
 
 	//
-	// Load rules either directly or from a filename.
+	// Load rules and returns a result object.
 	//
-	void load_rules_file(const std::string &rules_filename, bool verbose, bool all_events);
-	void load_rules(const std::string &rules_content, bool verbose, bool all_events);
-
-	//
-	// Identical to above, but returns a result object instead of
-	// throwing exceptions on error.
-	std::unique_ptr<falco::load_result> load_rules_file(const std::string &rules_filename);
 	std::unique_ptr<falco::load_result> load_rules(const std::string &rules_content, const std::string &name);
 
 	//
@@ -296,13 +289,6 @@ private:
 	// Throws falco_exception if the file can not be read
 	void read_file(const std::string& filename, std::string& contents);
 
-	// For load_rules methods that throw exceptions on error,
-	// interpret a load_result and throw an exception if needed.
-	void interpret_load_result(std::unique_ptr<falco::load_result>& res,
-				   const std::string& rules_filename,
-				   const std::string& rules_content,
-				   bool verbose);
-
 	indexed_vector<falco_source> m_sources;
 
 	const falco_source* find_source(std::size_t index) const;
@@ -387,4 +373,3 @@ private:
 	std::string m_extra;
 	bool m_replace_container_info;
 };
-

--- a/userspace/engine/falco_load_result.cpp
+++ b/userspace/engine/falco_load_result.cpp
@@ -66,7 +66,8 @@ static const std::string warning_codes[] = {
 	"LOAD_UNKNOWN_FILTER",
 	"LOAD_UNUSED_MACRO",
 	"LOAD_UNUSED_LIST",
-	"LOAD_UNKNOWN_ITEM"
+	"LOAD_UNKNOWN_ITEM",
+	"LOAD_DEPRECATED_ITEM"
 };
 
 const std::string& falco::load_result::warning_code_str(warning_code wc)
@@ -81,7 +82,8 @@ static const std::string warning_strings[] = {
 	"Unknown field or event-type in condition or output",
 	"Unused macro",
 	"Unused list",
-	"Unknown rules file item"
+	"Unknown rules file item",
+	"Used deprecated item"
 };
 
 const std::string& falco::load_result::warning_str(warning_code wc)
@@ -96,7 +98,8 @@ static const std::string warning_descs[] = {
 	"A rule condition or output refers to a field or evt.type that does not exist. This is normally an error, but if a rule has a skip-if-unknown-filter property, the error is downgraded to a warning.",
 	"A macro is defined in the rules content but is not used by any other macro or rule.",
 	"A list is defined in the rules content but is not used by any other list, macro, or rule.",
-	"An unknown top-level object is in the rules content. It will be ignored."
+	"An unknown top-level object is in the rules content. It will be ignored.",
+	"A deprecated item is employed by lists, macros, or rules."
 };
 
 const std::string& falco::load_result::warning_desc(warning_code wc)

--- a/userspace/engine/falco_load_result.h
+++ b/userspace/engine/falco_load_result.h
@@ -54,7 +54,8 @@ public:
 		LOAD_UNKNOWN_FILTER,
 		LOAD_UNUSED_MACRO,
 		LOAD_UNUSED_LIST,
-		LOAD_UNKNOWN_ITEM
+		LOAD_UNKNOWN_ITEM,
+		LOAD_DEPRECATED_ITEM
 	};
 
 	virtual ~load_result() = default;

--- a/userspace/engine/rule_loader_collector.cpp
+++ b/userspace/engine/rule_loader_collector.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "falco_engine.h"
 #include "rule_loader_collector.h"
+#include "rule_loading_messages.h"
 
 #define THROW(cond, err, ctx)    { if ((cond)) { throw rule_loader::rule_load_exception(falco::load_result::LOAD_ERR_VALIDATE, (err), (ctx)); } }
 
@@ -239,7 +240,7 @@ void rule_loader::collector::append(configuration& cfg, rule_update_info& info)
 {
 	auto prev = m_rule_infos.at(info.name);
 
-	THROW(!prev, ERROR_NO_PREVIOUS_RULE, info.ctx);
+	THROW(!prev, ERROR_NO_PREVIOUS_RULE_APPEND, info.ctx);
 	THROW(!info.has_any_value(),
 	       "Appended rule must have exceptions or condition property",
 	       // "Appended rule must have at least one field that can be appended to", // TODO replace with this and update testing
@@ -322,9 +323,7 @@ void rule_loader::collector::selective_replace(configuration& cfg, rule_update_i
 {
 	auto prev = m_rule_infos.at(info.name);
 
-	THROW(!prev,
-	       "An replace to a rule was requested but no rule by that name already exists",
-	       info.ctx);
+	THROW(!prev, ERROR_NO_PREVIOUS_RULE_REPLACE, info.ctx);
 	THROW(!info.has_any_value(),
 	       "The rule must have at least one field that can be replaced",
 	       info.ctx);

--- a/userspace/engine/rule_loader_collector.cpp
+++ b/userspace/engine/rule_loader_collector.cpp
@@ -190,10 +190,7 @@ void rule_loader::collector::define(configuration& cfg, list_info& info)
 void rule_loader::collector::append(configuration& cfg, list_info& info)
 {
 	auto prev = m_list_infos.at(info.name);
-	THROW(!prev,
-	       // "List has 'append' key or an append override but no list by that name already exists", // TODO update this error and update testing
-		   "List has 'append' key but no list by that name already exists",
-	       info.ctx);
+	THROW(!prev, ERROR_NO_PREVIOUS_LIST, info.ctx);
 	prev->items.insert(prev->items.end(), info.items.begin(), info.items.end());
 	append_info(prev, info, m_cur_index++);
 }
@@ -206,9 +203,7 @@ void rule_loader::collector::define(configuration& cfg, macro_info& info)
 void rule_loader::collector::append(configuration& cfg, macro_info& info)
 {
 	auto prev = m_macro_infos.at(info.name);
-	THROW(!prev,
-	       "Macro has 'append' key but no macro by that name already exists",
-	       info.ctx);
+	THROW(!prev, ERROR_NO_PREVIOUS_MACRO, info.ctx);
 	prev->cond += " ";
 	prev->cond += info.cond;
 	append_info(prev, info, m_cur_index++);
@@ -244,10 +239,7 @@ void rule_loader::collector::append(configuration& cfg, rule_update_info& info)
 {
 	auto prev = m_rule_infos.at(info.name);
 
-	THROW(!prev,
-	       // "Rule has 'append' key or an append override but no rule by that name already exists", // TODO replace with this and update testing
-		   "Rule has 'append' key but no rule by that name already exists",
-	       info.ctx);
+	THROW(!prev, ERROR_NO_PREVIOUS_RULE, info.ctx);
 	THROW(!info.has_any_value(),
 	       "Appended rule must have exceptions or condition property",
 	       // "Appended rule must have at least one field that can be appended to", // TODO replace with this and update testing

--- a/userspace/engine/rule_loader_reader.cpp
+++ b/userspace/engine/rule_loader_reader.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "rule_loader_reader.h"
 #include "falco_engine_version.h"
+#include "rule_loading_messages.h"
 
 #define THROW(cond, err, ctx)    { if ((cond)) { throw rule_loader::rule_load_exception(falco::load_result::LOAD_ERR_YAML_VALIDATE, (err), (ctx)); } }
 

--- a/userspace/engine/rule_loader_reader.cpp
+++ b/userspace/engine/rule_loader_reader.cpp
@@ -368,7 +368,6 @@ static void read_item(
 
 			// Build proper semver representation
 			v.version = rule_loader::reader::get_implicit_engine_version(ver);
-			cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_ENGINE_VERSION_NOT_SEMVER, ctx);
 		} 
 		catch(std::exception& e)
 		{

--- a/userspace/engine/rule_loader_reader.cpp
+++ b/userspace/engine/rule_loader_reader.cpp
@@ -22,7 +22,6 @@ limitations under the License.
 
 #include "rule_loader_reader.h"
 #include "falco_engine_version.h"
-#include "logger.h"
 
 #define THROW(cond, err, ctx)    { if ((cond)) { throw rule_loader::rule_load_exception(falco::load_result::LOAD_ERR_YAML_VALIDATE, (err), (ctx)); } }
 

--- a/userspace/engine/rule_loader_reader.cpp
+++ b/userspace/engine/rule_loader_reader.cpp
@@ -368,6 +368,7 @@ static void read_item(
 
 			// Build proper semver representation
 			v.version = rule_loader::reader::get_implicit_engine_version(ver);
+			cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_ENGINE_VERSION_NOT_SEMVER, ctx);
 		} 
 		catch(std::exception& e)
 		{

--- a/userspace/engine/rule_loader_reader.cpp
+++ b/userspace/engine/rule_loader_reader.cpp
@@ -448,7 +448,7 @@ static void read_item(
 
 		if(append == true && has_overrides)
 		{
-			THROW(true, "Keys 'override' and 'append: true' cannot be used together.", ctx);
+			THROW(true, OVERRIDE_APPEND_ERROR_MESSAGE, ctx);
 		}
 
 		// Since a list only has items, if we have chosen to append them we can append the entire object
@@ -490,7 +490,7 @@ static void read_item(
 
 		if(append == true && has_overrides)
 		{
-			THROW(true, "Keys 'override' and 'append: true' cannot be used together.", ctx);
+			THROW(true, OVERRIDE_APPEND_ERROR_MESSAGE, ctx);
 		}
 
 		// Since a macro only has a condition, if we have chosen to append to it we can append the entire object
@@ -528,8 +528,7 @@ static void read_item(
 		bool has_overrides_replace = !override_replace.empty();
 		bool has_overrides = has_overrides_append || has_overrides_replace;
 
-		THROW((has_append_flag && has_overrides),
-			"Keys 'override' and 'append: true' cannot be used together. Add an append entry (e.g. 'condition: append') under override instead.", ctx);
+		THROW((has_append_flag && has_overrides), OVERRIDE_APPEND_ERROR_MESSAGE, ctx);
 
 		if(has_overrides)
 		{

--- a/userspace/engine/rule_loader_reader.cpp
+++ b/userspace/engine/rule_loader_reader.cpp
@@ -442,7 +442,7 @@ static void read_item(
 		decode_optional_val(item, "append", has_append_flag, ctx);
 		if(has_append_flag)
 		{
-			cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_APPEND_MESSAGE, ctx);
+			cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_APPEND, ctx);
 		}
 
 		std::set<std::string> override_append, override_replace;
@@ -450,7 +450,7 @@ static void read_item(
 		decode_overrides(item, overridable, overridable, override_append, override_replace, ctx);
 		bool has_overrides = !override_append.empty() || !override_replace.empty();
 
-		THROW(has_append_flag && has_overrides, OVERRIDE_APPEND_ERROR_MESSAGE, ctx);
+		THROW(has_append_flag && has_overrides, ERROR_OVERRIDE_APPEND, ctx);
 
 		// Since a list only has items, if we have chosen to append them we can append the entire object
 		// otherwise we just want to redefine the list.
@@ -485,7 +485,7 @@ static void read_item(
 		decode_optional_val(item, "append", has_append_flag, ctx);
 		if(has_append_flag)
 		{
-			cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_APPEND_MESSAGE, ctx);
+			cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_APPEND, ctx);
 		}
 
 		std::set<std::string> override_append, override_replace;
@@ -493,7 +493,7 @@ static void read_item(
 		decode_overrides(item, overridable, overridable, override_append, override_replace, ctx);
 		bool has_overrides = !override_append.empty() || !override_replace.empty();
 
-		THROW((has_append_flag && has_overrides), OVERRIDE_APPEND_ERROR_MESSAGE, ctx);
+		THROW((has_append_flag && has_overrides), ERROR_OVERRIDE_APPEND, ctx);
 
 		// Since a macro only has a condition, if we have chosen to append to it we can append the entire object
 		// otherwise we just want to redefine the macro.
@@ -522,7 +522,7 @@ static void read_item(
 		decode_optional_val(item, "append", has_append_flag, ctx);
 		if(has_append_flag)
 		{
-			cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_APPEND_MESSAGE, ctx);
+			cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_APPEND, ctx);
 		}
 
 		std::set<std::string> override_append, override_replace;
@@ -534,7 +534,7 @@ static void read_item(
 		bool has_overrides_replace = !override_replace.empty();
 		bool has_overrides = has_overrides_append || has_overrides_replace;
 
-		THROW((has_append_flag && has_overrides), OVERRIDE_APPEND_ERROR_MESSAGE, ctx);
+		THROW((has_append_flag && has_overrides), ERROR_OVERRIDE_APPEND, ctx);
 
 		if(has_overrides)
 		{
@@ -694,7 +694,7 @@ static void read_item(
 			    !item["priority"].IsDefined())
 			{
 				decode_val(item, "enabled", v.enabled, ctx);
-				cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_ENABLED_MESSAGE, ctx);
+				cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_ENABLED, ctx);
 				collector.enable(cfg, v);
 			}
 			else

--- a/userspace/engine/rule_loader_reader.cpp
+++ b/userspace/engine/rule_loader_reader.cpp
@@ -435,12 +435,12 @@ static void read_item(
 		rule_loader::context ctx(item, rule_loader::context::LIST, name, parent);
 		rule_loader::list_info v(ctx);
 
-		bool has_append_flag = false;
+		bool append = false;
 		decode_val(item, "list", v.name, ctx);
 		decode_items(item, v.items, ctx);
 
-		decode_optional_val(item, "append", has_append_flag, ctx);
-		if(has_append_flag)
+		decode_optional_val(item, "append", append, ctx);
+		if(append)
 		{
 			cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_APPEND, ctx);
 		}
@@ -450,13 +450,13 @@ static void read_item(
 		decode_overrides(item, overridable, overridable, override_append, override_replace, ctx);
 		bool has_overrides = !override_append.empty() || !override_replace.empty();
 
-		THROW(has_append_flag && has_overrides, ERROR_OVERRIDE_APPEND, ctx);
+		THROW(append && has_overrides, ERROR_OVERRIDE_APPEND, ctx);
 
 		// Since a list only has items, if we have chosen to append them we can append the entire object
 		// otherwise we just want to redefine the list.
-		has_append_flag |= override_append.find("items") != override_append.end();
+		append |= override_append.find("items") != override_append.end();
 
-		if(has_append_flag)
+		if(append)
 		{
 			collector.append(cfg, v);
 		}
@@ -476,14 +476,14 @@ static void read_item(
 		rule_loader::macro_info v(ctx);
 		v.name = name;
 
-		bool has_append_flag = false;
+		bool append = false;
 		decode_val(item, "condition", v.cond, ctx);
 
 		// Now set the proper context for the condition now that we know it exists
 		v.cond_ctx = rule_loader::context(item["condition"], rule_loader::context::MACRO_CONDITION, "", ctx);
 
-		decode_optional_val(item, "append", has_append_flag, ctx);
-		if(has_append_flag)
+		decode_optional_val(item, "append", append, ctx);
+		if(append)
 		{
 			cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_APPEND, ctx);
 		}
@@ -493,13 +493,13 @@ static void read_item(
 		decode_overrides(item, overridable, overridable, override_append, override_replace, ctx);
 		bool has_overrides = !override_append.empty() || !override_replace.empty();
 
-		THROW((has_append_flag && has_overrides), ERROR_OVERRIDE_APPEND, ctx);
+		THROW((append && has_overrides), ERROR_OVERRIDE_APPEND, ctx);
 
 		// Since a macro only has a condition, if we have chosen to append to it we can append the entire object
 		// otherwise we just want to redefine the macro.
-		has_append_flag |= override_append.find("condition") != override_append.end();
+		append |= override_append.find("condition") != override_append.end();
 
-		if(has_append_flag)
+		if(append)
 		{
 			collector.append(cfg, v);
 		}

--- a/userspace/engine/rule_loader_reader.cpp
+++ b/userspace/engine/rule_loader_reader.cpp
@@ -693,6 +693,7 @@ static void read_item(
 			    !item["priority"].IsDefined())
 			{
 				decode_val(item, "enabled", v.enabled, ctx);
+				cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_ENABLED_MESSAGE, ctx);
 				collector.enable(cfg, v);
 			}
 			else

--- a/userspace/engine/rule_loader_reader.h
+++ b/userspace/engine/rule_loader_reader.h
@@ -32,6 +32,9 @@ limitations under the License.
 // Warning message used when `enabled` is used without override.
 #define WARNING_ENABLED_MESSAGE "The standalone 'enabled' key usage is deprecated. The correct approach requires also a 'replace' entry under the 'override' key (i.e. 'enabled: replace')."
 
+// Warning message used when the `required_engine_version` is not semver compatible.
+#define WARNING_ENGINE_VERSION_NOT_SEMVER "The 'required_engine_version' should be SemVer compatible. All non-SemVer compatible values are deprecated."
+
 namespace rule_loader
 {
 

--- a/userspace/engine/rule_loader_reader.h
+++ b/userspace/engine/rule_loader_reader.h
@@ -24,10 +24,13 @@ limitations under the License.
 #include "falco_engine_version.h"
 
 // Error message used when both 'override' and 'append' are specified.
-#define OVERRIDE_APPEND_ERROR_MESSAGE "Keys 'override' and 'append: true' cannot be used together. Add an append entry (e.g. 'condition: append') under 'override' instead."
+#define OVERRIDE_APPEND_ERROR_MESSAGE "Keys 'override' and 'append: true' cannot be used together. Add an 'append' entry (e.g. 'condition: append') under 'override' instead."
 
 // Warning message used when `append` is used.
-#define WARNING_APPEND_MESSAGE "'append' key is deprecated. Add an append entry (e.g. 'condition: append') under 'override' instead."
+#define WARNING_APPEND_MESSAGE "'append' key is deprecated. Add an 'append' entry (e.g. 'condition: append') under 'override' instead."
+
+// Warning message used when `enabled` is used without override.
+#define WARNING_ENABLED_MESSAGE "The standalone 'enabled' key usage is deprecated. The correct approach requires also a 'replace' entry under the 'override' key (i.e. 'enabled: replace')."
 
 namespace rule_loader
 {

--- a/userspace/engine/rule_loader_reader.h
+++ b/userspace/engine/rule_loader_reader.h
@@ -24,7 +24,10 @@ limitations under the License.
 #include "falco_engine_version.h"
 
 // Error message used when both 'override' and 'append' are specified.
-#define OVERRIDE_APPEND_ERROR_MESSAGE "Keys 'override' and 'append: true' cannot be used together. Add an append entry (e.g. 'condition: append') under override instead."
+#define OVERRIDE_APPEND_ERROR_MESSAGE "Keys 'override' and 'append: true' cannot be used together. Add an append entry (e.g. 'condition: append') under 'override' instead."
+
+// Warning message used when `append` is used.
+#define WARNING_APPEND_MESSAGE "'append' key is deprecated. Add an append entry (e.g. 'condition: append') under 'override' instead."
 
 namespace rule_loader
 {

--- a/userspace/engine/rule_loader_reader.h
+++ b/userspace/engine/rule_loader_reader.h
@@ -23,6 +23,9 @@ limitations under the License.
 #include "version.h"
 #include "falco_engine_version.h"
 
+// Error message used when both 'override' and 'append' are specified.
+#define OVERRIDE_APPEND_ERROR_MESSAGE "Keys 'override' and 'append: true' cannot be used together. Add an append entry (e.g. 'condition: append') under override instead."
+
 namespace rule_loader
 {
 

--- a/userspace/engine/rule_loader_reader.h
+++ b/userspace/engine/rule_loader_reader.h
@@ -23,15 +23,6 @@ limitations under the License.
 #include "version.h"
 #include "falco_engine_version.h"
 
-// Error message used when both 'override' and 'append' are specified.
-#define OVERRIDE_APPEND_ERROR_MESSAGE "Keys 'override' and 'append: true' cannot be used together. Add an 'append' entry (e.g. 'condition: append') under 'override' instead."
-
-// Warning message used when `append` is used.
-#define WARNING_APPEND_MESSAGE "'append' key is deprecated. Add an 'append' entry (e.g. 'condition: append') under 'override' instead."
-
-// Warning message used when `enabled` is used without override.
-#define WARNING_ENABLED_MESSAGE "The standalone 'enabled' key usage is deprecated. The correct approach requires also a 'replace' entry under the 'override' key (i.e. 'enabled: replace')."
-
 namespace rule_loader
 {
 

--- a/userspace/engine/rule_loader_reader.h
+++ b/userspace/engine/rule_loader_reader.h
@@ -32,9 +32,6 @@ limitations under the License.
 // Warning message used when `enabled` is used without override.
 #define WARNING_ENABLED_MESSAGE "The standalone 'enabled' key usage is deprecated. The correct approach requires also a 'replace' entry under the 'override' key (i.e. 'enabled: replace')."
 
-// Warning message used when the `required_engine_version` is not semver compatible.
-#define WARNING_ENGINE_VERSION_NOT_SEMVER "The 'required_engine_version' should be SemVer compatible. All non-SemVer compatible values are deprecated."
-
 namespace rule_loader
 {
 

--- a/userspace/engine/rule_loading_messages.h
+++ b/userspace/engine/rule_loading_messages.h
@@ -1,0 +1,16 @@
+#pragma once
+
+// Error message used when both 'override' and 'append' keys are specified.
+#define OVERRIDE_APPEND_ERROR_MESSAGE "Keys 'override' and 'append: true' cannot be used together. Add an 'append' entry (e.g. 'condition: append') under 'override' instead."
+
+// Warning message used when 'append' key is used.
+#define WARNING_APPEND_MESSAGE "'append' key is deprecated. Add an 'append' entry (e.g. 'condition: append') under 'override' instead."
+
+// Warning message used when 'enabled' is used without 'override' key.
+#define WARNING_ENABLED_MESSAGE "The standalone 'enabled' key usage is deprecated. The correct approach requires also a 'replace' entry under the 'override' key (i.e. 'enabled: replace')."
+
+#define ERROR_NO_PREVIOUS_MACRO "Macro uses 'append' or 'override.condition: append' but no macro by that name already exists"
+
+#define ERROR_NO_PREVIOUS_LIST "List uses 'append' or 'override.items: append' but no list by that name already exists"
+
+#define ERROR_NO_PREVIOUS_RULE "Rule uses 'append' or 'override.<key>: append' but no rule by that name already exists"

--- a/userspace/engine/rule_loading_messages.h
+++ b/userspace/engine/rule_loading_messages.h
@@ -1,11 +1,18 @@
 #pragma once
 
-// todo: rename putting error at the beginning
-#define OVERRIDE_APPEND_ERROR_MESSAGE "Keys 'override' and 'append: true' cannot be used together. Add an 'append' entry (e.g. 'condition: append') under 'override' instead."
+////////////////
+// Warnings
+////////////////
 
-#define WARNING_APPEND_MESSAGE "'append' key is deprecated. Add an 'append' entry (e.g. 'condition: append') under 'override' instead."
+#define WARNING_APPEND "'append' key is deprecated. Add an 'append' entry (e.g. 'condition: append') under 'override' instead."
 
-#define WARNING_ENABLED_MESSAGE "The standalone 'enabled' key usage is deprecated. The correct approach requires also a 'replace' entry under the 'override' key (i.e. 'enabled: replace')."
+#define WARNING_ENABLED "The standalone 'enabled' key usage is deprecated. The correct approach requires also a 'replace' entry under the 'override' key (i.e. 'enabled: replace')."
+
+////////////////
+// Errors
+////////////////
+
+#define ERROR_OVERRIDE_APPEND "Keys 'override' and 'append: true' cannot be used together. Add an 'append' entry (e.g. 'condition: append') under 'override' instead."
 
 #define ERROR_NO_PREVIOUS_MACRO "Macro uses 'append' or 'override.condition: append' but no macro by that name already exists"
 

--- a/userspace/engine/rule_loading_messages.h
+++ b/userspace/engine/rule_loading_messages.h
@@ -1,16 +1,16 @@
 #pragma once
 
-// Error message used when both 'override' and 'append' keys are specified.
+// todo: rename putting error at the beginning
 #define OVERRIDE_APPEND_ERROR_MESSAGE "Keys 'override' and 'append: true' cannot be used together. Add an 'append' entry (e.g. 'condition: append') under 'override' instead."
 
-// Warning message used when 'append' key is used.
 #define WARNING_APPEND_MESSAGE "'append' key is deprecated. Add an 'append' entry (e.g. 'condition: append') under 'override' instead."
 
-// Warning message used when 'enabled' is used without 'override' key.
 #define WARNING_ENABLED_MESSAGE "The standalone 'enabled' key usage is deprecated. The correct approach requires also a 'replace' entry under the 'override' key (i.e. 'enabled: replace')."
 
 #define ERROR_NO_PREVIOUS_MACRO "Macro uses 'append' or 'override.condition: append' but no macro by that name already exists"
 
 #define ERROR_NO_PREVIOUS_LIST "List uses 'append' or 'override.items: append' but no list by that name already exists"
 
-#define ERROR_NO_PREVIOUS_RULE "Rule uses 'append' or 'override.<key>: append' but no rule by that name already exists"
+#define ERROR_NO_PREVIOUS_RULE_APPEND "Rule uses 'append' or 'override.<key>: append' but no rule by that name already exists"
+
+#define ERROR_NO_PREVIOUS_RULE_REPLACE "An 'override.<key>: replace' to a rule was requested but no rule by that name already exists"

--- a/userspace/falco/app/actions/load_rules_files.cpp
+++ b/userspace/falco/app/actions/load_rules_files.cpp
@@ -79,10 +79,9 @@ falco::app::run_result falco::app::actions::load_rules_files(falco::app::state& 
 			break;
 		}
 
-		// If verbose is true, also print any warnings
-		if(s.options.verbose && res->has_warnings())
+		if(res->has_warnings())
 		{
-			fprintf(stderr, "%s\n", res->as_string(true, rc).c_str());
+			falco_logger::log(falco_logger::level::WARNING,res->as_string(true, rc) + "\n");
 		}
 	}
 

--- a/userspace/falco/app/actions/validate_rules_files.cpp
+++ b/userspace/falco/app/actions/validate_rules_files.cpp
@@ -114,12 +114,7 @@ falco::app::run_result falco::app::actions::validate_rules_files(falco::app::sta
 				// file was ok with warnings, without actually
 				// printing the warnings.
 				summary += filename + ": Ok, with warnings";
-
-				// If verbose is true, print the warnings now.
-				if(s.options.verbose)
-				{
-					fprintf(stderr, "%s\n", res->as_string(true, rc).c_str());
-				}
+				falco_logger::log(falco_logger::level::WARNING, res->as_string(true, rc) + "\n");
 			}
 		}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind design

**Any specific area of the project related to this PR?**

/area engine

/area tests

**What this PR does / why we need it**:

In this PR I propose to deprecate the `append` flag in the Falco rules. With `deprecate` I mean that we should log a warning when the `append` key is used suggesting the new `override` key. The flag shouldn't be removed until Falco 1.0.0 since it could cause a big breaking change between users (I'm open to other ideas, maybe we can wait for some release cycle). In this PR there are also some cleanups.

Side note: I'm not fully convinced by the fact that warnings in the rule loading are suppressed by default...if we introduce a warning I expect that users will see it by default since probably they need to take some actions... To be more concrete, in this PR i added a warning that in my opinion should be shown by default because users should know how to update the rules with the most recent features to avoid breaking changes in the future. Example:

```
Wed Jan  3 15:46:27 2024: Falco version: 0.37.0-231+ad964c0 (x86_64)
Wed Jan  3 15:46:27 2024: Falco initialized with configuration file: ../falco.yaml
Wed Jan  3 15:46:27 2024: System info: Linux version 6.2.0-39-generic (buildd@lcy02-amd64-045) (x86_64-linux-gnu-gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38) #40~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov 16 10:53:04 UTC 2
Wed Jan  3 15:46:27 2024: Loading rules from file ../rules/falco-deprecated_rules.yaml
Wed Jan  3 15:46:27 2024: Loading rules from file ../rules/falco-incubating_rules.yaml
../rules/falco-incubating_rules.yaml: Ok, with warnings
1 Warnings:
In rules content: (../rules/falco-incubating_rules.yaml:0:0)
    rule 'Non sudo setuid': (../rules/falco-incubating_rules.yaml:1275:2)
------
- rule: Non sudo setuid
  ^
------
LOAD_DEPRECATED_ITEM (Used deprecated item): 'append' key is deprecated. Add an append entry (e.g. 'condition: append') under 'override' instead.

Wed Jan  3 15:46:27 2024: Loading rules from file ../rules/falco-sandbox_rules.yaml
Wed Jan  3 15:46:28 2024: Loading rules from file ../rules/falco_rules.yaml
Wed Jan  3 15:46:28 2024: The chosen syscall buffer dimension is: 8388608 bytes (8 MBs)
Wed Jan  3 15:46:28 2024: Starting health webserver with threadiness 8, listening on 0.0.0.0:8765
Wed Jan  3 15:46:28 2024: Loaded event sources: syscall
Wed Jan  3 15:46:28 2024: Enabled event sources: syscall
Wed Jan  3 15:46:28 2024: Opening 'syscall' source with modern BPF probe.
Wed Jan  3 15:46:28 2024: One ring buffer every '2' CPUs.
```

Today to obtain the above result users should run Falco with the `-v` which IMO is not ideal, WDYT @falcosecurity/falco-maintainers ?




**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(rule_loader): deprecate the `append` flag in Falco rules
```
