### PR TITLE
cleanup(tests): consolidate Falco engine and rule loader tests

### DIFF
--- a/unit_tests/engine/test_enable_rule.cpp
+++ b/unit_tests/engine/test_enable_rule.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 #include <filter_check_list.h>
 #include <filter.h>
 
-#include <falco_engine.h>
+#include "../test_falco_engine.h"
 
 static std::string single_rule = R"END(
 - rule: test rule
@@ -52,200 +52,167 @@ static const std::string ruleset_2 = "ruleset-2";
 static const std::string ruleset_3 = "ruleset-3";
 static const std::string ruleset_4 = "ruleset-4";
 
-static void load_rules(falco_engine& engine, sinsp& inspector, sinsp_filter_check_list& filterchecks)
+TEST_F(test_falco_engine, enable_rule_name)
 {
-	std::unique_ptr<falco::load_result> res;
-
-	auto filter_factory = std::shared_ptr<sinsp_filter_factory>(
-		new sinsp_filter_factory(&inspector, filterchecks));
-	auto formatter_factory = std::shared_ptr<sinsp_evt_formatter_factory>(
-		new sinsp_evt_formatter_factory(&inspector, filterchecks));
-
-	engine.add_source("syscall", filter_factory, formatter_factory);
-
-	res = engine.load_rules(single_rule, "single_rule.yaml");
-
-	EXPECT_TRUE(res->successful());
-}
-
-TEST(EnableRule, enable_rule_name)
-{
-	falco_engine engine;
-	sinsp inspector;
-	sinsp_filter_check_list filterchecks;
-
-	load_rules(engine, inspector, filterchecks);
+	load_rules(single_rule, "single_rule.yaml");
 
 	// No rules should be enabled yet for any custom rulesets
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(default_ruleset));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_3));
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(default_ruleset));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_3));
 
 	// Enable for first ruleset, only that ruleset should have an
 	// enabled rule afterward
-	engine.enable_rule("test", true, ruleset_1);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_3));
+	m_engine->enable_rule("test", true, ruleset_1);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_3));
 
 	// Enable for second ruleset
-	engine.enable_rule("test", true, ruleset_2);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_3));
+	m_engine->enable_rule("test", true, ruleset_2);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_3));
 
 	// When the substring is blank, all rules are enabled
 	// (including the disabled rule)
-	engine.enable_rule("", true, ruleset_3);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(2, engine.num_rules_for_ruleset(ruleset_3));
+	m_engine->enable_rule("", true, ruleset_3);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(2, m_engine->num_rules_for_ruleset(ruleset_3));
 
 	// Now disable for second ruleset
-	engine.enable_rule("test", false, ruleset_2);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(2, engine.num_rules_for_ruleset(ruleset_3));
+	m_engine->enable_rule("test", false, ruleset_2);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(2, m_engine->num_rules_for_ruleset(ruleset_3));
 }
 
-TEST(EnableRule, enable_rule_tags)
+TEST_F(test_falco_engine, enable_rule_tags)
 {
-	falco_engine engine;
-	sinsp inspector;
-	sinsp_filter_check_list filterchecks;
 	std::set<std::string> process_tags = {"process"};
 
-	load_rules(engine, inspector, filterchecks);
+	load_rules(single_rule, "single_rule.yaml");
 
 	// No rules should be enabled yet for any custom rulesets
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(default_ruleset));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(default_ruleset));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_2));
 
 	// Enable for first ruleset, only that ruleset should have an
 	// enabled rule afterward
-	engine.enable_rule_by_tag(process_tags, true, ruleset_1);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_2));
+	m_engine->enable_rule_by_tag(process_tags, true, ruleset_1);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_2));
 
 	// Enable for second ruleset
-	engine.enable_rule_by_tag(process_tags, true, ruleset_2);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_2));
+	m_engine->enable_rule_by_tag(process_tags, true, ruleset_2);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_2));
 
 	// Now disable for second ruleset
-	engine.enable_rule_by_tag(process_tags, false, ruleset_2);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_2));
+	m_engine->enable_rule_by_tag(process_tags, false, ruleset_2);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_2));
 }
 
