### PR TITLE
fix: nlohmann_json lib include path

### DIFF
--- a/cmake/modules/njson.cmake
+++ b/cmake/modules/njson.cmake
@@ -19,8 +19,9 @@ if(USE_BUNDLED_NLOHMANN_JSON)
         CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/njson-prefix -DJSON_BuildTests=OFF -DBUILD_TESTING=OFF
     )
 
-    set(nlohmann_json_DIR ${PROJECT_BINARY_DIR}/njson-prefix/include)
+    set(nlohmann_json_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/njson-prefix/include)
 else()
     find_package(nlohmann_json CONFIG REQUIRED)
+    get_target_property(nlohmann_json_INCLUDE_DIRS nlohmann_json::nlohmann_json INTERFACE_INCLUDE_DIRECTORIES)
     add_custom_target(njson)
 endif()

--- a/userspace/engine/CMakeLists.txt
+++ b/userspace/engine/CMakeLists.txt
@@ -39,7 +39,7 @@ PUBLIC
     ${LIBSCAP_INCLUDE_DIRS}
     ${LIBSINSP_INCLUDE_DIRS}
     ${PROJECT_BINARY_DIR}/userspace/engine
-    ${nlohmann_json_DIR}
+    ${nlohmann_json_INCLUDE_DIRS}
     ${TBB_INCLUDE_DIR}
     ${YAMLCPP_INCLUDE_DIR}
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:
The include path of library `nlohmann-json` is wrong when the build is done with `USE_BUNDLED_NLOHMANN_JSON=OFF`. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
