### PR TITLE
refactor: test AtomicSignalHandler.handle_once_wait_consistency

### DIFF
--- a/unit_tests/engine/test_add_source.cpp
+++ b/unit_tests/engine/test_add_source.cpp
@@ -54,12 +54,9 @@ TEST(AddSource, basic)
 	sinsp inspector;
 	sinsp_filter_check_list filterchecks;
 
-	auto filter_factory = std::shared_ptr<sinsp_filter_factory>(
-		new sinsp_filter_factory(&inspector, filterchecks));
-	auto formatter_factory = std::shared_ptr<sinsp_evt_formatter_factory>(
-		new sinsp_evt_formatter_factory(&inspector, filterchecks));
-	test_ruleset_factory *test_factory = new test_ruleset_factory(filter_factory);
-	auto ruleset_factory = std::shared_ptr<filter_ruleset_factory>(test_factory);
+	auto filter_factory = std::make_shared<sinsp_filter_factory>(&inspector, filterchecks);
+	auto formatter_factory = std::make_shared<sinsp_evt_formatter_factory>(&inspector, filterchecks);
+	auto ruleset_factory = std::make_shared<test_ruleset_factory>(filter_factory);
 
 	falco_source syscall_source;
 	syscall_source.name = syscall_source_name;
@@ -84,6 +81,6 @@ TEST(AddSource, basic)
 	ASSERT_EQ(engine.ruleset_factory_for_source(syscall_source_name), ruleset_factory);
 	ASSERT_EQ(engine.ruleset_factory_for_source(source_idx), ruleset_factory);
 
-	ASSERT_EQ(engine.ruleset_for_source(syscall_source_name), test_factory->ruleset);
-	ASSERT_EQ(engine.ruleset_for_source(source_idx), test_factory->ruleset);
+	ASSERT_EQ(engine.ruleset_for_source(syscall_source_name), ruleset_factory->ruleset);
+	ASSERT_EQ(engine.ruleset_for_source(source_idx), ruleset_factory->ruleset);
 }

--- a/unit_tests/engine/test_plugin_requirements.cpp
+++ b/unit_tests/engine/test_plugin_requirements.cpp
@@ -23,15 +23,15 @@ static bool check_requirements(std::string& err,
 			       const std::vector<falco_engine::plugin_version_requirement>& plugins,
 			       const std::string& ruleset_content)
 {
-	std::unique_ptr<falco_engine> e(new falco_engine());
+	falco_engine e;
 	falco::load_result::rules_contents_t c = {{"test", ruleset_content}};
 
-	auto res = e->load_rules(c.begin()->second, c.begin()->first);
+	auto res = e.load_rules(c.begin()->second, c.begin()->first);
 	if(!res->successful())
 	{
 		return false;
 	}
-	return e->check_plugin_requirements(plugins, err);
+	return e.check_plugin_requirements(plugins, err);
 }
 
 TEST(PluginRequirements, check_plugin_requirements_success)

--- a/unit_tests/engine/test_rulesets.cpp
+++ b/unit_tests/engine/test_rulesets.cpp
@@ -25,30 +25,26 @@ limitations under the License.
 /* Helpers methods */
 static std::shared_ptr<sinsp_filter_factory> create_factory(sinsp* inspector, filter_check_list& list)
 {
-	std::shared_ptr<sinsp_filter_factory> ret(new sinsp_filter_factory(inspector, list));
-	return ret;
+	return std::make_shared<sinsp_filter_factory>(inspector, list);
 }
 
 static std::shared_ptr<filter_ruleset> create_ruleset(std::shared_ptr<sinsp_filter_factory> f)
 {
-	std::shared_ptr<filter_ruleset> ret(new evttype_index_ruleset(f));
-	return ret;
+	return std::make_shared<evttype_index_ruleset>(f);
 }
 
 static std::shared_ptr<libsinsp::filter::ast::expr> create_ast(std::shared_ptr<sinsp_filter_factory> f)
 {
 	libsinsp::filter::parser parser("evt.type=open");
-	std::shared_ptr<libsinsp::filter::ast::expr> ret(parser.parse());
-	return ret;
+	return parser.parse();
 }
 
 static std::shared_ptr<sinsp_filter> create_filter(
 	std::shared_ptr<sinsp_filter_factory> f,
-	std::shared_ptr<libsinsp::filter::ast::expr> ast)
+	libsinsp::filter::ast::expr* ast)
 {
-	sinsp_filter_compiler compiler(f, ast.get());
-	std::shared_ptr<sinsp_filter> filter(compiler.compile());
-	return filter;
+	sinsp_filter_compiler compiler(f, ast);
+	return std::shared_ptr<sinsp_filter>(compiler.compile());
 }
 
 TEST(Ruleset, enable_disable_rules_using_names)
@@ -59,7 +55,7 @@ TEST(Ruleset, enable_disable_rules_using_names)
 	auto f = create_factory(&inspector, filterlist);
 	auto r = create_ruleset(f);
 	auto ast = create_ast(f);
-	auto filter = create_filter(f, ast);
+	auto filter = create_filter(f, ast.get());
 
 	falco_rule rule_A = {};
 	rule_A.name = "rule_A";
@@ -128,7 +124,7 @@ TEST(Ruleset, enable_disable_rules_using_tags)
 	auto f = create_factory(&inspector, filterlist);
 	auto r = create_ruleset(f);
 	auto ast = create_ast(f);
-	auto filter = create_filter(f, ast);
+	auto filter = create_filter(f, ast.get());
 
 	falco_rule rule_A = {};
 	rule_A.name = "rule_A";

--- a/userspace/engine/evttype_index_ruleset.cpp
+++ b/userspace/engine/evttype_index_ruleset.cpp
@@ -199,7 +199,7 @@ void evttype_index_ruleset::add(
 {
 	try
 	{
-		std::shared_ptr<filter_wrapper> wrap(new filter_wrapper());
+		auto wrap = std::make_shared<filter_wrapper>();
 		wrap->rule = rule;
 		wrap->filter = filter;
 		if(rule.source == falco_common::syscall_source)
@@ -369,7 +369,7 @@ libsinsp::events::set<ppm_sc_code> evttype_index_ruleset::enabled_sc_codes(uint1
 	}
 	return m_rulesets[ruleset]->sc_codes();
 }
-	
+
 libsinsp::events::set<ppm_event_code> evttype_index_ruleset::enabled_event_codes(uint16_t ruleset)
 {
 	if(m_rulesets.size() < (size_t)ruleset + 1)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area tests

**What this PR does / why we need it**:
Refactor test `AtomicSignalHandler.handle_once_wait_consistency` to make it simpler, especially in the management of threads, by avoiding using the `std::thread` object directly and relying on `std::future` returned by function `std::async`, instead.
A few changes from `std::shared_ptr`+`new` to `std::make_shared` have also been done.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
