### PR TITLE
added option for insecure http driver download

### DIFF
--- a/docker/driver-loader-legacy/docker-entrypoint.sh
+++ b/docker/driver-loader-legacy/docker-entrypoint.sh
@@ -21,18 +21,19 @@
 print_usage() {
 	echo ""
 	echo "Usage:"
-	echo "  docker run -i -t --privileged -v /root/.falco:/root/.falco -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc:ro falcosecurity/falco-driver-loader-legacy:latest [driver] [options]"
+	echo "  docker run -i -t --privileged -v /root/.falco:/root/.falco -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc:ro falcosecurity/falco-driver-loader:latest [driver] [options]"
 	echo ""
 	echo "Available drivers:"
 	echo "  kmod           kernel module (default)"
 	echo "  ebpf           eBPF probe"
 	echo ""
 	echo "Options:"
-	echo "  --help         show this help message"
-	echo "  --clean        try to remove an already present driver installation"
-	echo "  --compile      try to compile the driver locally (default true)"
-	echo "  --download     try to download a prebuilt driver (default true)"
-	echo "  --print-env    skip execution and print env variables for other tools to consume"
+	echo "  --help           show this help message"
+	echo "  --clean          try to remove an already present driver installation"
+	echo "  --compile        try to compile the driver locally (default true)"
+	echo "  --download       try to download a prebuilt driver (default true)"
+ 	echo "  --http-insecure	 enable insecure downloads"
+	echo "  --print-env      skip execution and print env variables for other tools to consume"
 	echo ""
 	echo "Environment variables:"
 	echo "  FALCOCTL_DRIVER_REPOS             specify different URL(s) where to look for prebuilt Falco drivers (comma separated)"
@@ -50,6 +51,7 @@ done
 
 ENABLE_COMPILE="false"
 ENABLE_DOWNLOAD="false"
+HTTP_INSECURE="false"
 has_driver=
 has_opts=
 while test $# -gt 0; do
@@ -80,6 +82,9 @@ while test $# -gt 0; do
 			ENABLE_DOWNLOAD="true"
 			has_opts="true"
 			;;
+		--http-insecure)
+			HTTP_INSECURE="true"
+			;;   
 		--source-only)
 		    >&2 echo "Support dropped in Falco 0.37.0."
 			print_usage
@@ -108,4 +113,4 @@ if [ -z "$has_opts" ]; then
 	ENABLE_DOWNLOAD="true"
 fi
 
-/usr/bin/falcoctl driver install --compile=$ENABLE_COMPILE --download=$ENABLE_DOWNLOAD
+/usr/bin/falcoctl driver install --compile=$ENABLE_COMPILE --download=$ENABLE_DOWNLOAD --http-insecure=$HTTP_INSECURE

--- a/docker/driver-loader-legacy/docker-entrypoint.sh
+++ b/docker/driver-loader-legacy/docker-entrypoint.sh
@@ -21,7 +21,7 @@
 print_usage() {
 	echo ""
 	echo "Usage:"
-	echo "  docker run -i -t --privileged -v /root/.falco:/root/.falco -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc:ro falcosecurity/falco-driver-loader:latest [driver] [options]"
+	echo "  docker run -i -t --privileged -v /root/.falco:/root/.falco -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc:ro falcosecurity/falco-driver-loader-legacy:latest [driver] [options]"
 	echo ""
 	echo "Available drivers:"
 	echo "  kmod           kernel module (default)"

--- a/docker/driver-loader/docker-entrypoint.sh
+++ b/docker/driver-loader/docker-entrypoint.sh
@@ -28,11 +28,12 @@ print_usage() {
 	echo "  ebpf           eBPF probe"
 	echo ""
 	echo "Options:"
-	echo "  --help         show this help message"
-	echo "  --clean        try to remove an already present driver installation"
-	echo "  --compile      try to compile the driver locally (default true)"
-	echo "  --download     try to download a prebuilt driver (default true)"
-	echo "  --print-env    skip execution and print env variables for other tools to consume"
+	echo "  --help           show this help message"
+	echo "  --clean          try to remove an already present driver installation"
+	echo "  --compile        try to compile the driver locally (default true)"
+	echo "  --download       try to download a prebuilt driver (default true)"
+ 	echo "  --http-insecure	 enable insecure downloads"
+	echo "  --print-env      skip execution and print env variables for other tools to consume"
 	echo ""
 	echo "Environment variables:"
 	echo "  FALCOCTL_DRIVER_REPOS             specify different URL(s) where to look for prebuilt Falco drivers (comma separated)"
@@ -50,6 +51,7 @@ done
 
 ENABLE_COMPILE="false"
 ENABLE_DOWNLOAD="false"
+HTTP_INSECURE="false"
 has_driver=
 has_opts=
 while test $# -gt 0; do
@@ -80,6 +82,9 @@ while test $# -gt 0; do
 			ENABLE_DOWNLOAD="true"
 			has_opts="true"
 			;;
+		--http-insecure)
+			HTTP_INSECURE="true"
+			;;   
 		--source-only)
 		    >&2 echo "Support dropped in Falco 0.37.0."
 			print_usage
