### PR TITLE
fix(userspace/falco): fixed `falco_metrics::to_text` implementation when running with plugins

### DIFF
--- a/userspace/falco/stats_writer.cpp
+++ b/userspace/falco/stats_writer.cpp
@@ -327,12 +327,18 @@ void stats_writer::collector::get_metrics_output_fields_wrapper(
 	/* Wrapper fields useful for statistical analyses and attributions. Always enabled. */
 	output_fields["evt.time"] = now; /* Some ETLs may prefer a consistent timestamp within output_fields. */
 	output_fields["falco.version"] = FALCO_VERSION;
-	output_fields["falco.start_ts"] = agent_info->start_ts_epoch;
-	output_fields["falco.duration_sec"] = (uint64_t)((now - agent_info->start_ts_epoch) / ONE_SECOND_IN_NS);
-	output_fields["falco.kernel_release"] = agent_info->uname_r;
-	output_fields["evt.hostname"] = machine_info->hostname; /* Explicitly add hostname to log msg in case hostname rule output field is disabled. */
-	output_fields["falco.host_boot_ts"] = machine_info->boot_ts_epoch;
-	output_fields["falco.host_num_cpus"] = machine_info->num_cpus;
+	if (agent_info)
+	{
+		output_fields["falco.start_ts"] = agent_info->start_ts_epoch;
+		output_fields["falco.duration_sec"] = (uint64_t)((now - agent_info->start_ts_epoch) / ONE_SECOND_IN_NS);
+		output_fields["falco.kernel_release"] = agent_info->uname_r;
+	}
+	if (machine_info)
+	{
+		output_fields["evt.hostname"] = machine_info->hostname; /* Explicitly add hostname to log msg in case hostname rule output field is disabled. */
+		output_fields["falco.host_boot_ts"] = machine_info->boot_ts_epoch;
+		output_fields["falco.host_num_cpus"] = machine_info->num_cpus;
+	}
 	output_fields["falco.outputs_queue_num_drops"] = m_writer->m_outputs->get_outputs_queue_num_drops();
 
 #if defined(__linux__) and !defined(MINIMAL_BUILD) and !defined(__EMSCRIPTEN__)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR does 3 things:
* avoid crashing when scap_machine_info or scap_agent_info are NULL (ie: with non-linux scap platform, ie: while running plugins)
* properly use a `shared_ptr` for inspectors vector, so that we know they are kept alive while `to_text` runs and we can dereference the pointer
* only expose metrics for actually enabled sources (not loaded ones). Before, in `nodriver` mode with syscall source disabled, we would've tried to emit metrics for the syscall source/inspector too, but that is wrong since it is not enabled (and it would crash Falco too!)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #3229 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(userspace/falco): fixed `falco_metrics::to_text` implementation when running with plugins
```
