### PR TITLE
fix(c++): add missing explicit to single argument constructors

### DIFF
--- a/unit_tests/engine/test_add_source.cpp
+++ b/unit_tests/engine/test_add_source.cpp
@@ -31,7 +31,7 @@ namespace
 class test_ruleset_factory : public evttype_index_ruleset_factory
 {
 public:
-	test_ruleset_factory(std::shared_ptr<sinsp_filter_factory> factory):
+	explicit test_ruleset_factory(std::shared_ptr<sinsp_filter_factory> factory):
 		evttype_index_ruleset_factory(factory)
 	{
 		ruleset = evttype_index_ruleset_factory::new_ruleset();

--- a/unit_tests/engine/test_alt_rule_loader.cpp
+++ b/unit_tests/engine/test_alt_rule_loader.cpp
@@ -124,7 +124,7 @@ protected:
 class test_ruleset : public evttype_index_ruleset
 {
 public:
-	test_ruleset(std::shared_ptr<sinsp_filter_factory> factory):
+	explicit test_ruleset(std::shared_ptr<sinsp_filter_factory> factory):
 		evttype_index_ruleset(factory){};
 	virtual ~test_ruleset() = default;
 
@@ -154,7 +154,7 @@ public:
 class test_ruleset_factory : public filter_ruleset_factory
 {
 public:
-	test_ruleset_factory(std::shared_ptr<sinsp_filter_factory> factory):
+	explicit test_ruleset_factory(std::shared_ptr<sinsp_filter_factory> factory):
 		m_filter_factory(factory)
 	{
 	}

--- a/userspace/engine/evttype_index_ruleset.h
+++ b/userspace/engine/evttype_index_ruleset.h
@@ -35,7 +35,7 @@ limitations under the License.
 class evttype_index_ruleset: public filter_ruleset
 {
 public:
-	evttype_index_ruleset(std::shared_ptr<sinsp_filter_factory> factory);
+	explicit evttype_index_ruleset(std::shared_ptr<sinsp_filter_factory> factory);
 	virtual ~evttype_index_ruleset();
 
 	void add(
@@ -158,7 +158,7 @@ private:
 class evttype_index_ruleset_factory: public filter_ruleset_factory
 {
 public:
-	inline evttype_index_ruleset_factory(
+	inline explicit evttype_index_ruleset_factory(
 		std::shared_ptr<sinsp_filter_factory> factory
 	): m_filter_factory(factory) { }
 

--- a/userspace/engine/falco_common.h
+++ b/userspace/engine/falco_common.h
@@ -44,7 +44,7 @@ struct falco_exception : std::exception
 	{
 	}
 
-	falco_exception(std::string error_str)
+	explicit falco_exception(std::string error_str)
 	{
 		m_error_str = error_str;
 	}

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -44,7 +44,7 @@ limitations under the License.
 class falco_engine
 {
 public:
-	falco_engine(bool seed_rng=true);
+	explicit falco_engine(bool seed_rng=true);
 	virtual ~falco_engine();
 
 	// A given engine has a version which identifies the fields

--- a/userspace/engine/filter_details_resolver.h
+++ b/userspace/engine/filter_details_resolver.h
@@ -57,7 +57,7 @@ public:
 private:
 	struct visitor : public libsinsp::filter::ast::expr_visitor
 	{
-		visitor(filter_details& details) :
+		explicit visitor(filter_details& details) :
 			m_details(details),
 			m_expect_list(false),
 			m_expect_macro(false),

--- a/userspace/engine/rule_loader.h
+++ b/userspace/engine/rule_loader.h
@@ -226,7 +226,7 @@ namespace rule_loader
 	class result : public falco::load_result
 	{
 	public:
-		result(const std::string &name);
+		explicit result(const std::string &name);
 		virtual ~result() = default;
 		result(result&&) = default;
 		result& operator = (result&&) = default;
@@ -293,7 +293,7 @@ namespace rule_loader
 	struct engine_version_info
 	{
 		engine_version_info() : ctx("no-filename-given"), version("0.0.0") { };
-		engine_version_info(context &ctx);
+		explicit engine_version_info(context &ctx);
 		~engine_version_info() = default;
 		engine_version_info(engine_version_info&&) = default;
 		engine_version_info& operator = (engine_version_info&&) = default;
@@ -329,7 +329,7 @@ namespace rule_loader
 		// a default constructor. This allows it to be used
 		// by falco_engine, which aliases the type.
 		plugin_version_info();
-		plugin_version_info(context &ctx);
+		explicit plugin_version_info(context &ctx);
 		~plugin_version_info() = default;
 		plugin_version_info(plugin_version_info&&) = default;
 		plugin_version_info& operator = (plugin_version_info&&) = default;
@@ -345,7 +345,7 @@ namespace rule_loader
 	*/
 	struct list_info
 	{
-		list_info(context &ctx);
+		explicit list_info(context &ctx);
 		~list_info() = default;
 		list_info(list_info&&) = default;
 		list_info& operator = (list_info&&) = default;
@@ -364,7 +364,7 @@ namespace rule_loader
 	*/
 	struct macro_info
 	{
-		macro_info(context &ctx);
+		explicit macro_info(context &ctx);
 		~macro_info() = default;
 		macro_info(macro_info&&) = default;
 		macro_info& operator = (macro_info&&) = default;
@@ -384,7 +384,7 @@ namespace rule_loader
 	*/
 	struct rule_exception_info
 	{
-		rule_exception_info(context &ctx);
+		explicit rule_exception_info(context &ctx);
 		~rule_exception_info() = default;
 		rule_exception_info(rule_exception_info&&) = default;
 		rule_exception_info& operator = (rule_exception_info&&) = default;
@@ -429,7 +429,7 @@ namespace rule_loader
 	*/
 	struct rule_info
 	{
-		rule_info(context &ctx);
+		explicit rule_info(context &ctx);
 		~rule_info() = default;
 		rule_info(rule_info&&) = default;
 		rule_info& operator = (rule_info&&) = default;
@@ -461,7 +461,7 @@ namespace rule_loader
 
 	struct rule_update_info
 	{
-		rule_update_info(context &ctx);
+		explicit rule_update_info(context &ctx);
 		~rule_update_info() = default;
 		rule_update_info(rule_update_info&&) = default;
 		rule_update_info& operator = (rule_update_info&&) = default;

--- a/userspace/falco/app/actions/process_events.cpp
+++ b/userspace/falco/app/actions/process_events.cpp
@@ -43,7 +43,7 @@ using namespace falco::app::actions;
 class source_sync_context
 {
 public:
-	source_sync_context(falco::semaphore& s)
+	explicit source_sync_context(falco::semaphore& s)
 		: m_finished(false), m_joined(false), m_semaphore(s) { }
 
 	inline void finish()

--- a/userspace/falco/app/restart_handler.h
+++ b/userspace/falco/app/restart_handler.h
@@ -46,7 +46,7 @@ public:
      */
     using watch_list_t = std::vector<std::string>;
 
-    restart_handler(
+    explicit restart_handler(
         on_check_t on_check,
         const watch_list_t& watch_files = {},
         const watch_list_t& watch_dirs = {})

--- a/userspace/falco/falco_semaphore.h
+++ b/userspace/falco/falco_semaphore.h
@@ -31,7 +31,7 @@ namespace falco
         /**
          * @brief Creates a semaphore with the given initial counter value
          */
-        semaphore(int c = 0): count(c) {}
+        explicit semaphore(int c = 0): count(c) {}
 
         /**
          * @brief Increments the internal counter and unblocks acquirers

--- a/userspace/falco/grpc_context.h
+++ b/userspace/falco/grpc_context.h
@@ -36,7 +36,7 @@ const std::string meta_request = "request_id";
 class context
 {
 public:
-	context(::grpc::ServerContext* ctx);
+	explicit context(::grpc::ServerContext* ctx);
 	virtual ~context() = default;
 
 	void get_metadata(std::string key, std::string& val);
@@ -49,7 +49,7 @@ private:
 class stream_context : public context
 {
 public:
-	stream_context(::grpc::ServerContext* ctx):
+	explicit stream_context(::grpc::ServerContext* ctx):
 		context(ctx){};
 	virtual ~stream_context() = default;
 
@@ -68,7 +68,7 @@ public:
 class bidi_context : public stream_context
 {
 public:
-	bidi_context(::grpc::ServerContext* ctx):
+	explicit bidi_context(::grpc::ServerContext* ctx):
 		stream_context(ctx){};
 	virtual ~bidi_context() = default;
 };

--- a/userspace/falco/grpc_request_context.cpp
+++ b/userspace/falco/grpc_request_context.cpp
@@ -123,7 +123,7 @@ template<>
 void request_context<version::service, version::request, version::response>::process(server* srv)
 {
 	version::response res;
-	(srv->*m_process_func)(m_srv_ctx.get(), m_req, res);
+	(srv->*m_process_func)(context(m_srv_ctx.get()), m_req, res);
 
 	// Notify the gRPC runtime that this processing is done
 	m_state = request_context_base::FINISH;

--- a/userspace/falco/versions_info.h
+++ b/userspace/falco/versions_info.h
@@ -34,7 +34,7 @@ namespace falco
          * @brief Construct a versions info by using an inspector to obtain
          * versions about the drivers and the loaded plugins.
          */
-        versions_info(const std::shared_ptr<sinsp>& inspector);
+        explicit versions_info(const std::shared_ptr<sinsp>& inspector);
         versions_info(versions_info&&) = default;
         versions_info& operator = (versions_info&&) = default;
         versions_info(const versions_info& s) = default;

--- a/userspace/falco/yaml_helper.h
+++ b/userspace/falco/yaml_helper.h
@@ -42,7 +42,7 @@ class yaml_helper;
 class yaml_visitor {
 private:
 	using Callback = std::function<void(YAML::Node&)>;
-	yaml_visitor(Callback cb): seen(), cb(std::move(cb)) {}
+	explicit yaml_visitor(Callback cb): seen(), cb(std::move(cb)) {}
 
 	void operator()(YAML::Node &cur) {
 		seen.push_back(cur);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

/area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds missing explicit to single parameter constructors.

They were detected by cppcheck.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #3068 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
