### PR TITLE
fix(cmake): fix USE_BUNDLED_DEPS=ON and BUILD_FALCO_UNIT_TESTS=ON

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -65,10 +65,13 @@ PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR} # we need it to include `falco_test_var.h`
 )
 
+get_target_property(FALCO_APPLICATION_LIBRARIES falco_application LINK_LIBRARIES)
+
 target_link_libraries(falco_unit_tests
     falco_application
     GTest::gtest
     GTest::gtest_main
+    ${FALCO_APPLICATION_LIBRARIES}
 )
 
 if (EMSCRIPTEN)


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Build was failing when both `USE_BUNDLED_DEPS=ON` and `BUILD_FALCO_UNIT_TESTS=ON` were enabled at the same time with linking errors on `absl` and `grpc`. This fixes it by reintroducing explicit library linking for the test suite. It is not 100% clear to me why we need this line but I noticed that before this patch the following files would _not_ be linked in the final executable, hence the errors:

```
../_deps/yamlcpp-build/libyaml-cppd.a
../grpc-prefix/src/grpc/libgrpc++.a
../grpc-prefix/src/grpc/libgrpc.a
../grpc-prefix/src/grpc/libgpr.a
../protobuf-prefix/src/protobuf/target/lib/libprotobuf.a
../c-ares-prefix/src/c-ares/target/lib/libcares.a
../openssl-prefix/src/openssl/target/lib/libssl.a
../openssl-prefix/src/openssl/target/lib/libcrypto.a
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
