### PR TITLE
new(falco): add rule selection configuration in falco.yaml

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -177,7 +177,7 @@ rules_files:
   - /etc/falco/falco_rules.local.yaml
   - /etc/falco/rules.d
 
-# [Experimental] `rules`
+# [Incubating] `rules`
 #
 # --- [Description]
 #

--- a/falco.yaml
+++ b/falco.yaml
@@ -177,6 +177,39 @@ rules_files:
   - /etc/falco/falco_rules.local.yaml
   - /etc/falco/rules.d
 
+# [Experimental] `rules`
+#
+# --- [Description]
+#
+# Falco rules can be enabled or disabled by name (with wildcards *) and/or by tag.
+#
+# This configuration is applied after all rules files have been loaded, including
+# their overrides, and will take precedence over the enabled/disabled configuration
+# specified or overridden in the rules files.
+#
+# The ordering matters and selections are evaluated in order. For instance, if you
+# need to only enable a rule you would first disable all of them and then only
+# enable what you need, regardless of the enabled status in the files.
+#
+# --- [Examples]
+#
+# Only enable two rules:
+#
+# rules:
+#   - disable:
+#       rule: "*"
+#   - enable:
+#       rule: Netcat Remote Code Execution in Container
+#   - enable:
+#       rule: Delete or rename shell history
+#
+# Disable all rules with a specific tag:
+#
+# rules:
+#   - disable:
+#       tag: network
+#
+
 ################
 # Falco engine #
 ################

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(falco_unit_tests
     engine/test_rule_loader.cpp
     engine/test_rulesets.cpp
     falco/test_configuration.cpp
+    falco/test_configuration_rule_selection.cpp
     falco/app/actions/test_select_event_sources.cpp
     falco/app/actions/test_load_config.cpp
 )

--- a/unit_tests/engine/test_alt_rule_loader.cpp
+++ b/unit_tests/engine/test_alt_rule_loader.cpp
@@ -310,9 +310,8 @@ TEST(engine_loader_alt_loader, pass_compile_output_to_ruleset)
 	// Enable all rules for a ruleset id. Because the compile
 	// output contained one rule with priority >= INFO, that rule
 	// should be enabled.
-	bool match_exact = true;
 	uint16_t ruleset_id = 0;
-	ruleset->enable("", match_exact, ruleset_id);
+	ruleset->enable("", filter_ruleset::match_type::substring, ruleset_id);
 
 	EXPECT_EQ(ruleset->enabled_count(ruleset_id), 1);
 }

--- a/unit_tests/engine/test_falco_utils.cpp
+++ b/unit_tests/engine/test_falco_utils.cpp
@@ -72,3 +72,24 @@ TEST(FalcoUtils, parse_prometheus_interval)
 	 */
 	ASSERT_EQ(falco::utils::parse_prometheus_interval("200"), 0UL);
 }
+
+TEST(FalcoUtils, matches_wildcard)
+{
+	ASSERT_TRUE(falco::utils::matches_wildcard("*", "anything"));
+	ASSERT_TRUE(falco::utils::matches_wildcard("**", "anything"));
+	ASSERT_TRUE(falco::utils::matches_wildcard("*", ""));
+	ASSERT_TRUE(falco::utils::matches_wildcard("no star", "no star"));
+	ASSERT_TRUE(falco::utils::matches_wildcard("", ""));
+	ASSERT_TRUE(falco::utils::matches_wildcard("hello*world", "hello new world"));
+	ASSERT_TRUE(falco::utils::matches_wildcard("hello*world*", "hello new world yes"));
+	ASSERT_TRUE(falco::utils::matches_wildcard("*hello*world", "come on hello this world"));
+	ASSERT_TRUE(falco::utils::matches_wildcard("*hello*****world", "come on hello this world"));
+
+	ASSERT_FALSE(falco::utils::matches_wildcard("no star", ""));
+	ASSERT_FALSE(falco::utils::matches_wildcard("", "no star"));
+	ASSERT_FALSE(falco::utils::matches_wildcard("star", "no star"));
+	ASSERT_FALSE(falco::utils::matches_wildcard("hello*world", "hello new thing"));
+	ASSERT_FALSE(falco::utils::matches_wildcard("hello*world", "hello new world yes"));
+	ASSERT_FALSE(falco::utils::matches_wildcard("*hello*world", "come on hello this world yes"));
+	ASSERT_FALSE(falco::utils::matches_wildcard("*hello*world*", "come on hello this yes"));
+}

--- a/unit_tests/engine/test_rulesets.cpp
+++ b/unit_tests/engine/test_rulesets.cpp
@@ -74,46 +74,70 @@ TEST(Ruleset, enable_disable_rules_using_names)
 	r->add(rule_C, filter, ast);
 
 	/* Enable `rule_A` for RULESET_0 */
