### PR TITLE
fix(docker): added `zstd` dep to driver loader images

### DIFF
--- a/docker/driver-loader-legacy/Dockerfile
+++ b/docker/driver-loader-legacy/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 	netcat \
 	patchelf \
 	xz-utils \
+	zstd \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN if [ "$TARGETARCH" = "amd64" ]; \

--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update \
 	netcat-openbsd \
 	patchelf \
 	xz-utils \
+	zstd \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN curl -s https://falco.org/repo/falcosecurity-packages.asc | apt-key add - \


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Recent ubuntu kernel headers packages are `zstd` compressed. We need `zstd` to be able to decompress them for the new `falcoctl driver kernel headers automatic download` logic.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(docker): added zstd to driver loader images
```
