### PR TITLE
chore(userspace/engine): changed format of the 'output' field in the JSON payload

### DIFF
--- a/userspace/engine/formats.cpp
+++ b/userspace/engine/formats.cpp
@@ -43,9 +43,6 @@ std::string falco_formats::format_event(sinsp_evt *evt, const std::string &rule,
 
 	formatter = m_falco_engine->create_formatter(source, format);
 
-	// Format the original output string, regardless of output format
-	formatter->tostring_withformat(evt, line, sinsp_evt_formatter::OF_NORMAL);
-
 	if(formatter->get_output_format() == sinsp_evt_formatter::OF_JSON)
 	{
 		std::string json_line;
@@ -89,6 +86,7 @@ std::string falco_formats::format_event(sinsp_evt *evt, const std::string &rule,
 		if(m_json_include_output_property)
 		{
 			// This is the filled-in output line.
+			formatter->tostring_withformat(evt, line, sinsp_evt_formatter::OF_JSON);
 			event["output"] = line;
 		}
 
@@ -126,6 +124,10 @@ std::string falco_formats::format_event(sinsp_evt *evt, const std::string &rule,
 		full_line.append(json_line);
 		full_line.append("}");
 		line = full_line;
+	}
+    else
+	{
+		formatter->tostring_withformat(evt, line, sinsp_evt_formatter::OF_NORMAL);
 	}
 
 	return line;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
'timestamp' and 'priority' format of the 'output' field in the JSON format has been removed. 
**Which issue(s) this PR fixes**:
Change the format of the 'output' field in the JSON payload
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #2985 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
chore(userspace/engine): changed format of the 'output' field in the JSON payload
```