-	r->enable(rule_A.name, true, RULESET_0);
+	r->enable(rule_A.name, filter_ruleset::match_type::exact, RULESET_0);
 	ASSERT_EQ(r->enabled_count(RULESET_0), 1);
 	ASSERT_EQ(r->enabled_count(RULESET_1), 0);
 	ASSERT_EQ(r->enabled_count(RULESET_2), 0);
 
 	/* Disable `rule_A` for RULESET_1, this should have no effect */
-	r->disable(rule_A.name, true, RULESET_1);
+	r->disable(rule_A.name, filter_ruleset::match_type::exact, RULESET_1);
 	ASSERT_EQ(r->enabled_count(RULESET_0), 1);
 	ASSERT_EQ(r->enabled_count(RULESET_1), 0);
 	ASSERT_EQ(r->enabled_count(RULESET_2), 0);
 
 	/* Enable a not existing rule for RULESET_2, this should have no effect */
-	r->disable("<NA>", true, RULESET_2);
+	r->disable("<NA>", filter_ruleset::match_type::exact, RULESET_2);
 	ASSERT_EQ(r->enabled_count(RULESET_0), 1);
 	ASSERT_EQ(r->enabled_count(RULESET_1), 0);
 	ASSERT_EQ(r->enabled_count(RULESET_2), 0);
 
 	/* Enable all rules for RULESET_0 */
-	r->enable("rule_", false, RULESET_0);
+	r->enable("rule_", filter_ruleset::match_type::substring, RULESET_0);
 	ASSERT_EQ(r->enabled_count(RULESET_0), 3);
 	ASSERT_EQ(r->enabled_count(RULESET_1), 0);
 	ASSERT_EQ(r->enabled_count(RULESET_2), 0);
 
 	/* Try to disable all rules with exact match for RULESET_0, this should have no effect */
-	r->disable("rule_", true, RULESET_0);
+	r->disable("rule_", filter_ruleset::match_type::exact, RULESET_0);
 	ASSERT_EQ(r->enabled_count(RULESET_0), 3);
 	ASSERT_EQ(r->enabled_count(RULESET_1), 0);
 	ASSERT_EQ(r->enabled_count(RULESET_2), 0);
 
 	/* Disable all rules for RULESET_0 */
-	r->disable("rule_", false, RULESET_0);
+	r->disable("rule_", filter_ruleset::match_type::substring, RULESET_0);
 	ASSERT_EQ(r->enabled_count(RULESET_0), 0);
 	ASSERT_EQ(r->enabled_count(RULESET_1), 0);
 	ASSERT_EQ(r->enabled_count(RULESET_2), 0);
 
 	/* Enable rule_C for RULESET_2 without exact_match */
-	r->enable("_C", false, RULESET_2);
+	r->enable("_C", filter_ruleset::match_type::substring, RULESET_2);
 	ASSERT_EQ(r->enabled_count(RULESET_0), 0);
 	ASSERT_EQ(r->enabled_count(RULESET_1), 0);
 	ASSERT_EQ(r->enabled_count(RULESET_2), 1);
+
+	/* Disable rule_C for RULESET_2 without exact_match */
+	r->disable("_C", filter_ruleset::match_type::substring, RULESET_2);
+	ASSERT_EQ(r->enabled_count(RULESET_0), 0);
+	ASSERT_EQ(r->enabled_count(RULESET_1), 0);
+	ASSERT_EQ(r->enabled_count(RULESET_2), 0);
+
+	/* Enable all rules for RULESET_0 with wildcard */
+	r->enable("*", filter_ruleset::match_type::wildcard, RULESET_0);
+	ASSERT_EQ(r->enabled_count(RULESET_0), 3);
+	ASSERT_EQ(r->enabled_count(RULESET_1), 0);
+	ASSERT_EQ(r->enabled_count(RULESET_2), 0);
+
+	/* Disable rule C for RULESET_0 with wildcard */
+	r->disable("*C*", filter_ruleset::match_type::wildcard, RULESET_0);
+	ASSERT_EQ(r->enabled_count(RULESET_0), 2);
+	ASSERT_EQ(r->enabled_count(RULESET_1), 0);
+	ASSERT_EQ(r->enabled_count(RULESET_2), 0);
+
+	/* Disable all rules for RULESET_0 with wildcard */
+	r->disable("*_*", filter_ruleset::match_type::wildcard, RULESET_0);
+	ASSERT_EQ(r->enabled_count(RULESET_0), 0);
+	ASSERT_EQ(r->enabled_count(RULESET_1), 0);
+	ASSERT_EQ(r->enabled_count(RULESET_2), 0);
 }
 
 TEST(Ruleset, enable_disable_rules_using_tags)

--- a/unit_tests/falco/test_configuration.cpp
+++ b/unit_tests/falco/test_configuration.cpp
@@ -138,7 +138,7 @@ TEST(Configuration, configuration_config_files_secondary_fail)
 	std::vector<std::string> cmdline_config_options;
 	std::vector<std::string> loaded_conf_files;
 	falco_configuration falco_config;
