### PR TITLE
refactor: Use FetchContent for integrating three bundled libs

### DIFF
--- a/cmake/modules/cpp-httplib.cmake
+++ b/cmake/modules/cpp-httplib.cmake
@@ -12,32 +12,15 @@
 # specific language governing permissions and limitations under the License.
 #
 
-#
-# cpp-httplib (https://github.com/yhirose/cpp-httplib)
-#
-
 option(USE_BUNDLED_CPPHTTPLIB "Enable building of the bundled cpp-httplib" ${USE_BUNDLED_DEPS})
 
-if(CPPHTTPLIB_INCLUDE)
-    # we already have cpp-httplib
-elseif(NOT USE_BUNDLED_CPPHTTPLIB)
-    find_package(httplib CONFIG REQUIRED)
-    get_target_property(CPPHTTPLIB_INCLUDE httplib::httplib INTERFACE_INCLUDE_DIRECTORIES)
+if(USE_BUNDLED_CPPHTTPLIB)
+    include(FetchContent)
+    FetchContent_Declare(cpp-httplib
+        URL https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.15.3.tar.gz
+        URL_HASH SHA256=2121bbf38871bb2aafb5f7f2b9b94705366170909f434428352187cb0216124e
+    )
+    FetchContent_MakeAvailable(cpp-httplib)
 else()
-    set(CPPHTTPLIB_SRC "${PROJECT_BINARY_DIR}/cpp-httplib-prefix/src/cpp-httplib")
-    set(CPPHTTPLIB_INCLUDE "${CPPHTTPLIB_SRC}")
-
-    message(STATUS "Using bundled cpp-httplib in ${CPPHTTPLIB_SRC}")
-
-    ExternalProject_Add(cpp-httplib
-        PREFIX "${PROJECT_BINARY_DIR}/cpp-httplib-prefix"
-        URL "https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.13.1.tar.gz"
-        URL_HASH "SHA256=9b837d290b61e3f0c4239da0b23bbf14c382922e2bf2a9bac21c1e3feabe1ff9"
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-        INSTALL_COMMAND "")	
-endif()
-
-if(NOT TARGET cpp-httplib)
-	add_custom_target(cpp-httplib)
+    find_package(httplib CONFIG REQUIRED)
 endif()

--- a/cmake/modules/njson.cmake
+++ b/cmake/modules/njson.cmake
@@ -12,29 +12,15 @@
 # specific language governing permissions and limitations under the License.
 #
 
-#
-# njson (https://github.com/nlohmann/json)
-#
-
 option(USE_BUNDLED_NLOHMANN_JSON "Enable building of the bundled nlohmann-json" ${USE_BUNDLED_DEPS})
 
