### PR TITLE
update!(config): soft deprecation of drop stats counters in `syscall_event_drops`

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -61,7 +61,7 @@
 # Falco logging / alerting / metrics related to software functioning (advanced)
 #     output_timeout
 #     syscall_event_timeouts
-#     syscall_event_drops
+#     syscall_event_drops [DEPRECATED] -> Use `metrics` instead, `syscall_event_drops` will be removed in Falco 0.38!
 #     metrics
 # Falco performance tuning (advanced)
 #     syscall_buf_size_preset [DEPRECATED] -> Replaced by `engine.<driver>.buf_size_preset` starting Falco 0.38!
@@ -792,7 +792,7 @@ output_timeout: 2000
 syscall_event_timeouts:
   max_consecutives: 1000
 
-# [Stable] `syscall_event_drops`
+# [Stable] `syscall_event_drops` -> Use `metrics` instead, `syscall_event_drops` will be removed in Falco 0.38!
 #
 # Generates "Falco internal: syscall event drop" rule output when `priority=debug` at minimum
 #

--- a/falco.yaml
+++ b/falco.yaml
@@ -61,7 +61,7 @@
 # Falco logging / alerting / metrics related to software functioning (advanced)
 #     output_timeout
 #     syscall_event_timeouts
-#     syscall_event_drops [DEPRECATED] -> Use `metrics` instead, `syscall_event_drops` will be removed in Falco 0.38!
+#     syscall_event_drops -> [CHANGE NOTICE] Automatic notifications will be simplified in Falco 0.38! If you depend on the detailed drop counters payload, use 'metrics.output_rule' along with 'metrics.kernel_event_counters_enabled' instead
 #     metrics
 # Falco performance tuning (advanced)
 #     syscall_buf_size_preset [DEPRECATED] -> Replaced by `engine.<driver>.buf_size_preset` starting Falco 0.38!
@@ -792,7 +792,7 @@ output_timeout: 2000
 syscall_event_timeouts:
   max_consecutives: 1000
 
-# [Stable] `syscall_event_drops` -> Use `metrics` instead, `syscall_event_drops` will be removed in Falco 0.38!
+# [Stable] `syscall_event_drops` -> [CHANGE NOTICE] Automatic notifications will be simplified in Falco 0.38! If you depend on the detailed drop counters payload, use 'metrics.output_rule' along with 'metrics.kernel_event_counters_enabled' instead
 #
 # Generates "Falco internal: syscall event drop" rule output when `priority=debug` at minimum
 #

--- a/userspace/falco/app/actions/load_config.cpp
+++ b/userspace/falco/app/actions/load_config.cpp
@@ -41,6 +41,12 @@ static falco::app::run_result apply_deprecated_options(falco::app::state& s)
 		return run_result::fatal("You can not specify more than one of -e, -g (--gvisor-config), --modern-bpf, --nodriver, and the FALCO_BPF_PROBE env var");
 	}
 
+	if(s.config->m_min_priority == falco_common::PRIORITY_DEBUG)
+	{
+		falco_logger::log(falco_logger::level::WARNING,
+				"DEPRECATION NOTICE: 'syscall_event_drops' config is deprecated and will be removed in Falco 0.38! Use 'metrics' config instead. Note that the 'syscall_event_drops' config is enabled by default when the 'priority' is set to 'debug'. You can turn it off by setting the 'priority' to any higher level\n");
+	}
+
 	// Please note: is not possible to mix command line options and configs to obtain a configuration
 	// we need to use only one method. For example, is not possible to set the gvisor-config through
 	// the command line and the gvisor-root through the config file. For this reason, if we detect

--- a/userspace/falco/app/actions/load_config.cpp
+++ b/userspace/falco/app/actions/load_config.cpp
@@ -44,7 +44,7 @@ static falco::app::run_result apply_deprecated_options(falco::app::state& s)
 	if(s.config->m_min_priority == falco_common::PRIORITY_DEBUG)
 	{
 		falco_logger::log(falco_logger::level::WARNING,
-				"DEPRECATION NOTICE: 'syscall_event_drops' config is deprecated and will be removed in Falco 0.38! Use 'metrics' config instead. Note that the 'syscall_event_drops' config is enabled by default when the 'priority' is set to 'debug'. You can turn it off by setting the 'priority' to any higher level\n");
+				"DEPRECATION NOTICE: 'syscall_event_drops' config is deprecated and will be removed in Falco 0.38! If you rely on this config, use 'metrics.output_rule' along with 'metrics.kernel_event_counters_enabled' to monitor the number of drops. Note that the 'syscall_event_drops' config is enabled by default when the 'priority' is set to 'debug'. You can turn it off by setting the 'priority' to any higher level\n");
 	}
 
 	// Please note: is not possible to mix command line options and configs to obtain a configuration

--- a/userspace/falco/app/actions/load_config.cpp
+++ b/userspace/falco/app/actions/load_config.cpp
@@ -41,12 +41,6 @@ static falco::app::run_result apply_deprecated_options(falco::app::state& s)
 		return run_result::fatal("You can not specify more than one of -e, -g (--gvisor-config), --modern-bpf, --nodriver, and the FALCO_BPF_PROBE env var");
 	}
 
-	if(s.config->m_min_priority == falco_common::PRIORITY_DEBUG)
-	{
-		falco_logger::log(falco_logger::level::WARNING,
-				"DEPRECATION NOTICE: 'syscall_event_drops' config is deprecated and will be removed in Falco 0.38! If you rely on this config, use 'metrics.output_rule' along with 'metrics.kernel_event_counters_enabled' to monitor the number of drops. Note that the 'syscall_event_drops' config is enabled by default when the 'priority' is set to 'debug'. You can turn it off by setting the 'priority' to any higher level\n");
-	}
-
 	// Please note: is not possible to mix command line options and configs to obtain a configuration
 	// we need to use only one method. For example, is not possible to set the gvisor-config through
 	// the command line and the gvisor-root through the config file. For this reason, if we detect


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Let's discuss deprecating `syscall_event_drops`.
@falcosecurity/falco-maintainers 

**Which issue(s) this PR fixes**:

https://github.com/falcosecurity/falco/issues/2910

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
update!(config): soft deprecation of drop stats counters in `syscall_event_drops`
```
