### PR TITLE
cleanup: falco_engine deps and include paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,6 @@ include(rules)
 include(static-analysis)
 
 # Shared build variables
-set(FALCO_SINSP_LIBRARY sinsp)
 set(FALCO_SHARE_DIR share/falco)
 set(FALCO_ABSOLUTE_SHARE_DIR "${CMAKE_INSTALL_PREFIX}/${FALCO_SHARE_DIR}")
 set(FALCO_BIN_DIR bin)

--- a/userspace/engine/CMakeLists.txt
+++ b/userspace/engine/CMakeLists.txt
@@ -37,14 +37,14 @@ add_dependencies(falco_engine yamlcpp njson)
 
 target_include_directories(falco_engine
 PUBLIC
-    ${LIBS_DIR}/userspace
-    ${PROJECT_BINARY_DIR}/userspace/engine
+    ${CMAKE_CURRENT_SOURCE_DIR}
     ${nlohmann_json_INCLUDE_DIRS}
     ${TBB_INCLUDE_DIR}
     ${YAMLCPP_INCLUDE_DIR}
 )
 
 target_link_libraries(falco_engine
-    ${FALCO_SINSP_LIBRARY}
+PUBLIC
+    sinsp
     ${YAMLCPP_LIB}
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area build
/area engine

**What this PR does / why we need it**:
Library `falco_engine` links against library `sinsp` by means of a CMake variable (`FALCO_SINSP_LIBRARY`) that, in principle, could be changed in a preliminary CMake configuration for the build. This appears to be a leftover from the past that is no longer needed and can be simplified.
Also, a small adjustment in the include paths of `falco_engine` provides further simplification.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