-if(nlohmann_json_INCLUDE_DIRS)
-    # we already have nlohmnann-json
-elseif(NOT USE_BUNDLED_NLOHMANN_JSON)
-    find_package(nlohmann_json CONFIG REQUIRED)
-    get_target_property(nlohmann_json_INCLUDE_DIRS nlohmann_json::nlohmann_json INTERFACE_INCLUDE_DIRECTORIES)
-else()
-    set(nlohmann_json_INCLUDE_DIRS "${PROJECT_BINARY_DIR}/njson-prefix/include")
-
-    message(STATUS "Using bundled nlohmann-json in ${nlohmann_json_INCLUDE_DIRS}")
-
-    ExternalProject_Add(njson
-        URL "https://github.com/nlohmann/json/archive/v3.3.0.tar.gz"
-        URL_HASH "SHA256=2fd1d207b4669a7843296c41d3b6ac5b23d00dec48dba507ba051d14564aa801"
-        CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/njson-prefix -DJSON_BuildTests=OFF -DBUILD_TESTING=OFF
+if(USE_BUNDLED_NLOHMANN_JSON)
+    include(FetchContent)
+    FetchContent_Declare(nlohmann_json
+        URL https://github.com/nlohmann/json/archive/v3.11.3.tar.gz
+        URL_HASH SHA256=0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406
     )
-endif()
-
-if(NOT TARGET njson)
-    add_custom_target(njson)
+    FetchContent_MakeAvailable(nlohmann_json)
+else()
+    find_package(nlohmann_json CONFIG REQUIRED)
 endif()

--- a/cmake/modules/yaml-cpp.cmake
+++ b/cmake/modules/yaml-cpp.cmake
@@ -12,45 +12,15 @@
 # specific language governing permissions and limitations under the License.
 #
 
-#
-# yamlcpp (https://github.com/jbeder/yaml-cpp)
-#
-
 option(USE_BUNDLED_YAMLCPP "Enable building of the bundled yamlcpp" ${USE_BUNDLED_DEPS})
 
-if(YAMLCPP_INCLUDE_DIR)
-    # we already have yamlcpp
-elseif(NOT USE_BUNDLED_YAMLCPP)
-    find_path(YAMLCPP_INCLUDE_DIR NAMES yaml-cpp/yaml.h)
-    find_library(YAMLCPP_LIB NAMES yaml-cpp)
-
-    if(YAMLCPP_INCLUDE_DIR)
-        message(STATUS "Found yamlcpp: include: ${YAMLCPP_INCLUDE_DIR}")
-    else()
-        message(FATAL_ERROR "Couldn't find system yamlcpp")
-    endif()
+if(USE_BUNDLED_YAMLCPP)
+    include(FetchContent)
+    FetchContent_Declare(yamlcpp
+        URL https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz
+        URL_HASH SHA256=fbe74bbdcee21d656715688706da3c8becfd946d92cd44705cc6098bb23b3a16
+    )
+    FetchContent_MakeAvailable(yamlcpp)
 else()
-    set(YAMLCPP_SRC "${PROJECT_BINARY_DIR}/yamlcpp-prefix/src/yamlcpp")
-    set(YAMLCPP_INCLUDE_DIR "${YAMLCPP_SRC}/include")
-
-    message(STATUS "Using bundled yaml-cpp in '${YAMLCPP_SRC}'")
-
-    if(NOT WIN32)
-        set(YAMLCPP_LIB "${YAMLCPP_SRC}/libyaml-cpp.a")
-    else()
-        set(YAMLCPP_LIB "${YAMLCPP_SRC}/${CMAKE_BUILD_TYPE}/yaml-cpp.lib")
-    endif()
-
-    ExternalProject_Add(
-        yamlcpp
-        URL "https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.7.0.tar.gz"
-        URL_HASH "SHA256=43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3"
-        BUILD_BYPRODUCTS ${YAMLCPP_LIB}
-        CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release -DYAML_MSVC_SHARED_RT=Off -DYAML_BUILD_SHARED_LIBS=Off -DYAML_CPP_BUILD_TESTS=Off -DYAML_CPP_BUILD_TOOLS=OFF -DYAML_CPP_BUILD_CONTRIB=OFF -DCMAKE_DEBUG_POSTFIX=''
-        BUILD_IN_SOURCE 1
-        INSTALL_COMMAND "")
-endif()
-
-if(NOT TARGET yamlcpp)
-    add_custom_target(yamlcpp)
+    find_package(yaml-cpp CONFIG REQUIRED)
 endif()

--- a/userspace/engine/CMakeLists.txt
+++ b/userspace/engine/CMakeLists.txt
@@ -33,17 +33,15 @@ if (EMSCRIPTEN)
 	target_compile_options(falco_engine PRIVATE "-sDISABLE_EXCEPTION_CATCHING=0")
 endif()
 
-add_dependencies(falco_engine yamlcpp)
-
 target_include_directories(falco_engine
 PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TBB_INCLUDE_DIR}
-    ${YAMLCPP_INCLUDE_DIR}
 )
 
 target_link_libraries(falco_engine
 PUBLIC
     sinsp
     nlohmann_json::nlohmann_json
+    yaml-cpp
 )

--- a/userspace/engine/CMakeLists.txt
+++ b/userspace/engine/CMakeLists.txt
@@ -33,12 +33,11 @@ if (EMSCRIPTEN)
 	target_compile_options(falco_engine PRIVATE "-sDISABLE_EXCEPTION_CATCHING=0")
 endif()
 
-add_dependencies(falco_engine yamlcpp njson)
+add_dependencies(falco_engine yamlcpp)
 
 target_include_directories(falco_engine
 PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${nlohmann_json_INCLUDE_DIRS}
     ${TBB_INCLUDE_DIR}
     ${YAMLCPP_INCLUDE_DIR}
 )
@@ -46,5 +45,5 @@ PUBLIC
 target_link_libraries(falco_engine
 PUBLIC
     sinsp
-    ${YAMLCPP_LIB}
+    nlohmann_json::nlohmann_json
 )

--- a/userspace/falco/CMakeLists.txt
+++ b/userspace/falco/CMakeLists.txt
@@ -14,8 +14,7 @@
 
 configure_file(config_falco.h.in config_falco.h)
 
