### PR TITLE
refactor(userspace/engine): reduce allocations during rules loading

### DIFF
--- a/userspace/engine/filter_macro_resolver.cpp
+++ b/userspace/engine/filter_macro_resolver.cpp
@@ -54,8 +54,8 @@ bool filter_macro_resolver::run(std::shared_ptr<libsinsp::filter::ast::expr>& fi
 }
 
 void filter_macro_resolver::set_macro(
-		std::string name,
-		std::shared_ptr<libsinsp::filter::ast::expr> macro)
+		const std::string& name,
+		const std::shared_ptr<libsinsp::filter::ast::expr>& macro)
 {
 	m_macros[name] = macro;
 }

--- a/userspace/engine/filter_macro_resolver.h
+++ b/userspace/engine/filter_macro_resolver.h
@@ -56,8 +56,8 @@ class filter_macro_resolver
 			\param macro The AST of the macro.
 		*/
 		void set_macro(
-			std::string name,
-			std::shared_ptr<libsinsp::filter::ast::expr> macro);
+			const std::string& name,
+			const std::shared_ptr<libsinsp::filter::ast::expr>& macro);
 
 		/*!
 		    \brief used in get_{resolved,unknown}_macros and get_errors
@@ -85,6 +85,18 @@ class filter_macro_resolver
 			the latest invocation of run().
 		*/
 		const std::vector<value_info>& get_errors() const;
+
+		/*!
+			\brief Clears the resolver by resetting all state related to
+			known macros and everything related to the previous resolution run.
+		*/
+		inline void clear()
+		{
+			m_errors.clear();
+			m_unknown_macros.clear();
+			m_resolved_macros.clear();
+			m_macros.clear();
+		}
 
 	private:
 		typedef std::unordered_map<

--- a/userspace/engine/rule_loader_compiler.h
+++ b/userspace/engine/rule_loader_compiler.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "rule_loader.h"
 #include "rule_loader_compile_output.h"
 #include "rule_loader_collector.h"
+#include "filter_macro_resolver.h"
 #include "indexed_vector.h"
 #include "falco_rule.h"
 
@@ -61,12 +62,13 @@ protected:
         */
 	bool compile_condition(
 		configuration& cfg,
+		filter_macro_resolver& macro_resolver,
 		indexed_vector<falco_list>& lists,
 		const indexed_vector<rule_loader::macro_info>& macros,
 		const std::string& condition,
 		std::shared_ptr<sinsp_filter_factory> filter_factory,
-		rule_loader::context cond_ctx,
-		rule_loader::context parent_ctx,
+		const rule_loader::context& cond_ctx,
+		const rule_loader::context& parent_ctx,
 		bool allow_unknown_fields,
 		indexed_vector<falco_macro>& macros_out,
 		std::shared_ptr<libsinsp::filter::ast::expr>& ast_out,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

When loading large rulesets, I noticed a spike of allocations that could be mitigated with few changes.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
refactor(userspace/engine): reduce allocations during rules loading
```
