### PR TITLE
fix(userspace/engine): avoid storing escaped strings in engine

### DIFF
--- a/userspace/engine/rule_loader_compiler.cpp
+++ b/userspace/engine/rule_loader_compiler.cpp
@@ -181,6 +181,7 @@ static bool resolve_list(std::string& cnd, const falco_list& list)
 {
 	static std::string blanks = " \t\n\r";
 	static std::string delims = blanks + "(),=";
+	std::string tmp;
 	std::string new_cnd;
 	size_t start, end;
 	bool used = false;
@@ -212,7 +213,9 @@ static bool resolve_list(std::string& cnd, const falco_list& list)
 				{
 					sub += ", ";
 				}
-				sub += v;
+				tmp = v;
+				quote_item(tmp);
+				sub += tmp;
 			}
 			// if substituted list is empty, we need to
 			// remove a comma from the left or the right
@@ -339,7 +342,6 @@ void rule_loader::compiler::compile_list_infos(
 		const collector& col,
 		indexed_vector<falco_list>& out) const
 {
-	std::string tmp;
 	std::list<std::string> used;
 	falco_list v;
 	for (const auto &list : col.lists())
@@ -352,17 +354,14 @@ void rule_loader::compiler::compile_list_infos(
 			if (ref && ref->index < list.visibility)
 			{
 				used.push_back(ref->name);
-				for (auto val : ref->items)
+				for (const auto &val : ref->items)
 				{
-					quote_item(val);
 					v.items.push_back(val);
 				}
 			}
 			else
 			{
-				tmp = item;
-				quote_item(tmp);
-				v.items.push_back(tmp);
+				v.items.push_back(item);
 			}
 		}
 		v.used = false;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

When the engine compiles list infos, we have a small bug for which we store forcefully-quoted strings in the engine's data structures instead of quoting them only at the time of their usage (at list refs resolution time). After investigating, this doesn't seem to affect the runtime-evaluated rules data structures, but it's clearly visible with the `-L` functionality and reproduced on list items that are YAML-escaped or contain spaces.

Example:

```yaml
# rules_sample.yaml
- list: my_list
  items: [non_escaped_val, "escaped val"]
```

```
$ falco -L -o json_output=true -r rules_sample | jq .
{
  "lists": [
    {
      "details": {
        "items_compiled": [
          "non_escaped_val",
          "\"escaped val\""
        ],
        "lists": [
          "escaped val"
        ],
        "plugins": [],
        "used": false
      },
      "info": {
        "items": [
          "non_escaped_val"
        ],
        "name": "my_list"
      }
    }
  ],
  "macros": [],
  "required_engine_version": "0.0.0",
  "required_plugin_versions": [],
  "rules": []
}
```

Here, `"escaped val"` is interpreted as a list reference and is not properly escaped when printed as a value.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

With these changes, the same example now correctly prints as:
```
{
  "lists": [
    {
      "details": {
        "items_compiled": [
          "non_escaped_val",
          "escaped val"
        ],
        "lists": [],
        "plugins": [],
        "used": false
      },
      "info": {
        "items": [
          "non_escaped_val",
          "escaped val"
        ],
        "name": "my_list"
      }
    }
  ],
  "macros": [],
  "required_engine_version": "0.0.0",
  "required_plugin_versions": [],
  "rules": []
}
```

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/engine): avoid storing escaped strings in engine defs
```