-set(
-  FALCO_SOURCES
+add_library(falco_application STATIC
   app/app.cpp
   app/options.cpp
   app/restart_handler.cpp
@@ -62,15 +61,11 @@ set(
 set(
   FALCO_INCLUDE_DIRECTORIES
   "${PROJECT_SOURCE_DIR}/userspace/engine"
-  "${PROJECT_BINARY_DIR}/userspace/falco"
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${CMAKE_CURRENT_BINARY_DIR}"
   "${PROJECT_BINARY_DIR}/driver/src"
   "${CXXOPTS_INCLUDE_DIR}"
-  "${YAMLCPP_INCLUDE_DIR}"
-  "${CMAKE_CURRENT_BINARY_DIR}"
-  "${CMAKE_CURRENT_SOURCE_DIR}"
 )
-
-list(APPEND FALCO_INCLUDE_DIRECTORIES "${FALCO_EXTRA_INCLUDE_DIRS}")
 
 set(
   FALCO_DEPENDENCIES
@@ -81,22 +76,20 @@ set(
   FALCO_LIBRARIES
   falco_engine
   sinsp
-  "${YAMLCPP_LIB}"
+  yaml-cpp
 )
-
-list(APPEND FALCO_DEPENDENCIES yamlcpp)
 
 if(NOT WIN32)
-  list(
-    APPEND FALCO_SOURCES
-	outputs_program.cpp
-	outputs_syslog.cpp
-)
+  target_sources(falco_application
+  PRIVATE
+    outputs_program.cpp
+    outputs_syslog.cpp
+  )
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT MINIMAL_BUILD)
-  list(
-    APPEND FALCO_SOURCES
+  target_sources(falco_application
+  PRIVATE
     outputs_grpc.cpp
     outputs_http.cpp
     webserver.cpp
@@ -136,14 +129,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT MINIMAL_BUILD)
     "${PROTOBUF_LIB}"
     "${CARES_LIB}"
     "${OPENSSL_LIBRARIES}"
-    "${YAMLCPP_LIB}"
   )
 endif()
-
-add_library(
-  falco_application STATIC
-  ${FALCO_SOURCES}
-)
 
 if (EMSCRIPTEN)
 	target_compile_options(falco_application PRIVATE "-sDISABLE_EXCEPTION_CATCHING=0")

--- a/userspace/falco/CMakeLists.txt
+++ b/userspace/falco/CMakeLists.txt
@@ -115,7 +115,6 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT MINIMAL_BUILD)
 
   list(
     APPEND FALCO_INCLUDE_DIRECTORIES
-    "${CPPHTTPLIB_INCLUDE}"
     "${OPENSSL_INCLUDE_DIR}"
     "${GRPC_INCLUDE}"
     "${GRPCPP_INCLUDE}"
@@ -128,10 +127,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT MINIMAL_BUILD)
     list(APPEND FALCO_LIBRARIES "${GRPC_LIBRARIES}")
   endif()
 
-  list(APPEND FALCO_DEPENDENCIES cpp-httplib)
-
   list(
     APPEND FALCO_LIBRARIES
+    httplib::httplib
     "${GRPCPP_LIB}"
     "${GRPC_LIB}"
     "${GPR_LIB}"
@@ -150,6 +148,8 @@ add_library(
 if (EMSCRIPTEN)
 	target_compile_options(falco_application PRIVATE "-sDISABLE_EXCEPTION_CATCHING=0")
 endif()
+
+target_compile_definitions(falco_application PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)
 
 add_dependencies(falco_application ${FALCO_DEPENDENCIES})
 

--- a/userspace/falco/webserver.h
+++ b/userspace/falco/webserver.h
@@ -16,13 +16,14 @@ limitations under the License.
 */
 #pragma once
 
-#define CPPHTTPLIB_OPENSSL_SUPPORT
-#define CPPHTTPLIB_ZLIB_SUPPORT
-#include <httplib.h>
-#include <thread>
-#include <memory>
-#include <libsinsp/sinsp.h>
 #include "configuration.h"
+
+#include <libsinsp/sinsp.h>
+
+#include <httplib.h>
+
+#include <memory>
+#include <thread>
 
 class falco_webserver
 {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:

Libraries `nlohmann-json`, `yaml-cpp`, and `cpp-httplib` in their "bundled" configuration are now integrated through the CMake construct `FetchContent` rather than `ExternalProject_Add`. This has the benefit of being treated in a way similar to integrating the library with `find_package`, thus making the bundled/non-bundled approach similar in the rest of the code.

One important beneficial consequence is the simplification in client code: new targets can reference `falco_engine` without having to specify these libs in their include path or explicitly link against it, because the target `falco_engine` brings all the needed properties on board through the usage of aliases such as `httplib::httplib` or `nlohmann_json::nlohmann_json`.
The libraries have also been upgraded as newer versions provide the target aliases and allow integration with `FetchContent` without building the library's test targets, which obviously Falco doesn't need.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
