### PR TITLE
refactor: smart pointer usage

### DIFF
--- a/unit_tests/engine/test_alt_rule_loader.cpp
+++ b/unit_tests/engine/test_alt_rule_loader.cpp
@@ -263,11 +263,11 @@ static void load_rules(sinsp& inspector,
 	rule_loader::collector collector;
 	rule_loader::compiler compiler;
 
-	EXPECT_TRUE(reader.read(*(cfg.get()), collector));
+	EXPECT_TRUE(reader.read(*cfg, collector));
 
 	compile_output = compiler.new_compile_output();
 
-	compiler.compile(*(cfg.get()), collector, *(compile_output.get()));
+	compiler.compile(*cfg, collector, *compile_output);
 }
 
 TEST(engine_loader_alt_loader, load_rules)
@@ -303,7 +303,7 @@ TEST(engine_loader_alt_loader, pass_compile_output_to_ruleset)
 
 	std::shared_ptr<filter_ruleset> ruleset = sources.at(syscall_source_name)->ruleset;
 
-	ruleset->add_compile_output(*(compile_output.get()),
+	ruleset->add_compile_output(*compile_output,
 				    falco_common::PRIORITY_INFORMATIONAL,
 				    syscall_source_name);
 

--- a/userspace/engine/evttype_index_ruleset.cpp
+++ b/userspace/engine/evttype_index_ruleset.cpp
@@ -249,7 +249,7 @@ void evttype_index_ruleset::enable_disable(const std::string &substring, bool ma
 {
 	while(m_rulesets.size() < (size_t)ruleset_id + 1)
 	{
-		m_rulesets.emplace_back(new ruleset_filters());
+		m_rulesets.emplace_back(std::make_shared<ruleset_filters>());
 	}
 
 	for(const auto &wrap : m_filters)
@@ -296,7 +296,7 @@ void evttype_index_ruleset::enable_disable_tags(const std::set<std::string> &tag
 {
 	while(m_rulesets.size() < (size_t)ruleset_id + 1)
 	{
-		m_rulesets.emplace_back(new ruleset_filters());
+		m_rulesets.emplace_back(std::make_shared<ruleset_filters>());
 	}
 
 	for(const auto &wrap : m_filters)
@@ -325,7 +325,7 @@ uint64_t evttype_index_ruleset::enabled_count(uint16_t ruleset_id)
 {
 	while(m_rulesets.size() < (size_t)ruleset_id + 1)
 	{
-		m_rulesets.emplace_back(new ruleset_filters());
+		m_rulesets.emplace_back(std::make_shared<ruleset_filters>());
 	}
 
 	return m_rulesets[ruleset_id]->num_filters();

--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -198,11 +198,11 @@ std::unique_ptr<load_result> falco_engine::load_rules(const std::string &rules_c
 	cfg.replace_output_container_info = m_replace_container_info;
 
 	// read rules YAML file and collect its definitions
-	if(m_rule_reader->read(cfg, *(m_rule_collector.get())))
+	if(m_rule_reader->read(cfg, *m_rule_collector))
 	{
 		// compile the definitions (resolve macro/list refs, exceptions, ...)
 		m_last_compile_output = m_rule_compiler->new_compile_output();
-		m_rule_compiler->compile(cfg, *(m_rule_collector.get()), *m_last_compile_output.get());
+		m_rule_compiler->compile(cfg, *m_rule_collector, *m_last_compile_output);
 
 		// clear the rules known by the engine and each ruleset
 		m_rules.clear();
@@ -210,7 +210,7 @@ std::unique_ptr<load_result> falco_engine::load_rules(const std::string &rules_c
 		// add rules to each ruleset
 		{
 			src.ruleset = create_ruleset(src.ruleset_factory);
-			src.ruleset->add_compile_output(*(m_last_compile_output.get()),
+			src.ruleset->add_compile_output(*m_last_compile_output,
 							m_min_priority,
 							src.name);
 		}

--- a/userspace/engine/rule_loader.h
+++ b/userspace/engine/rule_loader.h
@@ -270,10 +270,8 @@ namespace rule_loader
 			const std::string& cont,
 			const indexed_vector<falco_source>& srcs,
 			const std::string& name)
-				: content(cont), sources(srcs), name(name),
-				  output_extra(), replace_output_container_info(false)
+				: content(cont), sources(srcs), name(name), res(std::make_unique<result>(name))
 			{
-				res.reset(new result(name));
 			}
 
 		// inputs
@@ -281,7 +279,7 @@ namespace rule_loader
 		const indexed_vector<falco_source>& sources;
 		std::string name;
 		std::string output_extra;
-		bool replace_output_container_info;
+		bool replace_output_container_info = false;
 
 		// outputs
 		std::unique_ptr<result> res;

--- a/userspace/engine/stats_manager.cpp
+++ b/userspace/engine/stats_manager.cpp
@@ -44,7 +44,7 @@ void stats_manager::format(
 	out += "Rule counts by severity:\n";
 	for (size_t i = 0; i < m_by_priority.size(); i++)
 	{
-		auto val = m_by_priority[i].get()->load();
+		auto val = m_by_priority[i]->load();
 		if (val > 0)
 		{
 			falco_common::format_priority(
@@ -56,7 +56,7 @@ void stats_manager::format(
 	out += "Triggered rules by rule name:\n";
 	for (size_t i = 0; i < m_by_rule_id.size(); i++)
 	{
-		auto val = m_by_rule_id[i].get()->load();
+		auto val = m_by_rule_id[i]->load();
 		if (val > 0)
 		{
 			out += "   " + rules.at(i)->name + ": " + std::to_string(val) + "\n";
@@ -68,13 +68,11 @@ void stats_manager::on_rule_loaded(const falco_rule& rule)
 {
 	while (m_by_rule_id.size() <= rule.id)
 	{
-		m_by_rule_id.emplace_back();
-		m_by_rule_id[m_by_rule_id.size() - 1].reset(new std::atomic<uint64_t>(0));
+		m_by_rule_id.emplace_back(std::make_unique<std::atomic<uint64_t>>(0));
 	}
 	while (m_by_priority.size() <= (size_t) rule.priority)
 	{
-		m_by_priority.emplace_back();
-		m_by_priority[m_by_priority.size() - 1].reset(new std::atomic<uint64_t>(0));
+		m_by_priority.emplace_back(std::make_unique<std::atomic<uint64_t>>(0));
 	}
 }
 

--- a/userspace/falco/app/actions/init_inspectors.cpp
+++ b/userspace/falco/app/actions/init_inspectors.cpp
@@ -108,7 +108,7 @@ falco::app::run_result falco::app::actions::init_inspectors(falco::app::state& s
 	std::string err;
 	std::unordered_set<std::string> used_plugins;
 	const auto& all_plugins = s.offline_inspector->get_plugin_manager()->plugins();
-	
+
 	for (const auto &src : s.loaded_sources)
 	{
 		auto src_info = s.source_infos.at(src);
@@ -182,7 +182,7 @@ falco::app::run_result falco::app::actions::init_inspectors(falco::app::state& s
 		if (!populate_filterchecks(
 				src_info->inspector,
 				src,
-				*src_info->filterchecks.get(),
+				*src_info->filterchecks,
 				used_plugins,
 				err))
 		{

--- a/userspace/falco/app/actions/init_outputs.cpp
+++ b/userspace/falco/app/actions/init_outputs.cpp
@@ -60,7 +60,7 @@ falco::app::run_result falco::app::actions::init_outputs(falco::app::state& s)
 		return run_result::ok();
 	}
 
-	s.outputs.reset(new falco_outputs(
+	s.outputs = std::make_shared<falco_outputs>(
 		s.engine,
 		s.config->m_outputs,
 		s.config->m_json_output,
@@ -70,7 +70,7 @@ falco::app::run_result falco::app::actions::init_outputs(falco::app::state& s)
 		s.config->m_buffered_outputs,
 		s.config->m_outputs_queue_capacity,
 		s.config->m_time_format_iso_8601,
-		hostname));
+		hostname);
 
 	return run_result::ok();
 }

--- a/userspace/falco/app/actions/load_plugins.cpp
+++ b/userspace/falco/app/actions/load_plugins.cpp
@@ -29,10 +29,10 @@ falco::app::run_result falco::app::actions::load_plugins(falco::app::state& s)
 		return run_result::fatal("Loading plugins dynamic libraries is not supported by this Falco build");
 	}
 #endif
-	// Initialize the set of loaded event sources. 
+	// Initialize the set of loaded event sources.
 	// By default, the set includes the 'syscall' event source
 	state::source_info syscall_src_info;
-	syscall_src_info.filterchecks.reset(new sinsp_filter_check_list());
+	syscall_src_info.filterchecks = std::make_shared<sinsp_filter_check_list>();
 	s.source_infos.clear();
 	s.source_infos.insert(syscall_src_info, falco_common::syscall_source);
 	s.loaded_sources = { falco_common::syscall_source };
@@ -44,7 +44,7 @@ falco::app::run_result falco::app::actions::load_plugins(falco::app::state& s)
 	// plugins in order to have them available every time we need to access
 	// their static info. If Falco is in capture mode, this inspector is also
 	// used to open and read the trace file
-	s.offline_inspector.reset(new sinsp());
+	s.offline_inspector = std::make_shared<sinsp>();
 
 	// Load all the configured plugins
 	for(auto &p : s.config->m_plugins)
@@ -55,7 +55,7 @@ falco::app::run_result falco::app::actions::load_plugins(falco::app::state& s)
 		if(plugin->caps() & CAP_SOURCING && plugin->id() != 0)
 		{
 			state::source_info src_info;
-			src_info.filterchecks.reset(new filter_check_list());
+			src_info.filterchecks = std::make_shared<filter_check_list>();
 			auto sname = plugin->event_source();
 			s.source_infos.insert(src_info, sname);
 			// note: this avoids duplicate values

--- a/userspace/falco/app/actions/process_events.cpp
+++ b/userspace/falco/app/actions/process_events.cpp
@@ -310,7 +310,7 @@ static falco::app::run_result do_inspect(
 		auto res = s.engine->process_event(source_engine_idx, ev, s.config->m_rule_matching);
 		if(res != nullptr)
 		{
-			for(auto& rule_res : *res.get())
+			for(auto& rule_res : *res)
 			{
 				s.outputs->handle_event(rule_res.evt, rule_res.rule, rule_res.source, rule_res.priority_num, rule_res.format, rule_res.tags);
 			}
@@ -490,7 +490,7 @@ falco::app::run_result falco::app::actions::process_events(falco::app::state& s)
 		{
 			auto& ctx = ctxs.emplace_back();
 			ctx.source = source;
-			ctx.sync.reset(new source_sync_context(termination_sem));
+			ctx.sync = std::make_unique<source_sync_context>(termination_sem);
 			auto src_info = s.source_infos.at(source);
 
 			try
@@ -516,9 +516,9 @@ falco::app::run_result falco::app::actions::process_events(falco::app::state& s)
 				{
 					auto res_ptr = &ctx.res;
 					auto sync_ptr = ctx.sync.get();
-					ctx.thread.reset(new std::thread([&s, src_info, &statsw, source, sync_ptr, res_ptr](){
+					ctx.thread = std::make_unique<std::thread>([&s, src_info, &statsw, source, sync_ptr, res_ptr]() {
 						process_inspector_events(s, src_info->inspector, statsw, source, sync_ptr, res_ptr);
-					}));
+					});
 				}
 			}
 			catch (std::exception &e)

--- a/userspace/falco/app/state.h
+++ b/userspace/falco/app/state.h
@@ -48,18 +48,11 @@ struct state
     // Holds the info mapped for each loaded event source
     struct source_info
     {
-        source_info():
-            engine_idx(-1),
-            filterchecks(new filter_check_list()),
-            inspector(nullptr) { }
-        source_info(source_info&&) = default;
-        source_info& operator = (source_info&&) = default;
-        source_info(const source_info&) = default;
-        source_info& operator = (const source_info&) = default;
+        source_info() : filterchecks(std::make_shared<filter_check_list>()) {}
 
         // The index of the given event source in the state's falco_engine,
         // as returned by falco_engine::add_source
-        std::size_t engine_idx;
+        std::size_t engine_idx = -1;
         // The filtercheck list containing all fields compatible
         // with the given event source
         std::shared_ptr<filter_check_list> filterchecks;
@@ -71,32 +64,21 @@ struct state
     };
 
     state():
-        restart(false),
         config(std::make_shared<falco_configuration>()),
-        outputs(nullptr),
         engine(std::make_shared<falco_engine>()),
-        loaded_sources(),
-        enabled_sources(),
-        offline_inspector(std::make_shared<sinsp>()),
-        source_infos(),
-        plugin_configs(),
-        selected_sc_set(),
-        syscall_buffer_bytes_size(DEFAULT_DRIVER_BUFFER_BYTES_DIM),
-        restarter(nullptr)
+        offline_inspector(std::make_shared<sinsp>())
     {
     }
 
-    state(const std::string& cmd, const falco::app::options& opts): state()
+    state(const std::string& cmd, const falco::app::options& opts):
+        cmdline(cmd),
+        options(opts)
     {
-        cmdline = cmd;
-        options = opts;
     }
-
-    ~state() = default;
 
     std::string cmdline;
     falco::app::options options;
-    std::atomic<bool> restart;
+    std::atomic<bool> restart = false;
 
 
     std::shared_ptr<falco_configuration> config;
@@ -129,7 +111,7 @@ struct state
     libsinsp::events::set<ppm_sc_code> selected_sc_set;
 
     // Dimension of the syscall buffer in bytes.
-    uint64_t syscall_buffer_bytes_size;
+    uint64_t syscall_buffer_bytes_size = DEFAULT_DRIVER_BUFFER_BYTES_DIM;
 
     // Helper responsible for watching of handling hot application restarts
     std::shared_ptr<restart_handler> restarter;

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -50,22 +50,18 @@ falco_outputs::falco_outputs(
 	size_t outputs_queue_capacity,
 	bool time_format_iso_8601,
 	const std::string& hostname)
+	: m_formats(std::make_unique<falco_formats>(engine, json_include_output_property, json_include_tags_property)),
+	  m_buffered(buffered),
+	  m_json_output(json_output),
+	  m_time_format_iso_8601(time_format_iso_8601),
+	  m_timeout(std::chrono::milliseconds(timeout)),
+	  m_hostname(hostname)
 {
-	m_formats.reset(new falco_formats(engine, json_include_output_property, json_include_tags_property));
-
-	m_json_output = json_output;
-
-	m_timeout = std::chrono::milliseconds(timeout);
-
-	m_buffered = buffered;
-	m_time_format_iso_8601 = time_format_iso_8601;
-	m_hostname = hostname;
-
 	for(const auto& output : outputs)
 	{
 		add_output(output);
 	}
-	m_outputs_queue_num_drops = 0;
+
 #ifndef __EMSCRIPTEN__
 	m_queue.set_capacity(outputs_queue_capacity);
 	m_worker_thread = std::thread(&falco_outputs::worker, this);

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -85,7 +85,7 @@ public:
 	void reopen_outputs();
 
 	/*!
-		\brief Return the number of events currently dropped due to failed push 
+		\brief Return the number of events currently dropped due to failed push
 		attempts into the outputs queue
 	*/
 	uint64_t get_outputs_queue_num_drops();
@@ -119,7 +119,7 @@ private:
 	falco_outputs_cbq m_queue;
 #endif
 
-	std::atomic<uint64_t> m_outputs_queue_num_drops;
+	std::atomic<uint64_t> m_outputs_queue_num_drops = 0;
 	std::thread m_worker_thread;
 	inline void push(const ctrl_msg& cmsg);
 	inline void push_ctrl(ctrl_msg_type cmt);

--- a/userspace/falco/grpc_request_context.cpp
+++ b/userspace/falco/grpc_request_context.cpp
@@ -28,9 +28,9 @@ template<>
 void request_stream_context<outputs::service, outputs::request, outputs::response>::start(server* srv)
 {
 	m_state = request_context_base::REQUEST;
-	m_srv_ctx.reset(new ::grpc::ServerContext);
+	m_srv_ctx = std::make_unique<::grpc::ServerContext>();
 	auto srvctx = m_srv_ctx.get();
-	m_res_writer.reset(new ::grpc::ServerAsyncWriter<outputs::response>(srvctx));
+	m_res_writer = std::make_unique<::grpc::ServerAsyncWriter<outputs::response>>(srvctx);
 	m_stream_ctx.reset();
 	m_req.Clear();
 	auto cq = srv->m_completion_queue.get();
@@ -45,7 +45,7 @@ void request_stream_context<outputs::service, outputs::request, outputs::respons
 	if(m_state == request_context_base::REQUEST)
 	{
 		m_state = request_context_base::WRITE;
-		m_stream_ctx.reset(new stream_context(m_srv_ctx.get()));
+		m_stream_ctx = std::make_unique<stream_context>(m_srv_ctx.get());
 	}
 
 	// Processing
@@ -108,9 +108,9 @@ template<>
 void request_context<version::service, version::request, version::response>::start(server* srv)
 {
 	m_state = request_context_base::REQUEST;
-	m_srv_ctx.reset(new ::grpc::ServerContext);
+	m_srv_ctx = std::make_unique<::grpc::ServerContext>();
 	auto srvctx = m_srv_ctx.get();
-	m_res_writer.reset(new ::grpc::ServerAsyncResponseWriter<version::response>(srvctx));
+	m_res_writer = std::make_unique<::grpc::ServerAsyncResponseWriter<version::response>>(srvctx);
 	m_req.Clear();
 	auto cq = srv->m_completion_queue.get();
 	// Request to start processing given requests.
@@ -144,9 +144,9 @@ template<>
 void request_bidi_context<outputs::service, outputs::request, outputs::response>::start(server* srv)
 {
 	m_state = request_context_base::REQUEST;
-	m_srv_ctx.reset(new ::grpc::ServerContext);
+	m_srv_ctx = std::make_unique<::grpc::ServerContext>();
 	auto srvctx = m_srv_ctx.get();
-	m_reader_writer.reset(new ::grpc::ServerAsyncReaderWriter<outputs::response, outputs::request>(srvctx));
+	m_reader_writer = std::make_unique<::grpc::ServerAsyncReaderWriter<outputs::response, outputs::request>>(srvctx);
 	m_req.Clear();
 	auto cq = srv->m_completion_queue.get();
 	// Request to start processing given requests.
@@ -161,7 +161,7 @@ void request_bidi_context<outputs::service, outputs::request, outputs::response>
 	switch(m_state)
 	{
 	case request_context_base::REQUEST:
-		m_bidi_ctx.reset(new bidi_context(m_srv_ctx.get()));
+		m_bidi_ctx = std::make_unique<bidi_context>(m_srv_ctx.get());
 		m_bidi_ctx->m_status = bidi_context::STREAMING;
 		m_state = request_context_base::WRITE;
 		m_reader_writer->Read(&m_req, this);


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
No specific area.

**What this PR does / why we need it**:
There are some usages of smart pointers that can be simplified a but and, occasionally, made more efficient.

1. Use the overloaded dereference operator directly on the smart pointer without invoking get(), i.e. prefer *ptr rather than *(ptr.get()).
2. Create objects stored in smart pointers with make_unique or make_shared rather than using new. For shared_ptrs this has the performance advantage of storing the pointer's control block with the object itself, improving memory locality, beneficial for cache reasons, and using a single allocation call.
3. Prefer using automatic objects - i.e. stored on the stack - than heap allocated ones. This effectively removes the usage of the smart pointer.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