-TEST(EnableRule, enable_disabled_rule_by_tag)
+TEST_F(test_falco_engine, enable_disabled_rule_by_tag)
 {
-	falco_engine engine;
-	sinsp inspector;
-	sinsp_filter_check_list filterchecks;
 	std::set<std::string> exec_process_tags = {"exec process"};
 
-	load_rules(engine, inspector, filterchecks);
+	load_rules(single_rule, "single_rule.yaml");
 
 	// Only the first rule should be enabled
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(default_ruleset));
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(default_ruleset));
 
 	// Enable the disabled rule by tag
-	engine.enable_rule_by_tag(exec_process_tags, true);
+	m_engine->enable_rule_by_tag(exec_process_tags, true);
 
 	// Both rules should be enabled now
-	EXPECT_EQ(2, engine.num_rules_for_ruleset(default_ruleset));
+	EXPECT_EQ(2, m_engine->num_rules_for_ruleset(default_ruleset));
 }
 
-TEST(EnableRule, enable_rule_id)
+TEST_F(test_falco_engine, enable_rule_id)
 {
-	falco_engine engine;
-	sinsp inspector;
-	sinsp_filter_check_list filterchecks;
 	uint16_t ruleset_1_id;
 	uint16_t ruleset_2_id;
 	uint16_t ruleset_3_id;
 
-	load_rules(engine, inspector, filterchecks);
+	load_rules(single_rule, "single_rule.yaml");
 
 	// The cases are identical to above, just using ruleset ids
 	// instead of names.
 
-	ruleset_1_id = engine.find_ruleset_id(ruleset_1);
-	ruleset_2_id = engine.find_ruleset_id(ruleset_2);
-	ruleset_3_id = engine.find_ruleset_id(ruleset_3);
+	ruleset_1_id = m_engine->find_ruleset_id(ruleset_1);
+	ruleset_2_id = m_engine->find_ruleset_id(ruleset_2);
+	ruleset_3_id = m_engine->find_ruleset_id(ruleset_3);
 
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(default_ruleset));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_3));
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(default_ruleset));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_3));
 
-	engine.enable_rule("test rule", true, ruleset_1_id);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_3));
+	m_engine->enable_rule("test rule", true, ruleset_1_id);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_3));
 
-	engine.enable_rule("test rule", true, ruleset_2_id);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_3));
+	m_engine->enable_rule("test rule", true, ruleset_2_id);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_3));
 
-	engine.enable_rule("", true, ruleset_3_id);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(2, engine.num_rules_for_ruleset(ruleset_3));
+	m_engine->enable_rule("", true, ruleset_3_id);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(2, m_engine->num_rules_for_ruleset(ruleset_3));
 
-	engine.enable_rule("test", false, ruleset_2_id);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(2, engine.num_rules_for_ruleset(ruleset_3));
+	m_engine->enable_rule("test", false, ruleset_2_id);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(2, m_engine->num_rules_for_ruleset(ruleset_3));
 }
 
-TEST(EnableRule, enable_rule_name_exact)
+TEST_F(test_falco_engine, enable_rule_name_exact)
 {
-	falco_engine engine;
-	sinsp inspector;
-	sinsp_filter_check_list filterchecks;
+	load_rules(single_rule, "single_rule.yaml");
 
-	load_rules(engine, inspector, filterchecks);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(default_ruleset));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_3));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_4));
 
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(default_ruleset));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_3));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_4));
+	m_engine->enable_rule_exact("test rule", true, ruleset_1);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_3));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_4));
 
-	engine.enable_rule_exact("test rule", true, ruleset_1);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_3));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_4));
-
-	engine.enable_rule_exact("test rule", true, ruleset_2);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_3));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_4));
+	m_engine->enable_rule_exact("test rule", true, ruleset_2);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_3));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_4));
 
 	// This should **not** enable as this is a substring and not
 	// an exact match.
-	engine.enable_rule_exact("test", true, ruleset_3);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_3));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_4));
+	m_engine->enable_rule_exact("test", true, ruleset_3);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_3));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_4));
 
