### PR TITLE
fix(build): metrics compilation after refactoring into classes

### DIFF
--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -23,7 +23,7 @@ if(DRIVER_SOURCE_DIR)
 else()
   # DRIVER_REPO accepts a repository name (<org name>/<repo name>) alternative to the falcosecurity/libs repository.
   # In case you want to test against a fork of falcosecurity/libs just pass the variable -
-  # ie., `cmake -DDRIVER_REPO=<your-gh-handle>/libs ..` 
+  # ie., `cmake -DDRIVER_REPO=<your-gh-handle>/libs ..`
   if (NOT DRIVER_REPO)
     set(DRIVER_REPO "falcosecurity/libs")
   endif()
@@ -34,8 +34,8 @@ else()
   # In case you want to test against another driver version (or branch, or commit) just pass the variable -
   # ie., `cmake -DDRIVER_VERSION=dev ..`
   if(NOT DRIVER_VERSION)
-    set(DRIVER_VERSION "473bf06780abf9b00923c90d779e4ff16f19903a")
-    set(DRIVER_CHECKSUM "SHA256=aa45432acd385881365a8aee7bfe1982fd6278aa7b23466d6864c2ffda5216dd")
+    set(DRIVER_VERSION "8615f0b69235bd9eca98e34c221b5754e33a85f3")
+    set(DRIVER_CHECKSUM "SHA256=a440951c4d1cb9e15cfcde985e150e6fdecb2ba617e9485b10f90615a374dd6d")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -35,8 +35,8 @@ else()
   # In case you want to test against another falcosecurity/libs version (or branch, or commit) just pass the variable -
   # ie., `cmake -DFALCOSECURITY_LIBS_VERSION=dev ..`
   if(NOT FALCOSECURITY_LIBS_VERSION)
-    set(FALCOSECURITY_LIBS_VERSION "473bf06780abf9b00923c90d779e4ff16f19903a")
-    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=aa45432acd385881365a8aee7bfe1982fd6278aa7b23466d6864c2ffda5216dd")
+    set(FALCOSECURITY_LIBS_VERSION "8615f0b69235bd9eca98e34c221b5754e33a85f3")
+    set(FALCOSECURITY_LIBS_CHECKSUM "SHA256=a440951c4d1cb9e15cfcde985e150e6fdecb2ba617e9485b10f90615a374dd6d")
   endif()
 
   # cd /path/to/build && cmake /path/to/source

--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -1034,7 +1034,7 @@ TEST_F(test_falco_engine, exceptions_values_rhs_field_ambiguous)
 
   ASSERT_TRUE(load_rules(rules_content, "rules.yaml"));
   EXPECT_EQ(get_compiled_rule_condition("test_rule"), "(evt.type = open and not proc.name = proc.pname)");
-  EXPECT_TRUE(check_warning_message("string 'proc.pname' may be a valid field wrongly interpreted as a string value"));
+  EXPECT_TRUE(check_warning_message("'proc.pname' may be a valid field misused as a const string value"));
 }
 
 TEST_F(test_falco_engine, exceptions_values_rhs_field_ambiguous_quoted)
@@ -1050,7 +1050,7 @@ TEST_F(test_falco_engine, exceptions_values_rhs_field_ambiguous_quoted)
 
   ASSERT_TRUE(load_rules(rules_content, "rules.yaml"));
   EXPECT_EQ(get_compiled_rule_condition("test_rule"), "(evt.type = open and not proc.name = proc.pname)");
-  EXPECT_TRUE(check_warning_message("string 'proc.pname' may be a valid field wrongly interpreted as a string value"));
+  EXPECT_TRUE(check_warning_message("'proc.pname' may be a valid field misused as a const string value"));
 }
 
 TEST_F(test_falco_engine, exceptions_values_rhs_field_ambiguous_space_quoted)
@@ -1066,7 +1066,7 @@ TEST_F(test_falco_engine, exceptions_values_rhs_field_ambiguous_space_quoted)
 
   ASSERT_TRUE(load_rules(rules_content, "rules.yaml"));
   EXPECT_EQ(get_compiled_rule_condition("test_rule"), "(evt.type = open and not proc.name = \"proc.pname \")");
-  EXPECT_TRUE(check_warning_message("string 'proc.pname ' may be a valid field wrongly interpreted as a string value"));
+  EXPECT_TRUE(check_warning_message("'proc.pname ' may be a valid field misused as a const string value"));
 }
 
 TEST_F(test_falco_engine, exceptions_values_rhs_transformer)
@@ -1112,7 +1112,7 @@ TEST_F(test_falco_engine, exceptions_values_transformer_space)
 
   ASSERT_TRUE(load_rules(rules_content, "rules.yaml"));
   EXPECT_EQ(get_compiled_rule_condition("test_rule"), "(evt.type = open and not proc.name = \"toupper( proc.pname)\")");
-  EXPECT_TRUE(check_warning_message("string 'toupper( proc.pname)' may be a valid field transformer wrongly interpreted as a string value"));
+  EXPECT_TRUE(check_warning_message("'toupper( proc.pname)' may be a valid field transformer misused as a const string value"));
 }
 
 TEST_F(test_falco_engine, exceptions_values_transformer_space_quoted)