-	ASSERT_ANY_THROW(falco_config.init("main.yaml", loaded_conf_files, cmdline_config_options));
+	ASSERT_ANY_THROW(falco_config.init_from_file("main.yaml", loaded_conf_files, cmdline_config_options));
 
 	std::filesystem::remove("main.yaml");
 	std::filesystem::remove("conf_2.yaml");
@@ -187,7 +187,7 @@ TEST(Configuration, configuration_config_files_ok)
 	std::vector<std::string> cmdline_config_options;
 	std::vector<std::string> loaded_conf_files;
 	falco_configuration falco_config;
-	ASSERT_NO_THROW(falco_config.init("main.yaml", loaded_conf_files, cmdline_config_options));
+	ASSERT_NO_THROW(falco_config.init_from_file("main.yaml", loaded_conf_files, cmdline_config_options));
 
 	// main + conf_2 + conf_3
 	ASSERT_EQ(loaded_conf_files.size(), 3);
@@ -260,7 +260,7 @@ TEST(Configuration, configuration_config_files_relative_main)
 	std::vector<std::string> cmdline_config_options;
 	std::vector<std::string> loaded_conf_files;
 	falco_configuration falco_config;
-	ASSERT_NO_THROW(falco_config.init(temp_main.string(), loaded_conf_files, cmdline_config_options));
+	ASSERT_NO_THROW(falco_config.init_from_file(temp_main.string(), loaded_conf_files, cmdline_config_options));
 
 	// main + conf_2 + conf_3
 	ASSERT_EQ(loaded_conf_files.size(), 3);
@@ -317,7 +317,7 @@ TEST(Configuration, configuration_config_files_override)
 	std::vector<std::string> cmdline_config_options;
 	std::vector<std::string> loaded_conf_files;
 	falco_configuration falco_config;
-	ASSERT_NO_THROW(falco_config.init("main.yaml", loaded_conf_files, cmdline_config_options));
+	ASSERT_NO_THROW(falco_config.init_from_file("main.yaml", loaded_conf_files, cmdline_config_options));
 
 	// main + conf_2 + conf_3
 	ASSERT_EQ(loaded_conf_files.size(), 3);
@@ -355,7 +355,7 @@ TEST(Configuration, configuration_config_files_unexistent)
 	std::vector<std::string> cmdline_config_options;
 	std::vector<std::string> loaded_conf_files;
 	falco_configuration falco_config;
-	ASSERT_NO_THROW(falco_config.init("main.yaml", loaded_conf_files, cmdline_config_options));
+	ASSERT_NO_THROW(falco_config.init_from_file("main.yaml", loaded_conf_files, cmdline_config_options));
 
 	// main
 	ASSERT_EQ(loaded_conf_files.size(), 1);
@@ -393,7 +393,7 @@ TEST(Configuration, configuration_config_files_scalar_configs_files)
 	std::vector<std::string> cmdline_config_options;
 	std::vector<std::string> loaded_conf_files;
 	falco_configuration falco_config;
-	ASSERT_NO_THROW(falco_config.init("main.yaml", loaded_conf_files, cmdline_config_options));
+	ASSERT_NO_THROW(falco_config.init_from_file("main.yaml", loaded_conf_files, cmdline_config_options));
 
 	// main + conf_2
 	ASSERT_EQ(loaded_conf_files.size(), 2);
@@ -430,7 +430,7 @@ TEST(Configuration, configuration_config_files_empty_configs_files)
 	std::vector<std::string> cmdline_config_options;
 	std::vector<std::string> loaded_conf_files;
 	falco_configuration falco_config;
-	ASSERT_NO_THROW(falco_config.init("main.yaml", loaded_conf_files, cmdline_config_options));
+	ASSERT_NO_THROW(falco_config.init_from_file("main.yaml", loaded_conf_files, cmdline_config_options));
 
 	// main
 	ASSERT_EQ(loaded_conf_files.size(), 1);
@@ -462,7 +462,7 @@ TEST(Configuration, configuration_config_files_self)
 	std::vector<std::string> cmdline_config_options;
 	std::vector<std::string> loaded_conf_files;
 	falco_configuration falco_config;
-	ASSERT_ANY_THROW(falco_config.init("main.yaml", loaded_conf_files, cmdline_config_options));
+	ASSERT_ANY_THROW(falco_config.init_from_file("main.yaml", loaded_conf_files, cmdline_config_options));
 
 	std::filesystem::remove("main.yaml");
 }
@@ -516,7 +516,7 @@ TEST(Configuration, configuration_config_files_directory)
 	std::vector<std::string> cmdline_config_options;
 	std::vector<std::string> loaded_conf_files;
 	falco_configuration falco_config;