-	engine.enable_rule_exact("", true, ruleset_4);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_3));
-	EXPECT_EQ(2, engine.num_rules_for_ruleset(ruleset_4));
+	m_engine->enable_rule_exact("", true, ruleset_4);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_3));
+	EXPECT_EQ(2, m_engine->num_rules_for_ruleset(ruleset_4));
 
-	engine.enable_rule("test rule", false, ruleset_2);
-	EXPECT_EQ(1, engine.num_rules_for_ruleset(ruleset_1));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_2));
-	EXPECT_EQ(0, engine.num_rules_for_ruleset(ruleset_3));
-	EXPECT_EQ(2, engine.num_rules_for_ruleset(ruleset_4));
+	m_engine->enable_rule("test rule", false, ruleset_2);
+	EXPECT_EQ(1, m_engine->num_rules_for_ruleset(ruleset_1));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_2));
+	EXPECT_EQ(0, m_engine->num_rules_for_ruleset(ruleset_3));
+	EXPECT_EQ(2, m_engine->num_rules_for_ruleset(ruleset_4));
 }

--- a/unit_tests/engine/test_rulesets.cpp
+++ b/unit_tests/engine/test_rulesets.cpp
@@ -23,9 +23,9 @@ limitations under the License.
 #define RULESET_2 2
 
 /* Helpers methods */
-static std::shared_ptr<sinsp_filter_factory> create_factory(filter_check_list& list)
+static std::shared_ptr<sinsp_filter_factory> create_factory(sinsp* inspector, filter_check_list& list)
 {
-	std::shared_ptr<sinsp_filter_factory> ret(new sinsp_filter_factory(NULL, list));
+	std::shared_ptr<sinsp_filter_factory> ret(new sinsp_filter_factory(inspector, list));
 	return ret;
 }
 
