### PR TITLE
cleanup(falco.yaml): rename `none` in `nodriver`

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -179,7 +179,8 @@ rules_file:
 # - `modern_ebpf`: Modern eBPF (CO-RE eBPF probe)
 # - `gvisor`: gVisor (gVisor sandbox)
 # - `replay`: Replay a scap trace file
-# - `none`: No event producer loaded, useful to run with plugins.
+# - `nodriver`: No driver is injected into the system.
+#   This is useful to debug and to run plugins with 'syscall' source.
 #
 # Only one engine can be specified in the `kind` key.
 # Moreover, for each engine multiple options might be available,

--- a/userspace/falco/app/actions/load_config.cpp
+++ b/userspace/falco/app/actions/load_config.cpp
@@ -125,8 +125,8 @@ static falco::app::run_result apply_deprecated_options(falco::app::state& s)
 	}
 	if (s.options.nodriver)
 	{
-		falco_logger::log(falco_logger::level::WARNING, "DEPRECATION NOTICE: the '--nodriver' command line option is deprecated and will be removed in Falco 0.38! Set 'engine.kind: none' instead in falco.yaml\n");
-		s.config->m_engine_mode =  engine_kind_t::NONE;
+		falco_logger::log(falco_logger::level::WARNING, "DEPRECATION NOTICE: the '--nodriver' command line option is deprecated and will be removed in Falco 0.38! Set 'engine.kind: nodriver' instead in falco.yaml\n");
+		s.config->m_engine_mode =  engine_kind_t::NODRIVER;
 	}
 	if (!s.options.capture_file.empty())
 	{

--- a/userspace/falco/app/state.h
+++ b/userspace/falco/app/state.h
@@ -168,7 +168,7 @@ struct state
 
     inline bool is_nodriver() const
     {
-        return config->m_engine_mode == engine_kind_t::NONE;
+        return config->m_engine_mode == engine_kind_t::NODRIVER;
     }
 
     inline bool is_source_enabled(const std::string& src) const

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -109,7 +109,7 @@ void falco_configuration::load_engine_config(const std::string& config_name, con
 		{"modern_ebpf",engine_kind_t::MODERN_EBPF},
 		{"replay",engine_kind_t::REPLAY},
 		{"gvisor",engine_kind_t::GVISOR},
-		{"none",engine_kind_t::NONE},
+		{"nodriver",engine_kind_t::NODRIVER},
 	};
 
 	auto driver_mode_str = config.get_scalar<std::string>("engine.kind", "kmod");
@@ -172,7 +172,7 @@ void falco_configuration::load_engine_config(const std::string& config_name, con
 		}
 		m_gvisor.m_root = config.get_scalar<std::string>("engine.gvisor.root", "");
 		break;
-	case engine_kind_t::NONE:
+	case engine_kind_t::NODRIVER:
 	default:
 		break;
 	}

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -49,7 +49,7 @@ enum class engine_kind_t : uint8_t
 	MODERN_EBPF,
 	REPLAY,
 	GVISOR,
-	NONE
+	NODRIVER
 };
 
 class falco_configuration


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR renames the `none` engine config into `state_only`. The idea is that `none` should mean no engine enabled, but this is not the case. Even though the `nodriver` is a particular engine, it opens an inspector without generating events. **So the idea is to rename the `none` into `state_only` and leave the `none` config for future use cases**. 

For example `none` should be used when we want to run a source plugin like `k8saudit` without opening a syscall engine. Today we need to do something like this:

```bash
falco -c /etc/falco.yaml -r k8saudit.rules --disable-source=syscall
```

In the future, if we add the config `none` we could simply specify `none` in the config file and we have done

```bash
falco -c /etc/falco.yaml -r k8saudit.rules
```

I renamed the config into `state_only` because, in the end, this is what the `nodriver` does, it opens an inspector and the thread table allowing plugins with syscall source to run.

**Special notes for your reviewer**:

I would like to have it in this release because if we do it now this is not a breaking change, if we wait Falco 0.38.0 it will become a breaking change

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
