### PR TITLE
chore(userspace/falco): deprecate old 'rules_file' config key.

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -28,7 +28,7 @@
 # Falco config files
 #     configs_files
 # Falco rules files
-#     rules_file
+#     rules_files
 # Falco engine
 #     engine
 # Falco plugins
@@ -128,7 +128,7 @@
 # Therefore, loaded config files *can* override values from main config file.
 # Also, nested include is not allowed, ie: included config files won't be able to include other config files.
 #
-# Like for 'rules_file', specifying a folder will load all the configs files present in it in a lexicographical order.
+# Like for 'rules_files', specifying a folder will load all the configs files present in it in a lexicographical order.
 configs_files:
   - /etc/falco/config.d
 
@@ -136,11 +136,12 @@ configs_files:
 # Falco rules files #
 #####################
 
-# [Stable] `rules_file`
+# [Stable] `rules_files`
 #
 # Falco rules can be specified using files or directories, which are loaded at
-# startup. The name "rules_file" is maintained for backwards compatibility. If
-# the entry is a file, it will be read directly. If the entry is a directory,
+# startup. The old name "rules_file" is maintained for backwards compatibility.
+#
+# If the entry is a file, it will be read directly. If the entry is a directory,
 # all files within that directory will be read in alphabetical order.
 #
 # The falco_rules.yaml file ships with the Falco package and is overridden with
@@ -169,7 +170,7 @@ configs_files:
 # "first match wins" principle. However, enabling the `all` matching option may result
 # in a performance penalty. We recommend carefully testing this alternative setting  
 # before deploying it in production. Read more under the `rule_matching` configuration.
-rules_file:
+rules_files:
   - /etc/falco/falco_rules.yaml
   - /etc/falco/falco_rules.local.yaml
   - /etc/falco/rules.d

--- a/falco.yaml
+++ b/falco.yaml
@@ -137,9 +137,11 @@ configs_files:
 #####################
 
 # [Stable] `rules_files`
+
+NOTICE: Before Falco 0.38, this config key was `rules_file` (singular form), which is now deprecated in favor of `rules_files` (plural form).
 #
 # Falco rules can be specified using files or directories, which are loaded at
-# startup. The old name "rules_file" is maintained for backwards compatibility.
+# startup.
 #
 # If the entry is a file, it will be read directly. If the entry is a directory,
 # all files within that directory will be read in alphabetical order.

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -266,7 +266,7 @@ void falco_configuration::load_yaml(const std::string& config_name)
 	{
 		num_rules_files_opts++;
 		config.get_sequence<std::list<std::string>>(rules_files, std::string("rules_file"));
-		falco_logger::log(falco_logger::level::WARNING, "Using deprecated config key 'rules_file'. Please use new 'rules_files' config key.");
+		falco_logger::log(falco_logger::level::WARNING, "Using deprecated config key 'rules_file' (singular form). Please use new 'rules_files' config key (plural form).");
 	}
 	if (num_rules_files_opts == 2)
 	{

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -173,13 +173,10 @@ public:
 
 private:
 	void merge_configs_files(const std::string& config_name, std::vector<std::string>& loaded_config_files);
-
 	void load_yaml(const std::string& config_name);
-
+	void init_logger();
 	void load_engine_config(const std::string& config_name);
-
 	void init_cmdline_options(const std::vector<std::string>& cmdline_options);
-
 	/**
 	 * Given a <key>=<value> specifier, set the appropriate option
 	 * in the underlying yaml config. <key> can contain '.'


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Deprecates old 'rules_file' config option in favor of new 'rules_files'.
Old config option is still kept for backward compatiblity (and will possibly go away with Falco 1.0.0).
So:
* only `rules_files` present -> ok we use it
* only `rules_file` present -> ok we use it but give a warning about deprecation
* both keys used -> throw an exception

Example output:
* only `rules_file` present:
```
sudo ./userspace/falco/falco -c ../../falco.yaml  -r ../rules/falco_rules.yaml 
Wed Apr 10 17:26:45 2024: Using deprecated config key 'rules_file'. Please use new 'rules_files' config key.
Wed Apr 10 17:26:45 2024: Falco version: 0.38.0-182+e840a4a (x86_64)
Wed Apr 10 17:26:45 2024: Falco initialized with configuration files:
Wed Apr 10 17:26:45 2024:    ../../falco.yaml
```

* both keys present:
```
sudo ./userspace/falco/falco -c ../falco.yaml  -r ../rules/falco_rules.yaml -o configs_files=../../falco.yaml
Wed Apr 10 17:26:32 2024: Using deprecated config key 'rules_file'. Please use new 'rules_files' config key.
Error: Error reading config file (../falco.yaml): both 'rules_files' and 'rules_file' keys set
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
chore(userspace/falco): deprecated old 'rules_file' config key
```
