### PR TITLE
cleanup: falco_engine test fixture

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -19,67 +19,57 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.12.1
+  GIT_TAG        v1.14.0
 )
 
 FetchContent_MakeAvailable(googletest)
 
-file(GLOB_RECURSE ENGINE_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/engine/*.cpp)
-file(GLOB_RECURSE FALCO_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/falco/*.cpp)
-
 # Create a libscap_test_var.h file with some variables used by our tests
 # for example the kmod path or the bpf path.
 configure_file (
-    "${CMAKE_CURRENT_SOURCE_DIR}/falco_test_var.h.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/falco_test_var.h"
+    ${CMAKE_CURRENT_SOURCE_DIR}/falco_test_var.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/falco_test_var.h
 )
 
-set(FALCO_UNIT_TESTS_SOURCES
-  "${ENGINE_TESTS}"
-  falco/test_configuration.cpp
-  falco/app/actions/test_select_event_sources.cpp
-  falco/app/actions/test_load_config.cpp
+add_executable(falco_unit_tests
+    test_falco_engine.cpp
+    engine/test_add_source.cpp
+    engine/test_alt_rule_loader.cpp
+    engine/test_enable_rule.cpp
+    engine/test_falco_utils.cpp
+    engine/test_filter_details_resolver.cpp
+    engine/test_filter_macro_resolver.cpp
+    engine/test_filter_warning_resolver.cpp
+    engine/test_plugin_requirements.cpp
+    engine/test_rule_loader.cpp
+    engine/test_rulesets.cpp
+    falco/test_configuration.cpp
+    falco/app/actions/test_select_event_sources.cpp
+    falco/app/actions/test_load_config.cpp
 )
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
-  list(APPEND FALCO_UNIT_TESTS_SOURCES
-    falco/test_atomic_signal_handler.cpp
-    falco/app/actions/test_configure_interesting_sets.cpp
-    falco/app/actions/test_configure_syscall_buffer_num.cpp)
+    target_sources(falco_unit_tests
+    PRIVATE
+        falco/test_atomic_signal_handler.cpp
+        falco/app/actions/test_configure_interesting_sets.cpp
+        falco/app/actions/test_configure_syscall_buffer_num.cpp
+    )
 endif()
 
-set(FALCO_UNIT_TESTS_INCLUDES
-    PRIVATE
+target_include_directories(falco_unit_tests
+PRIVATE
     ${CMAKE_SOURCE_DIR}/userspace
     ${CMAKE_BINARY_DIR}/userspace/falco # we need it to include indirectly `config_falco.h` file
     ${CMAKE_SOURCE_DIR}/userspace/engine # we need it to include indirectly `falco_common.h` file
-	"${CMAKE_CURRENT_BINARY_DIR}" # we need it to include `falco_test_var.h`
+    ${CMAKE_CURRENT_BINARY_DIR} # we need it to include `falco_test_var.h`
 )
 
-set(FALCO_UNIT_TESTS_DEPENDENCIES
-  gtest
-  gtest_main
-  falco_application
+target_link_libraries(falco_unit_tests
+    falco_application
+    GTest::gtest
+    GTest::gtest_main
 )
-
-get_target_property(FALCO_APPLICATION_LIBRARIES falco_application LINK_LIBRARIES)
-
-set(FALCO_UNIT_TESTS_LIBRARIES
-  gtest
-  gtest_main
-  falco_application
-  ${FALCO_APPLICATION_LIBRARIES}
-)
-
-message(STATUS "FALCO_UNIT_TESTS_SOURCES: ${FALCO_UNIT_TESTS_SOURCES}")
-message(STATUS "FALCO_UNIT_TESTS_INCLUDES: ${FALCO_UNIT_TESTS_INCLUDES}")
-message(STATUS "FALCO_UNIT_TESTS_DEPENDENCIES: ${FALCO_UNIT_TESTS_DEPENDENCIES}")
-message(STATUS "FALCO_UNIT_TESTS_LIBRARIES: ${FALCO_UNIT_TESTS_LIBRARIES}")
-
-add_executable(falco_unit_tests ${FALCO_UNIT_TESTS_SOURCES})
-target_include_directories(falco_unit_tests ${FALCO_UNIT_TESTS_INCLUDES})
-target_link_libraries(falco_unit_tests ${FALCO_UNIT_TESTS_LIBRARIES})
-add_dependencies(falco_unit_tests ${FALCO_UNIT_TESTS_DEPENDENCIES})
 
 if (EMSCRIPTEN)
 	target_compile_options(falco_unit_tests PRIVATE "-sDISABLE_EXCEPTION_CATCHING=0")

--- a/unit_tests/test_falco_engine.cpp
+++ b/unit_tests/test_falco_engine.cpp
@@ -1,0 +1,87 @@
+#include "test_falco_engine.h"
+
+test_falco_engine::test_falco_engine()
+{
+	// create a falco engine ready to load the ruleset
+	m_filter_factory = std::make_shared<sinsp_filter_factory>(&m_inspector, m_filterlist);
+	m_formatter_factory = std::make_shared<sinsp_evt_formatter_factory>(&m_inspector, m_filterlist);
+	m_engine = std::make_shared<falco_engine>();
+	m_engine->add_source(m_sample_source, m_filter_factory, m_formatter_factory);
+}
+
+bool test_falco_engine::load_rules(const std::string& rules_content, const std::string& rules_filename)
+{
+	bool ret = false;
+	falco::load_result::rules_contents_t rc = {{rules_filename, rules_content}};
+	m_load_result = m_engine->load_rules(rules_content, rules_filename);
+	m_load_result_string = m_load_result->as_string(true, rc);
+	m_load_result_json = m_load_result->as_json(rc);
+	ret = m_load_result->successful();
+
+	if (ret)
+	{
+		m_engine->enable_rule("", true, m_sample_ruleset);
+	}
+
+	return ret;
+}
+
+// This must be kept in line with the (private) falco_engine::s_default_ruleset
+uint64_t test_falco_engine::num_rules_for_ruleset(const std::string& ruleset)
+{
+	return m_engine->num_rules_for_ruleset(ruleset);
+}
+
+bool test_falco_engine::has_warnings() const
+{
+	return m_load_result->has_warnings();
+}
+
+bool test_falco_engine::check_warning_message(const std::string& warning_msg) const
+{
+	if(!m_load_result->has_warnings())
+	{
+		return false;
+	}
+
+	for(const auto &warn : m_load_result_json["warnings"])
+	{
+		std::string msg = warn["message"];
+		// Debug:
+		// printf("msg: %s\n", msg.c_str());
+		if(msg.find(warning_msg) != std::string::npos)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool test_falco_engine::check_error_message(const std::string& error_msg) const
+{
+	// if the loading is successful there are no errors
+	if(m_load_result->successful())
+	{
+		return false;
+	}
+
+	for(const auto &err : m_load_result_json["errors"])
+	{
+		std::string msg = err["message"];
+		// Debug:
+		// printf("msg: %s\n", msg.c_str());
+		if(msg.find(error_msg) != std::string::npos)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+std::string test_falco_engine::get_compiled_rule_condition(std::string rule_name) const
+{
+	auto rule_description = m_engine->describe_rule(&rule_name, {});
+	return rule_description["rules"][0]["details"]["condition_compiled"].template get<std::string>();
+}

--- a/unit_tests/test_falco_engine.h
+++ b/unit_tests/test_falco_engine.h
@@ -1,113 +1,28 @@
 #pragma once
 
-#include <gtest/gtest.h>
-
 #include "falco_engine.h"
 #include "rule_loader_reader.h"
 #include "rule_loader_compiler.h"
 #include "rule_loading_messages.h"
 
-class test_falco_engine : public ::testing::Test {
+#include <gtest/gtest.h>
+
+class test_falco_engine : public testing::Test
+{
 protected:
-	void SetUp() override
-	{
-		m_sample_ruleset = "sample-ruleset";
-		m_sample_source = falco_common::syscall_source;
+	test_falco_engine();
 
-		// create a falco engine ready to load the ruleset
-		m_inspector.reset(new sinsp());
-		m_engine = std::make_shared<falco_engine>();
-		m_filter_factory = std::shared_ptr<sinsp_filter_factory>(
-			new sinsp_filter_factory(m_inspector.get(), m_filterlist));
-		m_formatter_factory = std::shared_ptr<sinsp_evt_formatter_factory>(
-			new sinsp_evt_formatter_factory(m_inspector.get(), m_filterlist));
-		m_engine->add_source(m_sample_source, m_filter_factory, m_formatter_factory);
-	}
-
-	void TearDown() override
-	{
-
-	}
-
-	bool load_rules(const std::string& rules_content, const std::string& rules_filename)
-	{
-		bool ret = false;
-		falco::load_result::rules_contents_t rc = {{rules_filename, rules_content}};
-		m_load_result = m_engine->load_rules(rules_content, rules_filename);
-		m_load_result_string = m_load_result->as_string(true, rc);
-		m_load_result_json = m_load_result->as_json(rc);
-		ret = m_load_result->successful();
-
-		if (ret)
-		{
-			m_engine->enable_rule("", true, m_sample_ruleset);
-		}
-
-		return ret;
-	}
-
+	bool load_rules(const std::string& rules_content, const std::string& rules_filename);
 	// This must be kept in line with the (private) falco_engine::s_default_ruleset
-	uint64_t num_rules_for_ruleset(const std::string& ruleset = "falco-default-ruleset")
-	{
-		return m_engine->num_rules_for_ruleset(ruleset);
-	}
+	uint64_t num_rules_for_ruleset(const std::string& ruleset = "falco-default-ruleset");
+	bool has_warnings() const;
+	bool check_warning_message(const std::string& warning_msg) const;
+	bool check_error_message(const std::string& error_msg) const;
+	std::string get_compiled_rule_condition(std::string rule_name = "") const;
 
-	bool has_warnings()
-	{
-		return m_load_result->has_warnings();
-	}
-
-	bool check_warning_message(const std::string& warning_msg) const
-	{
-		if(!m_load_result->has_warnings())
-		{
-			return false;
-		}
-
-		for(const auto &warn : m_load_result_json["warnings"])
-		{
-			std::string msg = warn["message"];
-			// Debug:
-			// printf("msg: %s\n", msg.c_str());
-			if(msg.find(warning_msg) != std::string::npos)
-			{
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	bool check_error_message(const std::string& error_msg) const
-	{
-		// if the loading is successful there are no errors
-		if(m_load_result->successful())
-		{
-			return false;
-		}
-
-		for(const auto &err : m_load_result_json["errors"])
-		{
-			std::string msg = err["message"];
-			// Debug:
-			// printf("msg: %s\n", msg.c_str());
-			if(msg.find(error_msg) != std::string::npos)
-			{
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	std::string get_compiled_rule_condition(std::string rule_name = "") const
-	{
-		auto rule_description = m_engine->describe_rule(&rule_name, {});
-		return rule_description["rules"][0]["details"]["condition_compiled"].template get<std::string>();
-	}
-
-	std::string m_sample_ruleset;
-	std::string m_sample_source;
+	std::string m_sample_ruleset = "sample-ruleset";
+	std::string m_sample_source = falco_common::syscall_source;
+	sinsp m_inspector;
 	sinsp_filter_check_list m_filterlist;
 	std::shared_ptr<sinsp_filter_factory> m_filter_factory;
 	std::shared_ptr<sinsp_evt_formatter_factory> m_formatter_factory;
@@ -115,5 +30,4 @@ protected:
 	std::unique_ptr<falco::load_result> m_load_result;
 	std::string m_load_result_string;
 	nlohmann::json m_load_result_json;
-	std::unique_ptr<sinsp> m_inspector;
 };


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area build
/area tests

**What this PR does / why we need it**:
Cleanup of the test fixture class `test_falco_engine` also separating the implementation from the header in its own cpp file.
Cleanup of the CMake script for the tests and upgrade GTest to 1.14.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
