### PR TITLE
feat(docker/no-driver/Dockerfile.no-falcoctl-distroless): Provide distroless falco image without falcoctl

### DIFF
--- a/.github/workflows/reusable_build_docker.yaml
+++ b/.github/workflows/reusable_build_docker.yaml
@@ -56,7 +56,17 @@ jobs:
             --build-arg TARGETARCH=${TARGETARCH} \
             .
             docker save docker.io/falcosecurity/falco-distroless:${{ inputs.arch }}-${{ inputs.tag }} --output /tmp/falco-distroless-${{ inputs.arch }}.tar
-            
+
+      - name: Build no-falcoctl-distroless image
+        run: |
+          cd ${{ github.workspace }}/docker/no-driver/
+          docker build -f Dockerfile.no-falcoctl-distroless -t docker.io/falcosecurity/no-falcoctl-distroless:${{ inputs.arch }}-${{ inputs.tag }} \
+            --build-arg VERSION_BUCKET=bin${{ inputs.bucket_suffix }} \
+            --build-arg FALCO_VERSION=${{ inputs.version }} \
+            --build-arg TARGETARCH=${TARGETARCH} \
+            .
+            docker save docker.io/falcosecurity/no-falcoctl-distroless:${{ inputs.arch }}-${{ inputs.tag }} --output /tmp/no-falcoctl-distroless-${{ inputs.arch }}.tar
+
       - name: Build falco image
         run: |
           cd ${{ github.workspace }}/docker/falco/

--- a/docker/no-driver/Dockerfile.no-falcoctl-distroless
+++ b/docker/no-driver/Dockerfile.no-falcoctl-distroless
@@ -17,7 +17,7 @@ RUN FALCO_VERSION_URLENCODED=$(echo -n ${FALCO_VERSION}|jq -sRr @uri) && \
     rm -f falco.tar.gz && \
     mv falco-${FALCO_VERSION}-$(uname -m) falco && \
     rm -rf /falco/usr/bin/falcoctl && \
-	rm -rf /falco/etc/falcoctl && \
+    rm -rf /falco/etc/falcoctl && \
     rm -rf /falco/usr/src/falco-*
 
 RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /falco/etc/falco/falco.yaml > /falco/etc/falco/falco.yaml.new \

--- a/docker/no-driver/Dockerfile.no-falcoctl-distroless
+++ b/docker/no-driver/Dockerfile.no-falcoctl-distroless
@@ -1,0 +1,42 @@
+FROM cgr.dev/chainguard/wolfi-base as builder
+
+ARG FALCO_VERSION
+ARG VERSION_BUCKET=bin
+
+ENV FALCO_VERSION=${FALCO_VERSION}
+ENV VERSION_BUCKET=${VERSION_BUCKET}
+
+RUN apk update && apk add build-base gcc curl ca-certificates jq elfutils
+
+WORKDIR /
+
+RUN FALCO_VERSION_URLENCODED=$(echo -n ${FALCO_VERSION}|jq -sRr @uri) && \
+    curl -L -o falco.tar.gz \
+    https://download.falco.org/packages/${VERSION_BUCKET}/$(uname -m)/falco-${FALCO_VERSION_URLENCODED}-$(uname -m).tar.gz && \
+    tar -xvf falco.tar.gz && \
+    rm -f falco.tar.gz && \
+    mv falco-${FALCO_VERSION}-$(uname -m) falco && \
+    rm -rf /falco/usr/bin/falcoctl && \
+	rm -rf /falco/etc/falcoctl && \
+    rm -rf /falco/usr/src/falco-*
+
+RUN sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < /falco/etc/falco/falco.yaml > /falco/etc/falco/falco.yaml.new \
+    && mv /falco/etc/falco/falco.yaml.new /falco/etc/falco/falco.yaml
+
+FROM cgr.dev/chainguard/wolfi-base
+
+LABEL maintainer="cncf-falco-dev@lists.cncf.io"
+LABEL org.opencontainers.image.source="https://github.com/falcosecurity/falco"
+
+LABEL usage="docker run -i -t --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro --name NAME IMAGE"
+# NOTE: for the "least privileged" use case, please refer to the official documentation
+
+RUN apk update && apk add libelf libstdc++
+
+ENV HOST_ROOT /host
+ENV HOME /root
+
+USER root
+COPY --from=builder /falco /
+
+CMD ["/usr/bin/falco", "-o", "time_format_iso_8601=true"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR introduces a new Docker image that builds the Falco application without falcoctl present in said image. People could build Falco using this Docker image if they are operating Falco in a sensitive environment or just don't want/need falcoctl. This proposed Dockerfile can also reduce the attack surface introduced by falcoctl in the Falco image.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Related to points made in #3165

**Special notes for your reviewer**:
After reading through #3165 I noticed that there is a proposal to depreciate the Falco distroless image. I figured I would open this PR anyway to help with the dev work / show that there is interest in having a Falco image that does not contain falcoctl. 

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
feat(docker/no-driver/Dockerfile.no-falcoctl-distroless): Users now have the option to build the Falco Docker image without installing falcoctl.
```