@@ -53,8 +53,10 @@ static std::shared_ptr<sinsp_filter> create_filter(
 
 TEST(Ruleset, enable_disable_rules_using_names)
 {
+	sinsp inspector;
+
 	sinsp_filter_check_list filterlist;
-	auto f = create_factory(filterlist);
+	auto f = create_factory(&inspector, filterlist);
 	auto r = create_ruleset(f);
 	auto ast = create_ast(f);
 	auto filter = create_filter(f, ast);
@@ -120,8 +122,10 @@ TEST(Ruleset, enable_disable_rules_using_names)
 
 TEST(Ruleset, enable_disable_rules_using_tags)
 {
+	sinsp inspector;
+
 	sinsp_filter_check_list filterlist;
-	auto f = create_factory(filterlist);
+	auto f = create_factory(&inspector, filterlist);
 	auto r = create_ruleset(f);
 	auto ast = create_ast(f);
 	auto filter = create_filter(f, ast);

--- a/unit_tests/test_falco_engine.h
+++ b/unit_tests/test_falco_engine.h
@@ -16,7 +16,7 @@ protected:
 
 		// create a falco engine ready to load the ruleset
 		m_inspector.reset(new sinsp());
-		m_engine.reset(new falco_engine());
+		m_engine = std::make_shared<falco_engine>();
 		m_filter_factory = std::shared_ptr<sinsp_filter_factory>(
 			new sinsp_filter_factory(m_inspector.get(), m_filterlist));
 		m_formatter_factory = std::shared_ptr<sinsp_evt_formatter_factory>(
@@ -111,7 +111,7 @@ protected:
 	sinsp_filter_check_list m_filterlist;
 	std::shared_ptr<sinsp_filter_factory> m_filter_factory;
 	std::shared_ptr<sinsp_evt_formatter_factory> m_formatter_factory;
-	std::unique_ptr<falco_engine> m_engine;
+	std::shared_ptr<falco_engine> m_engine;
 	std::unique_ptr<falco::load_result> m_load_result;
 	std::string m_load_result_string;
 	nlohmann::json m_load_result_json;

--- a/unit_tests/test_falco_engine.h
+++ b/unit_tests/test_falco_engine.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "falco_engine.h"
+#include "rule_loader_reader.h"
+#include "rule_loader_compiler.h"
+#include "rule_loading_messages.h"
+
+class test_falco_engine : public ::testing::Test {
+protected:
+	void SetUp() override
+	{
+		m_sample_ruleset = "sample-ruleset";
+		m_sample_source = falco_common::syscall_source;
+
+		// create a falco engine ready to load the ruleset
+		m_inspector.reset(new sinsp());
+		m_engine.reset(new falco_engine());
+		m_filter_factory = std::shared_ptr<sinsp_filter_factory>(
+			new sinsp_filter_factory(m_inspector.get(), m_filterlist));
+		m_formatter_factory = std::shared_ptr<sinsp_evt_formatter_factory>(
+			new sinsp_evt_formatter_factory(m_inspector.get(), m_filterlist));
+		m_engine->add_source(m_sample_source, m_filter_factory, m_formatter_factory);
+	}
+
+	void TearDown() override
+	{
+
+	}
+
+	bool load_rules(std::string rules_content, std::string rules_filename)
+	{
+		bool ret = false;
+		falco::load_result::rules_contents_t rc = {{rules_filename, rules_content}};
+		m_load_result = m_engine->load_rules(rules_content, rules_filename);
+		m_load_result_string = m_load_result->as_string(true, rc);
+		m_load_result_json = m_load_result->as_json(rc);
+		ret = m_load_result->successful();
+
+		if (ret)
+		{
+			m_engine->enable_rule("", true, m_sample_ruleset);
+		}
+
+		return ret;
+	}
+
+	// This must be kept in line with the (private) falco_engine::s_default_ruleset
+	uint64_t num_rules_for_ruleset(std::string ruleset = "falco-default-ruleset")
+	{
+		return m_engine->num_rules_for_ruleset(ruleset);
+	}
+
+	bool has_warnings()
+	{
+		return m_load_result->has_warnings();
+	}
+
+	bool check_warning_message(std::string warning_msg)
+	{
+		if(!m_load_result->has_warnings())
+		{
+			return false;
+		}
+
+		for(auto &warn : m_load_result_json["warnings"])
+		{
+			std::string msg = warn["message"];
+			// Debug:
+			// printf("msg: %s\n", msg.c_str());
+			if(msg.find(warning_msg) != std::string::npos)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	bool check_error_message(std::string error_msg)
+	{
+		// if the loading is successful there are no errors
+		if(m_load_result->successful())
+		{
+			return false;
+		}
+
+		for(auto &err : m_load_result_json["errors"])
+		{
+			std::string msg = err["message"];
+			// Debug:
+			// printf("msg: %s\n", msg.c_str());
+			if(msg.find(error_msg) != std::string::npos)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	std::string get_compiled_rule_condition(std::string rule_name = "")
+	{
+		auto rule_description = m_engine->describe_rule(&rule_name, {});
+		return rule_description["rules"][0]["details"]["condition_compiled"].template get<std::string>();
+	}
+
+	std::string m_sample_ruleset;
+	std::string m_sample_source;
+	sinsp_filter_check_list m_filterlist;
+	std::shared_ptr<sinsp_filter_factory> m_filter_factory;
+	std::shared_ptr<sinsp_evt_formatter_factory> m_formatter_factory;
+	std::unique_ptr<falco_engine> m_engine;
+	std::unique_ptr<falco::load_result> m_load_result;
+	std::string m_load_result_string;
+	nlohmann::json m_load_result_json;
+	std::unique_ptr<sinsp> m_inspector;
+};

--- a/userspace/falco/app/options.cpp
+++ b/userspace/falco/app/options.cpp
@@ -36,6 +36,7 @@ options::options()
 	  list_plugins(false),
 	  list_syscall_events(false),
 	  markdown(false),
+	  unbuffered_outputs(false),
 	  dry_run(false)
 {
 }


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

With this PR, tests that create a Falco engine to load rules will use the `test_falco_engine` fixture instead of creating their own. This removes duplication from the test codebase and also *allows the entire unit test suite to run with ASan and UBSan enabled*

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
