### PR TITLE
chore(cmake): enable modern bpf build by default.

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Prepare project
       run: |
-          cmake -B build -S . -DBUILD_BPF=On -DUSE_BUNDLED_DEPS=Off -DUSE_BUNDLED_NLOHMANN_JSON=On -DUSE_BUNDLED_CXXOPTS=On -DUSE_BUNDLED_CPPHTTPLIB=On
+          cmake -B build -S . -DBUILD_BPF=On -DBUILD_FALCO_MODERN_BPF=Off -DUSE_BUNDLED_DEPS=Off -DUSE_BUNDLED_NLOHMANN_JSON=On -DUSE_BUNDLED_CXXOPTS=On -DUSE_BUNDLED_CPPHTTPLIB=On
 
     - name: Build
       run: |

--- a/.github/workflows/reusable_build_dev.yaml
+++ b/.github/workflows/reusable_build_dev.yaml
@@ -61,6 +61,7 @@ jobs:
           cmake -B build -S .\
             -DBUILD_FALCO_UNIT_TESTS=On \
             -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} \
+            -DBUILD_FALCO_MODERN_BPF=Off \
             -DBUILD_BPF=${{ inputs.minimal == true && 'OFF' || 'ON' }} \
             -DBUILD_DRIVER=${{ inputs.minimal == true && 'OFF' || 'ON' }} \
             -DMINIMAL_BUILD=${{ inputs.minimal == true && 'ON' || 'OFF' }} \

--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Build modern BPF skeleton
         run: |
           cmake -B skeleton-build -S . \
-                -DUSE_BUNDLED_DEPS=ON -DBUILD_FALCO_MODERN_BPF=ON -DCREATE_TEST_TARGETS=Off -DFALCO_VERSION=${{ inputs.version }}
+                -DUSE_BUNDLED_DEPS=ON -DCREATE_TEST_TARGETS=Off -DFALCO_VERSION=${{ inputs.version }}
           cmake --build skeleton-build --target ProbeSkeleton -j6
 
       - name: Upload skeleton
@@ -84,7 +84,6 @@ jobs:
               -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} \
               -DUSE_BUNDLED_DEPS=On \
               -DFALCO_ETC_DIR=/etc/falco \
-              -DBUILD_FALCO_MODERN_BPF=ON \
               -DMODERN_BPF_SKEL_DIR=/tmp \
               -DBUILD_DRIVER=Off \
               -DBUILD_BPF=Off \
@@ -194,7 +193,7 @@ jobs:
           emcmake cmake -B build -S . \
             -DBUILD_BPF=Off \
             -DBUILD_DRIVER=Off \
-            -DBUILD_LIBSCAP_MODERN_BPF=OFF \
+            -DBUILD_FALCO_MODERN_BPF=Off \
             -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} \
             -DUSE_BUNDLED_DEPS=On \
             -DFALCO_ETC_DIR=/etc/falco \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 # Modern BPF is not supported on not Linux systems and in MINIMAL_BUILD
 if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT MINIMAL_BUILD)
-  option(BUILD_FALCO_MODERN_BPF "Build modern BPF support for Falco" OFF)
+  option(BUILD_FALCO_MODERN_BPF "Build modern BPF support for Falco" ON)
   if(BUILD_FALCO_MODERN_BPF)
     add_definitions(-DHAS_MODERN_BPF)
   endif()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Since modern-bpf is now the default driver, i think it should be built by default too!

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