@@ -1128,7 +1128,7 @@ TEST_F(test_falco_engine, exceptions_values_transformer_space_quoted)
 
   ASSERT_TRUE(load_rules(rules_content, "rules.yaml"));
   EXPECT_EQ(get_compiled_rule_condition("test_rule"), "(evt.type = open and not proc.name = \"toupper( proc.pname)\")");
-  EXPECT_TRUE(check_warning_message("string 'toupper( proc.pname)' may be a valid field transformer wrongly interpreted as a string value"));
+  EXPECT_TRUE(check_warning_message("'toupper( proc.pname)' may be a valid field transformer misused as a const string value"));
 }
 
 TEST_F(test_falco_engine, exceptions_fields_transformer)

--- a/userspace/falco/falco_metrics.cpp
+++ b/userspace/falco/falco_metrics.cpp
@@ -118,7 +118,7 @@ std::string falco_metrics::to_text(const falco::app::state& state)
 
 		if (agent_info)
 		{
-			additional_wrapper_metrics.emplace_back(libs_metrics_collector.new_metric("start_ts",
+			additional_wrapper_metrics.emplace_back(libs::metrics::libsinsp_metrics::new_metric("start_ts",
 												  METRICS_V2_MISC,
 												  METRIC_VALUE_TYPE_U64,
 												  METRIC_VALUE_UNIT_TIME_TIMESTAMP_NS,
@@ -127,20 +127,20 @@ std::string falco_metrics::to_text(const falco::app::state& state)
 		}
 		if (machine_info)
 		{
-			additional_wrapper_metrics.emplace_back(libs_metrics_collector.new_metric("host_boot_ts",
+			additional_wrapper_metrics.emplace_back(libs::metrics::libsinsp_metrics::new_metric("host_boot_ts",
 												  METRICS_V2_MISC,
 												  METRIC_VALUE_TYPE_U64,
 												  METRIC_VALUE_UNIT_TIME_TIMESTAMP_NS,
 												  METRIC_VALUE_METRIC_TYPE_NON_MONOTONIC_CURRENT,
 												  machine_info->boot_ts_epoch));
-			additional_wrapper_metrics.emplace_back(libs_metrics_collector.new_metric("host_num_cpus",
+			additional_wrapper_metrics.emplace_back(libs::metrics::libsinsp_metrics::new_metric("host_num_cpus",
 												  METRICS_V2_MISC,
 												  METRIC_VALUE_TYPE_U32,
 												  METRIC_VALUE_UNIT_COUNT,
 												  METRIC_VALUE_METRIC_TYPE_NON_MONOTONIC_CURRENT,
 												  machine_info->num_cpus));
 		}
-		additional_wrapper_metrics.emplace_back(libs_metrics_collector.new_metric("outputs_queue_num_drops",
+		additional_wrapper_metrics.emplace_back(libs::metrics::libsinsp_metrics::new_metric("outputs_queue_num_drops",
 												METRICS_V2_MISC,
 												METRIC_VALUE_TYPE_U64,
 												METRIC_VALUE_UNIT_COUNT,
@@ -150,7 +150,7 @@ std::string falco_metrics::to_text(const falco::app::state& state)
 		if (agent_info)
 		{
 			auto now = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-			additional_wrapper_metrics.emplace_back(libs_metrics_collector.new_metric("duration_sec",
+			additional_wrapper_metrics.emplace_back(libs::metrics::libsinsp_metrics::new_metric("duration_sec",
 												  METRICS_V2_MISC,
 												  METRIC_VALUE_TYPE_U64,
 												  METRIC_VALUE_UNIT_TIME_S_COUNT,
@@ -179,7 +179,7 @@ std::string falco_metrics::to_text(const falco::app::state& state)
 				auto count = rules_by_id[i]->load();
 				if (count > 0)
 				{
-					auto metric = libs_metrics_collector.new_metric("rules_counters",
+					auto metric = libs::metrics::libsinsp_metrics::new_metric("rules_counters",
 											METRICS_V2_RULE_COUNTERS,
 											METRIC_VALUE_TYPE_U64,
 											METRIC_VALUE_UNIT_COUNT,
@@ -213,7 +213,7 @@ std::string falco_metrics::to_text(const falco::app::state& state)
 		{
 			prometheus_metrics_converter.convert_metric_to_unit_convention(metric);
 			std::string namespace_name = "scap";
-			
+
 			if (metric.flags & METRICS_V2_RESOURCE_UTILIZATION || metric.flags & METRICS_V2_KERNEL_COUNTERS)
 			{
 				namespace_name = "falco";


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area build

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Once falcosecurity/libs#1920 is merged, compilation of falco will be broken due to the `new_metric` method changing the class it lives in. This PR makes falco compatible with this change.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**: The commit that changes the libs cmake files will be dropped and replaced with a commit that properly updates the libs commit and SHA once falcosecurity/libs#1920 is merged, please disregard these changes until that merge occurs.

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
