### PR TITLE
fix(ci): use vault.centos.org for centos:7 CI build.

### DIFF
--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -57,7 +57,18 @@ jobs:
       # Always install deps before invoking checkout action, to properly perform a full clone.
       - name: Install build dependencies
         run: |
+          # fix broken mirrors
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+          
           yum -y install centos-release-scl
+          
+          # fix broken mirrors (again)
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
+          
           yum -y install devtoolset-9-gcc devtoolset-9-gcc-c++
           source /opt/rh/devtoolset-9/enable
           yum install -y wget git make m4 rpm-build elfutils-libelf-devel perl-IPC-Cmd devtoolset-9-libasan-devel devtoolset-9-libubsan-devel

--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -49,6 +49,8 @@ jobs:
           retention-days: 1
 
   build-packages:
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     # See https://github.com/actions/runner/issues/409#issuecomment-1158849936
     runs-on: ${{ (inputs.arch == 'aarch64' && 'actuated-arm64-8cpu-16gb') || 'ubuntu-latest' }}
     needs: [build-modern-bpf-skeleton]

--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -55,20 +55,29 @@ jobs:
     container: centos:7
     steps:
       # Always install deps before invoking checkout action, to properly perform a full clone.
-      - name: Install build dependencies
+      - name: Fix mirrors to use vault.centos.org
         run: |
-          # fix broken mirrors
           sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
           sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
           sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
-          
+
+      - name: Install scl repos
+        run: |
           yum -y install centos-release-scl
-          
-          # fix broken mirrors (again)
+
+      - name: Fix new mirrors to use vault.centos.org
+        run: |
           sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
           sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
           sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
-          
+
+      - name: Fix arm64 scl repos to use correct mirror
+        if: inputs.arch == 'aarch64'
+        run: |
+          sed -i 's/vault.centos.org\/centos/vault.centos.org\/altarch/g' /etc/yum.repos.d/CentOS-SCLo-scl*.repo
+
+      - name: Install build deps
+        run: |
           yum -y install devtoolset-9-gcc devtoolset-9-gcc-c++
           source /opt/rh/devtoolset-9/enable
           yum install -y wget git make m4 rpm-build elfutils-libelf-devel perl-IPC-Cmd devtoolset-9-libasan-devel devtoolset-9-libubsan-devel


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

Enforce the usage of the vault.centos.org mirrors for centos:7 CI. This should fix the CI and let us gain time to design a proper solution to drop centos7.

Also, recently github actions enforced the usage of node20 runners, breaking our `actions/checkout` step when ran inside centos:7 container (glibc version mismatch); workaround that issue too, by adding the env `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` to the workflow.
See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(ci): use vault.centos.org for centos:7 CI build.
```
