### PR TITLE
update(app): close inspectors at teardown time

### DIFF
--- a/userspace/falco/CMakeLists.txt
+++ b/userspace/falco/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(falco_application STATIC
   app/actions/start_webserver.cpp
   app/actions/validate_rules_files.cpp
   app/actions/create_requested_paths.cpp
+  app/actions/close_inspectors.cpp
   configuration.cpp
   logger.cpp
   falco_outputs.cpp

--- a/userspace/falco/app/actions/actions.h
+++ b/userspace/falco/app/actions/actions.h
@@ -56,6 +56,7 @@ falco::app::run_result stop_grpc_server(falco::app::state& s);
 falco::app::run_result stop_webserver(falco::app::state& s);
 falco::app::run_result unregister_signal_handlers(falco::app::state& s);
 falco::app::run_result validate_rules_files(falco::app::state& s);
+falco::app::run_result close_inspectors(falco::app::state& s);
 
 }; // namespace actions
 }; // namespace app

--- a/userspace/falco/app/actions/close_inspectors.cpp
+++ b/userspace/falco/app/actions/close_inspectors.cpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "actions.h"
+#include "helpers.h"
+
+using namespace falco::app;
+using namespace falco::app::actions;
+
+falco::app::run_result falco::app::actions::close_inspectors(falco::app::state& s)
+{
+	falco_logger::log(falco_logger::level::DEBUG, "closing inspectors");
+
+	if (s.offline_inspector != nullptr)
+	{
+		s.offline_inspector->close();
+	}
+
+	for (const auto &src : s.loaded_sources)
+	{
+		auto src_info = s.source_infos.at(src);
+
+		if (src_info->inspector != nullptr)
+		{
+			src_info->inspector->close();
+		}
+	}
+
+	return run_result::ok();
+}

--- a/userspace/falco/app/actions/process_events.cpp
+++ b/userspace/falco/app/actions/process_events.cpp
@@ -535,9 +535,9 @@ falco::app::run_result falco::app::actions::process_events(falco::app::state& s)
 		// wait for event processing to terminate for all sources
 		// if a thread terminates with an error, we trigger the app termination
 		// to force all other event streams to terminate too.
-		// We accomulate the errors in a single run_result.
-		size_t closed_count = 0;
-		while (closed_count < ctxs.size())
+		// We accumulate the errors in a single run_result.
+		size_t stopped_count = 0;
+		while (stopped_count < ctxs.size())
 		{
 			if (!res.success && !termination_forced)
 			{
@@ -572,12 +572,12 @@ falco::app::run_result falco::app::actions::process_events(falco::app::state& s)
 						ctx.thread->join();
 					}
 
-					falco_logger::log(falco_logger::level::DEBUG, "Closing event source '" + ctx.source + "'\n");
-					s.source_infos.at(ctx.source)->inspector->close();
+					falco_logger::log(falco_logger::level::DEBUG, "Stopping capture for event source '" + ctx.source + "'\n");
+					s.source_infos.at(ctx.source)->inspector->stop_capture();
 
 					res = run_result::merge(res, ctx.res);
 					ctx.sync->join();
-					closed_count++;
+					stopped_count++;
 				}
 			}
 		}

--- a/userspace/falco/app/app.cpp
+++ b/userspace/falco/app/app.cpp
@@ -95,6 +95,7 @@ bool falco::app::run(falco::app::state& s, bool& restart, std::string& errstr)
 		falco::app::actions::unregister_signal_handlers,
 		falco::app::actions::stop_grpc_server,
 		falco::app::actions::stop_webserver,
+		falco::app::actions::close_inspectors,
 	};
 
 	falco::app::run_result res = falco::app::run_result::ok();


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

See https://github.com/falcosecurity/falco/pull/3140#issuecomment-2059234096 , basically if we want to allow the server thread to access inspectors we need to close them as the last thing before shutting down which is what this patch proposes.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
