### PR TITLE
fix: adopt new libsinsp logger

### DIFF
--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -34,8 +34,8 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "7.0.0+driver")
-    set(DRIVER_CHECKSUM "SHA256=9f2a0f14827c0d9d1c3d1abe45b8f074dea531ebeca9859363a92f0d2475757e")
+    set(DRIVER_VERSION "bfbc0076b4dd52054f858cc45e98f1fdd9a91010")
+    set(DRIVER_CHECKSUM "SHA256=e987fef047925171be1f599e15e7ab0f5afc88a19596518bcaebd5dc9c3c81ef")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -35,8 +35,8 @@ else()
   # In case you want to test against another falcosecurity/libs version (or branch, or commit) just pass the variable -
   # ie., `cmake -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "0.14.1")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=defdea24bf3b176c63f10900d3716fe4373151965cc09d3fe67a31a3a9af0b13")
+    set(FALCOSECURITY_LIBS_VERSION "bfbc0076b4dd52054f858cc45e98f1fdd9a91010")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=e987fef047925171be1f599e15e7ab0f5afc88a19596518bcaebd5dc9c3c81ef")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/userspace/engine/falco_engine_version.h
+++ b/userspace/engine/falco_engine_version.h
@@ -34,4 +34,4 @@ limitations under the License.
 // It represents the fields supported by this version of Falco,
 // the event types, and the underlying driverevent schema. It's used to
 // detetect changes in engine version in our CI jobs.
-#define FALCO_ENGINE_CHECKSUM "7c512927c89f594f024f2ff181077c780c4fe6e9dd4cee3f20a9ef208a356e4e"
+#define FALCO_ENGINE_CHECKSUM "b5e45959d248f7c28ad51ac12962150770770d1dd4506e8f7aa90d68ba670c12"

--- a/userspace/engine/falco_engine_version.h
+++ b/userspace/engine/falco_engine_version.h
@@ -20,7 +20,7 @@ limitations under the License.
 
 // The version of this Falco engine
 #define FALCO_ENGINE_VERSION_MAJOR 0
-#define FALCO_ENGINE_VERSION_MINOR 31
+#define FALCO_ENGINE_VERSION_MINOR 32
 #define FALCO_ENGINE_VERSION_PATCH 0
 
 #define FALCO_ENGINE_VERSION \

--- a/userspace/falco/logger.cpp
+++ b/userspace/falco/logger.cpp
@@ -112,9 +112,9 @@ void falco_logger::set_sinsp_logging(bool enable, const std::string& severity, c
 	if (enable)
 	{
 		s_sinsp_logger_prefix = prefix;
-		g_logger.set_severity(decode_sinsp_severity(severity));
-		g_logger.disable_timestamps();
-		g_logger.add_callback_log(
+		libsinsp_logger()->set_severity(decode_sinsp_severity(severity));
+		libsinsp_logger()->disable_timestamps();
+		libsinsp_logger()->add_callback_log(
 			[](std::string&& str, const sinsp_logger::severity sev)
 			{
 				// note: using falco_logger::level ensures that the sinsp
@@ -126,7 +126,7 @@ void falco_logger::set_sinsp_logging(bool enable, const std::string& severity, c
 	}
 	else
 	{
-		g_logger.remove_callback_log();
+		libsinsp_logger()->remove_callback_log();
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This adopts the new logger from libs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