-	ASSERT_NO_THROW(falco_config.init("main.yaml", loaded_conf_files, cmdline_config_options));
+	ASSERT_NO_THROW(falco_config.init_from_file("main.yaml", loaded_conf_files, cmdline_config_options));
 
 	// main + conf_2 + conf_3.
 	// test/foo is not parsed.
@@ -567,7 +567,7 @@ TEST(Configuration, configuration_config_files_cmdline)
 
 	std::vector<std::string> loaded_conf_files;
 	falco_configuration falco_config;
-	ASSERT_NO_THROW(falco_config.init("main.yaml", loaded_conf_files, cmdline_config_options));
+	ASSERT_NO_THROW(falco_config.init_from_file("main.yaml", loaded_conf_files, cmdline_config_options));
 
 	// main + conf_2
 	ASSERT_EQ(loaded_conf_files.size(), 2);
@@ -799,7 +799,7 @@ TEST(Configuration, configuration_webserver_ip)
         std::vector<std::string> cmdline_config_options;
         cmdline_config_options.push_back(option);
 
-        EXPECT_NO_THROW(falco_config.init(cmdline_config_options));
+        EXPECT_NO_THROW(falco_config.init_from_content("", cmdline_config_options));
 
         ASSERT_EQ(falco_config.m_webserver_config.m_listen_address, address);
     }
@@ -836,6 +836,6 @@ TEST(Configuration, configuration_webserver_ip)
         std::vector<std::string> cmdline_config_options;
         cmdline_config_options.push_back(option);
 
-        EXPECT_ANY_THROW(falco_config.init(cmdline_config_options));
+        EXPECT_ANY_THROW(falco_config.init_from_content("", cmdline_config_options));
     }
 }