@@ -108,4 +113,4 @@ if [ -z "$has_opts" ]; then
 	ENABLE_DOWNLOAD="true"
 fi
 
-/usr/bin/falcoctl driver install --compile=$ENABLE_COMPILE --download=$ENABLE_DOWNLOAD
+/usr/bin/falcoctl driver install --compile=$ENABLE_COMPILE --download=$ENABLE_DOWNLOAD --http-insecure=$HTTP_INSECURE

--- a/docker/falco/docker-entrypoint.sh
+++ b/docker/falco/docker-entrypoint.sh
@@ -28,11 +28,12 @@ print_usage() {
 	echo "  ebpf           eBPF probe"
 	echo ""
 	echo "FALCO_DRIVER_LOADER_OPTIONS options:"
-	echo "  --help         show this help message"
-	echo "  --clean        try to remove an already present driver installation"
-	echo "  --compile      try to compile the driver locally (default true)"
-	echo "  --download     try to download a prebuilt driver (default true)"
-	echo "  --print-env    skip execution and print env variables for other tools to consume"
+	echo "  --help           show this help message"
+	echo "  --clean          try to remove an already present driver installation"
+	echo "  --compile        try to compile the driver locally (default true)"
+	echo "  --download       try to download a prebuilt driver (default true)"
+ 	echo "  --http-insecure	 enable insecure downloads"
+	echo "  --print-env      skip execution and print env variables for other tools to consume"
 	echo ""
 	echo "Environment variables:"
 	echo "  FALCOCTL_DRIVER_REPOS             specify different URL(s) where to look for prebuilt Falco drivers (comma separated)"
@@ -57,6 +58,7 @@ if [[ -z "${SKIP_DRIVER_LOADER}" ]]; then
 
     ENABLE_COMPILE="false"
     ENABLE_DOWNLOAD="false"
+    HTTP_INSECURE="false"
     has_driver=
     has_opts=
     for opt in "${falco_driver_loader_option_arr[@]}"
@@ -88,6 +90,9 @@ if [[ -z "${SKIP_DRIVER_LOADER}" ]]; then
                 ENABLE_DOWNLOAD="true"
                 has_opts="true"
                 ;;
+	    --http-insecure)
+		HTTP_INSECURE="true"
+		;;	
             --source-only)
                 >&2 echo "Support dropped in Falco 0.37.0."
                 print_usage
@@ -113,7 +118,7 @@ if [[ -z "${SKIP_DRIVER_LOADER}" ]]; then
         ENABLE_COMPILE="true"
         ENABLE_DOWNLOAD="true"
     fi
-    /usr/bin/falcoctl driver install --compile=$ENABLE_COMPILE --download=$ENABLE_DOWNLOAD
+    /usr/bin/falcoctl driver install --compile=$ENABLE_COMPILE --download=$ENABLE_DOWNLOAD --http-insecure=$HTTP_INSECURE
 
 fi
 


### PR DESCRIPTION
Added option for insecure http driver download in the docker-entrypoint.sh script. By passing --http-insecure to the container via an argument, the flag is forwarded to the falcoctl driver install command.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area tests

/area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Adds a simple functionality to the driverbuilder script which has not been enabled before

**Which issue(s) this PR fixes**:
Feature has been available until the migration from script based driver build to falcoctl based one.

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #3057

**Special notes for your reviewer**:
Simply adds a flag that is forwarded

**Does this PR introduce a user-facing change?**:
No, everythin works as before and the default of the flag is false anyway

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
new(docker): added option for insecure http driver download to falco and driver-loader images
```
