### PR TITLE
fix(c++): add missing overrides

### DIFF
--- a/userspace/falco/grpc_request_context.h
+++ b/userspace/falco/grpc_request_context.h
@@ -64,9 +64,9 @@ public:
 	// Pointer to function that requests the system to start processing given requests
 	void (Service::AsyncService::*m_request_func)(::grpc::ServerContext*, Request*, ::grpc::ServerAsyncWriter<Response>*, ::grpc::CompletionQueue*, ::grpc::ServerCompletionQueue*, void*);
 
-	void start(server* srv);
-	void process(server* srv);
-	void end(server* srv, bool error);
+	void start(server* srv) override;
+	void process(server* srv) override;
+	void end(server* srv, bool error) override;
 
 private:
 	std::unique_ptr<::grpc::ServerAsyncWriter<Response>> m_res_writer;
@@ -91,9 +91,9 @@ public:
 	// Pointer to function that requests the system to start processing given requests
 	void (Service::AsyncService::*m_request_func)(::grpc::ServerContext*, Request*, ::grpc::ServerAsyncResponseWriter<Response>*, ::grpc::CompletionQueue*, ::grpc::ServerCompletionQueue*, void*);
 
-	void start(server* srv);
-	void process(server* srv);
-	void end(server* srv, bool error);
+	void start(server* srv) override;
+	void process(server* srv) override;
+	void end(server* srv, bool error) override;
 
 private:
 	std::unique_ptr<::grpc::ServerAsyncResponseWriter<Response>> m_res_writer;
@@ -115,9 +115,9 @@ public:
 	// Pointer to function that requests the system to start processing given requests
 	void (Service::AsyncService::*m_request_func)(::grpc::ServerContext*, ::grpc::ServerAsyncReaderWriter<Response, Request>*, ::grpc::CompletionQueue*, ::grpc::ServerCompletionQueue*, void*);
 
-	void start(server* srv);
-	void process(server* srv);
-	void end(server* srv, bool error);
+	void start(server* srv) override;
+	void process(server* srv) override;
+	void end(server* srv, bool error) override;
 
 private:
 	std::unique_ptr<::grpc::ServerAsyncReaderWriter<Response, Request>> m_reader_writer;

--- a/userspace/falco/outputs_file.h
+++ b/userspace/falco/outputs_file.h
@@ -28,11 +28,11 @@ namespace outputs
 
 class output_file : public abstract_output
 {
-	void output(const message *msg);
+	void output(const message *msg) override;
 
-	void cleanup();
+	void cleanup() override;
 
-	void reopen();
+	void reopen() override;
 
 private:
 	void open_file();

--- a/userspace/falco/outputs_grpc.h
+++ b/userspace/falco/outputs_grpc.h
@@ -26,7 +26,7 @@ namespace outputs
 
 class output_grpc : public abstract_output
 {
-	void output(const message *msg);
+	void output(const message *msg) override;
 };
 
 } // namespace outputs

--- a/userspace/falco/outputs_program.h
+++ b/userspace/falco/outputs_program.h
@@ -26,11 +26,11 @@ namespace outputs
 
 class output_program : public abstract_output
 {
-	void output(const message *msg);
+	void output(const message *msg) override;
 
-	void cleanup();
+	void cleanup() override;
 
-	void reopen();
+	void reopen() override;
 
 private:
 	void open_pfile();

--- a/userspace/falco/outputs_stdout.h
+++ b/userspace/falco/outputs_stdout.h
@@ -26,9 +26,9 @@ namespace outputs
 
 class output_stdout : public abstract_output
 {
-	void output(const message *msg);
+	void output(const message *msg) override;
 
-	void cleanup();
+	void cleanup() override;
 };
 
 } // namespace outputs

--- a/userspace/falco/outputs_syslog.h
+++ b/userspace/falco/outputs_syslog.h
@@ -26,7 +26,7 @@ namespace outputs
 
 class output_syslog : public abstract_output
 {
-	void output(const message *msg);
+	void output(const message *msg) override;
 };
 
 } // namespace outputs


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds missing override keywords.

They were detected by cppcheck.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #3063

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
