### PR TITLE
fix(userspace/engine): make sure exception fields are not optional in replace mode

### DIFF
--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -712,7 +712,7 @@ TEST_F(test_falco_engine, rule_override_exceptions_required_fields)
 )END";
 
 	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
-  ASSERT_FALSE(has_warnings());
+	ASSERT_FALSE(has_warnings());
 	ASSERT_TRUE(check_error_message("Item has no mapping for key 'fields'")) << m_load_result_json.dump();
 }
 

--- a/userspace/engine/rule_loader_reader.cpp
+++ b/userspace/engine/rule_loader_reader.cpp
@@ -650,7 +650,7 @@ void rule_loader::reader::read_item(
 
 				if (check_update_expected(expected_keys, override_replace, "replace", "exceptions", ctx))
 				{
-					read_rule_exceptions(cfg, item, v.exceptions, ctx, true);
+					read_rule_exceptions(cfg, item, v.exceptions, ctx, false);
 				}
 
 				if (check_update_expected(expected_keys, override_replace, "replace", "output", ctx))
@@ -771,7 +771,7 @@ void rule_loader::reader::read_item(
 				decode_optional_val(item, "warn_evttypes", v.warn_evttypes, ctx);
 				decode_optional_val(item, "skip-if-unknown-filter", v.skip_if_unknown_filter, ctx);
 				decode_tags(item, v.tags, ctx);
-				read_rule_exceptions(cfg, item, v.exceptions, ctx, has_append_flag);
+				read_rule_exceptions(cfg, item, v.exceptions, ctx, false);
 				collector.define(cfg, v);
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

When replaced with the new `override` YAML construct, `exceptions` must not have any of their sub-fields as optional, just like when first defined in regular rules definitions.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/engine): make sure exception fields are not optional in replace mode
```