--- a/unit_tests/falco/test_configuration_rule_selection.cpp
+++ b/unit_tests/falco/test_configuration_rule_selection.cpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <gtest/gtest.h>
+#include <falco/configuration.h>
+
+TEST(ConfigurationRuleSelection, parse_yaml)
+{
+	falco_configuration falco_config;
+	EXPECT_NO_THROW(falco_config.init_from_content(R"(
+rules:
+  - enable:
+      rule: 'Terminal Shell in Container'
+
+  - disable:
+      tag: experimental
+
+  - enable:
+      rule: 'hello*'
+	)", {}));
+
+	ASSERT_EQ(falco_config.m_rules_selection.size(), 3);
+
+	ASSERT_EQ(falco_config.m_rules_selection[0].m_op, falco_configuration::rule_selection_operation::enable);
+	ASSERT_EQ(falco_config.m_rules_selection[0].m_rule, "Terminal Shell in Container");
+
+	ASSERT_EQ(falco_config.m_rules_selection[1].m_op, falco_configuration::rule_selection_operation::disable);
+	ASSERT_EQ(falco_config.m_rules_selection[1].m_tag, "experimental");
+
+	ASSERT_EQ(falco_config.m_rules_selection[2].m_op, falco_configuration::rule_selection_operation::enable);
+	ASSERT_EQ(falco_config.m_rules_selection[2].m_rule, "hello*");
+}
+
+TEST(ConfigurationRuleSelection, cli_options)
+{
+	falco_configuration falco_config;
+	EXPECT_NO_THROW(falco_config.init(std::vector<std::string>{"rules[].disable.tag=maturity_incubating", "rules[].enable.rule=Adding ssh keys to authorized_keys"}));
+
+	ASSERT_EQ(falco_config.m_rules_selection.size(), 2);
+
+	ASSERT_EQ(falco_config.m_rules_selection[0].m_op, falco_configuration::rule_selection_operation::disable);
+	ASSERT_EQ(falco_config.m_rules_selection[0].m_tag, "maturity_incubating");
+
+	ASSERT_EQ(falco_config.m_rules_selection[1].m_op, falco_configuration::rule_selection_operation::enable);
+	ASSERT_EQ(falco_config.m_rules_selection[1].m_rule, "Adding ssh keys to authorized_keys");
+}

--- a/unit_tests/falco/test_configuration_rule_selection.cpp
+++ b/unit_tests/falco/test_configuration_rule_selection.cpp
@@ -48,7 +48,7 @@ rules:
 TEST(ConfigurationRuleSelection, cli_options)
 {
 	falco_configuration falco_config;
-	EXPECT_NO_THROW(falco_config.init(std::vector<std::string>{"rules[].disable.tag=maturity_incubating", "rules[].enable.rule=Adding ssh keys to authorized_keys"}));
+	EXPECT_NO_THROW(falco_config.init_from_content("", std::vector<std::string>{"rules[].disable.tag=maturity_incubating", "rules[].enable.rule=Adding ssh keys to authorized_keys"}));
 
 	ASSERT_EQ(falco_config.m_rules_selection.size(), 2);
 

--- a/userspace/engine/evttype_index_ruleset.h
+++ b/userspace/engine/evttype_index_ruleset.h
@@ -53,13 +53,13 @@ public:
 	void on_loading_complete() override;
 
 	void enable(
-		const std::string &substring,
-		bool match_exact,
+		const std::string &pattern,
+		match_type match,
 		uint16_t rulset_id) override;
 
 	void disable(
-		const std::string &substring,
-		bool match_exact,
+		const std::string &pattern,
+		match_type match,
 		uint16_t rulset_id) override;
 
 	void enable_tags(
@@ -85,8 +85,8 @@ private:
 
 	// Helper used by enable()/disable()
 	void enable_disable(
-		const std::string &substring,
-		bool match_exact,
+		const std::string &pattern,
+		match_type match,
 		bool enabled,
 		uint16_t rulset_id);
 

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -242,11 +242,11 @@ std::unique_ptr<load_result> falco_engine::load_rules(const std::string &rules_c
 			}
 			if(info->enabled)
 			{
-				source->ruleset->enable(rule.name, true, m_default_ruleset_id);
+				source->ruleset->enable(rule.name, filter_ruleset::match_type::exact, m_default_ruleset_id);
 			}
 			else
 			{
-				source->ruleset->disable(rule.name, true, m_default_ruleset_id);
+				source->ruleset->disable(rule.name, filter_ruleset::match_type::exact, m_default_ruleset_id);
 			}
 		}
 	}
@@ -272,17 +272,15 @@ void falco_engine::enable_rule(const std::string &substring, bool enabled, const
 
 void falco_engine::enable_rule(const std::string &substring, bool enabled, const uint16_t ruleset_id)
 {
-	bool match_exact = false;
-
 	for(const auto &it : m_sources)
 	{
 		if(enabled)
 		{
-			it.ruleset->enable(substring, match_exact, ruleset_id);
+			it.ruleset->enable(substring, filter_ruleset::match_type::substring, ruleset_id);
 		}
 		else
 		{
-			it.ruleset->disable(substring, match_exact, ruleset_id);
+			it.ruleset->disable(substring, filter_ruleset::match_type::substring, ruleset_id);
 		}
 	}
 }
@@ -296,17 +294,37 @@ void falco_engine::enable_rule_exact(const std::string &rule_name, bool enabled,
 
 void falco_engine::enable_rule_exact(const std::string &rule_name, bool enabled, const uint16_t ruleset_id)
 {
-	bool match_exact = true;
-
 	for(const auto &it : m_sources)
 	{
 		if(enabled)
 		{
-			it.ruleset->enable(rule_name, match_exact, ruleset_id);
+			it.ruleset->enable(rule_name, filter_ruleset::match_type::exact, ruleset_id);
 		}
 		else
 		{
-			it.ruleset->disable(rule_name, match_exact, ruleset_id);
+			it.ruleset->disable(rule_name, filter_ruleset::match_type::exact, ruleset_id);
+		}
+	}
+}
+
+void falco_engine::enable_rule_wildcard(const std::string &rule_name, bool enabled, const std::string &ruleset)
+{
+	uint16_t ruleset_id = find_ruleset_id(ruleset);
+
+	enable_rule_wildcard(rule_name, enabled, ruleset_id);
+}
+
+void falco_engine::enable_rule_wildcard(const std::string &rule_name, bool enabled, const uint16_t ruleset_id)
+{
+	for(const auto &it : m_sources)
+	{
+		if(enabled)
+		{
+			it.ruleset->enable(rule_name, filter_ruleset::match_type::wildcard, ruleset_id);
+		}
+		else
+		{
+			it.ruleset->disable(rule_name, filter_ruleset::match_type::wildcard, ruleset_id);
 		}
 	}
 }

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -102,6 +102,12 @@ public:
 	// Same as above but providing a ruleset id instead
 	void enable_rule_exact(const std::string &rule_name, bool enabled, const uint16_t ruleset_id);
 
+	// Like enable_rule, but wildcards are supported and substrings are not matched
+	void enable_rule_wildcard(const std::string &rule_name, bool enabled, const std::string &ruleset = s_default_ruleset);
+
+	// Same as above but providing a ruleset id instead
+	void enable_rule_wildcard(const std::string &rule_name, bool enabled, const uint16_t ruleset_id);
+
 	//
 	// Enable/Disable any rules with any of the provided tags (set, exact matches only)
 	//

--- a/userspace/engine/falco_utils.cpp
+++ b/userspace/engine/falco_utils.cpp
@@ -163,6 +163,48 @@ void readfile(const std::string& filename, std::string& data)
 	return;
 }
 
+bool matches_wildcard(const std::string &pattern, const std::string &s)
+{
+	std::string::size_type star_pos = pattern.find("*");
+	if(star_pos == std::string::npos)
+	{
+		// regular match (no wildcards)
+		return pattern == s;
+	}
+
+	if(star_pos == 0)
+	{
+		// wildcard at the beginning "*something*..."
+
+		std::string::size_type next_pattern_start = pattern.find_first_not_of("*");
+		if(next_pattern_start == std::string::npos)
+		{
+			// pattern was just a sequence of stars *, **, ***, ... . This always matches.
+			return true;
+		}
+
+		std::string next_pattern = pattern.substr(next_pattern_start);
+		std::string to_find = next_pattern.substr(0, next_pattern.find("*"));
+		std::string::size_type lit_pos = s.find(to_find);
+		if(lit_pos == std::string::npos)
+		{
+			return false;
+		}
+
+		return matches_wildcard(next_pattern.substr(to_find.size()), s.substr(lit_pos + to_find.size()));
+	} else
+	{
+		// wildcard at the end or in the middle "something*else*..."
+		
+		if(pattern.substr(0, star_pos) != s.substr(0, star_pos))
+		{
+			return false;
+		}
+
+		return matches_wildcard(pattern.substr(star_pos), s.substr(star_pos));
+	}
+}
+
 namespace network
 {
 bool is_unix_scheme(const std::string& url)

--- a/userspace/engine/falco_utils.h
+++ b/userspace/engine/falco_utils.h
@@ -33,6 +33,8 @@ void readfile(const std::string& filename, std::string& data);
 
 uint32_t hardware_concurrency();
 
+bool matches_wildcard(const std::string &pattern, const std::string &s);
+
 namespace network
 {
 static const std::string UNIX_SCHEME("unix://");

--- a/userspace/engine/filter_ruleset.h
+++ b/userspace/engine/filter_ruleset.h
@@ -41,6 +41,10 @@ public:
 		ruleset_retriever_func_t get_ruleset;
 	};
 
+	enum class match_type {
+		exact, substring, wildcard
+	};
+
 	virtual ~filter_ruleset() = default;
 
 	void set_engine_state(const engine_state_funcs &engine_state);
@@ -167,31 +171,37 @@ public:
 	/*!
 		\brief Find those rules matching the provided substring and enable
 		them in the provided ruleset.
-		\param substring Substring used to match rule names.
-		If empty, all rules are matched.
-		\param match_exact If true, substring must be an exact match for a
-		given rule name. Otherwise, any rules having substring as a substring
-		in the rule name are enabled/disabled.
+		\param pattern Pattern used to match rule names.
+		\param match How to match the pattern against rules:
+			- exact: rules that has the same exact name as the pattern are matched
+			- substring: rules having the pattern as a substring in the rule are matched.
+						 An empty pattern matches all rules.
+			- wildcard: rules with names that satisfies a wildcard (*) pattern are matched.
+						 A "*" pattern matches all rules.
+						 Wildcards can appear anywhere in the pattern (e.g. "*hello*world*")
 		\param ruleset_id The id of the ruleset to be used
 	*/
 	virtual void enable(
-		const std::string &substring,
-		bool match_exact,
+		const std::string &pattern,
+		match_type match,
 		uint16_t ruleset_id) = 0;
 
 	/*!
 		\brief Find those rules matching the provided substring and disable
 		them in the provided ruleset.
-		\param substring Substring used to match rule names.
-		If empty, all rules are matched.
-		\param match_exact If true, substring must be an exact match for a
-		given rule name. Otherwise, any rules having substring as a substring
-		in the rule name are enabled/disabled.
+		\param pattern Pattern used to match rule names.
+		\param match How to match the pattern against rules:
+			- exact: rules that has the same exact name as the pattern are matched
+			- substring: rules having the pattern as a substring in the rule are matched.
+						 An empty pattern matches all rules.
+			- wildcard: rules with names that satisfies a wildcard (*) pattern are matched.
+						 A "*" pattern matches all rules.
+						 Wildcards can appear anywhere in the pattern (e.g. "*hello*world*")
 		\param ruleset_id The id of the ruleset to be used
 	*/
 	virtual void disable(
-		const std::string &substring,
-		bool match_exact,
+		const std::string &pattern,
+		match_type match,
 		uint16_t ruleset_id) = 0;
 
 	/*!

--- a/userspace/falco/app/actions/load_config.cpp
+++ b/userspace/falco/app/actions/load_config.cpp
@@ -36,14 +36,14 @@ falco::app::run_result falco::app::actions::load_config(const falco::app::state&
 	{
 		if (!s.options.conf_filename.empty())
 		{
-			s.config->init(s.options.conf_filename, loaded_conf_files, s.options.cmdline_config_options);
+			s.config->init_from_file(s.options.conf_filename, loaded_conf_files, s.options.cmdline_config_options);
 		}
 		else
 		{
 			// Is possible to have an empty config file when we want to use some command line
 			// options like `--help`, `--version`, ...
 			// The configs used in `load_yaml` will be initialized to the default values.
-			s.config->init(s.options.cmdline_config_options);
+			s.config->init_from_content("", s.options.cmdline_config_options);
 		}
 	}
 	catch (std::exception& e)

--- a/userspace/falco/app/actions/load_rules_files.cpp
+++ b/userspace/falco/app/actions/load_rules_files.cpp
@@ -127,6 +127,12 @@ falco::app::run_result falco::app::actions::load_rules_files(falco::app::state& 
 		return run_result::fatal(err);
 	}
 
+	if((!s.options.disabled_rule_substrings.empty() || !s.options.disabled_rule_tags.empty() || !s.options.enabled_rule_tags.empty()) &&
+		!s.config->m_rules_selection.empty())
+	{
+		return run_result::fatal("Specifying -D, -t, -T command line options together with \"rules:\" configuration or -o \"rules...\" is not supported.");
+	}
+
 	for (const auto& substring : s.options.disabled_rule_substrings)
 	{
 		falco_logger::log(falco_logger::level::INFO, "Disabling rules matching substring: " + substring + "\n");
@@ -152,6 +158,27 @@ falco::app::run_result falco::app::actions::load_rules_files(falco::app::state& 
 			falco_logger::log(falco_logger::level::INFO, "Enabling rules with tag: " + tag + "\n");
 		}
 		s.engine->enable_rule_by_tag(s.options.enabled_rule_tags, true);
+	}
+
+	for(const auto& sel : s.config->m_rules_selection)
+	{
+		bool enable = sel.m_op == falco_configuration::rule_selection_operation::enable;
+
+		if(sel.m_rule != "")
+		{
+			falco_logger::log(falco_logger::level::INFO,
+				(enable ? "Enabling" : "Disabling") + std::string(" rules with name: ") + sel.m_rule + "\n");
+
+			s.engine->enable_rule_wildcard(sel.m_rule, enable);
+		}
+
+		if(sel.m_tag != "")
+		{
+			falco_logger::log(falco_logger::level::INFO,
+				(enable ? "Enabling" : "Disabling") + std::string(" rules with tag: ") + sel.m_tag + "\n");
+
+			s.engine->enable_rule_by_tag(std::set<std::string>{sel.m_tag}, enable); // TODO wildcard support
+		}
 	}
 
 	// printout of `-L` option

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -85,6 +85,13 @@ void falco_configuration::init(const std::vector<std::string>& cmdline_options)
 	load_yaml("default");
 }
 
+void falco_configuration::init_from_content(const std::string& config_content, const std::vector<std::string>& cmdline_options)
+{
+	config.load_from_string(config_content);
+	init_cmdline_options(cmdline_options);
+	load_yaml("default");
+}
+
 void falco_configuration::init(const std::string& conf_filename, std::vector<std::string>& loaded_conf_files,
 			       const std::vector<std::string> &cmdline_options)
 {
@@ -549,6 +556,8 @@ void falco_configuration::load_yaml(const std::string& config_name)
 
 	m_metrics_convert_memory_to_mb = config.get_scalar<bool>("metrics.convert_memory_to_mb", true);
 	m_metrics_include_empty_values = config.get_scalar<bool>("metrics.include_empty_values", false);
+
+	config.get_sequence<std::vector<rule_selection_config>>(m_rules_selection, "rules");
 
 	std::vector<std::string> load_plugins;
 

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -78,21 +78,14 @@ falco_configuration::falco_configuration():
 {
 }
 
-void falco_configuration::init(const std::vector<std::string>& cmdline_options)
-{
-	config.load_from_string("");
-	init_cmdline_options(cmdline_options);
-	load_yaml("default");
-}
-
-void falco_configuration::init_from_content(const std::string& config_content, const std::vector<std::string>& cmdline_options)
+void falco_configuration::init_from_content(const std::string& config_content, const std::vector<std::string>& cmdline_options, const std::string& filename)
 {
 	config.load_from_string(config_content);
 	init_cmdline_options(cmdline_options);
-	load_yaml("default");
+	load_yaml(filename);
 }
 
-void falco_configuration::init(const std::string& conf_filename, std::vector<std::string>& loaded_conf_files,
+void falco_configuration::init_from_file(const std::string& conf_filename, std::vector<std::string>& loaded_conf_files,
 			       const std::vector<std::string> &cmdline_options)
 {
 	loaded_conf_files.clear();

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -93,11 +93,23 @@ public:
 		bool m_prometheus_metrics_enabled = false;
 	};
 
+	enum class rule_selection_operation {
+		enable,
+		disable
+	};
+
+	struct rule_selection_config {
+		rule_selection_operation m_op;
+		std::string m_tag;
+		std::string m_rule;
+	};
+
 	falco_configuration();
 	virtual ~falco_configuration() = default;
 
 	void init(const std::string& conf_filename, std::vector<std::string>& loaded_conf_files, const std::vector<std::string>& cmdline_options);
 	void init(const std::vector<std::string>& cmdline_options);
+	void init_from_content(const std::string& config_content, const std::vector<std::string>& cmdline_options);
 
 	std::string dump();
 
@@ -114,6 +126,9 @@ public:
 	std::list<std::string> m_loaded_rules_filenames;
 	// List of loaded rule folders
 	std::list<std::string> m_loaded_rules_folders;
+	// Rule selection options passed by the user
+	std::vector<rule_selection_config> m_rules_selection;
+
 	bool m_json_output;
 	bool m_json_include_output_property;
 	bool m_json_include_tags_property;
@@ -192,6 +207,91 @@ private:
 };
 
 namespace YAML {
+	template<>
+	struct convert<falco_configuration::rule_selection_config> {
+		static Node encode(const falco_configuration::rule_selection_config & rhs) {
+			Node node;
+			Node subnode;
+			if(rhs.m_rule != "")
+			{
+				subnode["rule"] = rhs.m_rule;
+			}
+
+			if(rhs.m_tag != "")
+			{
+				subnode["tag"] = rhs.m_tag;
+			}
+			
+			if(rhs.m_op == falco_configuration::rule_selection_operation::enable)
+			{
+				node["enable"] = subnode;
+			}
+			else if(rhs.m_op == falco_configuration::rule_selection_operation::disable)
+			{
+				node["disable"] = subnode;
+			}
+
+			return node;
+		}
+
+		static bool decode(const Node& node, falco_configuration::rule_selection_config & rhs) {
+			if(!node.IsMap())
+			{
+				return false;
+			}
+
+			if(node["enable"])
+			{
+				rhs.m_op = falco_configuration::rule_selection_operation::enable;
+
+				const Node& enable = node["enable"];
+				if(!enable.IsMap())
+				{
+					return false;
+				}
+
+				if(enable["rule"])
+				{
+					rhs.m_rule = enable["rule"].as<std::string>();
+				}
+				if(enable["tag"])
+				{
+					rhs.m_tag = enable["tag"].as<std::string>();
+				}
+			}
+			else if(node["disable"])
+			{
+				rhs.m_op = falco_configuration::rule_selection_operation::disable;
+
+				const Node& disable = node["disable"];
+				if(!disable.IsMap())
+				{
+					return false;
+				}
+
+				if(disable["rule"])
+				{
+					rhs.m_rule = disable["rule"].as<std::string>();
+				}
+				if(disable["tag"])
+				{
+					rhs.m_tag = disable["tag"].as<std::string>();
+				}
+			}
+			else
+			{
+				return false;
+			}
+
+			if (rhs.m_rule == "" && rhs.m_tag == "")
+			{
+				return false;
+			}
+
+			return true;
+		}
+	};
+
 	template<>
 	struct convert<falco_configuration::plugin_config> {
 

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -107,9 +107,8 @@ public:
 	falco_configuration();
 	virtual ~falco_configuration() = default;
 
-	void init(const std::string& conf_filename, std::vector<std::string>& loaded_conf_files, const std::vector<std::string>& cmdline_options);
-	void init(const std::vector<std::string>& cmdline_options);
-	void init_from_content(const std::string& config_content, const std::vector<std::string>& cmdline_options);
+	void init_from_file(const std::string& conf_filename, std::vector<std::string>& loaded_conf_files, const std::vector<std::string>& cmdline_options);
+	void init_from_content(const std::string& config_content, const std::vector<std::string>& cmdline_options, const std::string& filename="default");
 
 	std::string dump();
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This is a rather straightforward implementation of https://github.com/falcosecurity/falco/issues/3174#issuecomment-2064152163 . Essentially, it introduces two new ways of enabling/disabling rules without changing the rule files. Following the example:

```yaml
rules:
  - disable:
      rule: *
  - enable:
      tag: network
  - enable:
      rule: Directory traversal monitored file
  - enable:
      rule: k8s_*
  - disable:
      rule: k8s_noisy_rule
```

This means: disable everything, enable all rules tagged `networking`, also enable the rule called `Directory traversal monitored file`, then enable any rule matching the wildcard pattern `k8s_*` and disable `k8s_noisy_rule`.

You can achieve the same via the CLI

```
falco -o "rules[].disable.rule=*" -o "rules[].enable.tag=network" -o "rules[].enable.rule=Directory traversal monitored file
" -o "rules[].enable.rule=k8s_*" -o "rules[].disable.rule=k8s_noisy_rule"
```

The new syntax `[]` allows to append a new element at the end of sequences, which is how the CLI works in this case.

At this point, rule names support wildcard while tag names do not. I am a bit unsure about what to do with tag names. On one side, what you want to do is enable and disable them one by one so wildcards seem a bit too much there. On the other hand we currently allow to "intersect" the tags we want, such as only `networking` AND `exec`, which is not supported here. Perhaps we could add a `tags` option for that?

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #3174 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
new(falco): allow selecting which rules to load from the configuration file or command line
```
