### PR TITLE
feat(cmake): add conditional builds for falcoctl and rules paths

### DIFF
--- a/cmake/modules/falcoctl.cmake
+++ b/cmake/modules/falcoctl.cmake
@@ -14,9 +14,14 @@
 
 include(ExternalProject)
 
+option(ADD_FALCOCTL_DEPENDENCY "Add falcoctl dependency while building falco" ON)
+
+if(ADD_FALCOCTL_DEPENDENCY)
 string(TOLOWER ${CMAKE_HOST_SYSTEM_NAME} FALCOCTL_SYSTEM_NAME)
 
 set(FALCOCTL_VERSION "0.8.0")
+
+message(STATUS "Building with falcoctl: ${FALCOCTL_VERSION}")
 
 if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     set(FALCOCTL_SYSTEM_PROC_GO "amd64")
@@ -36,3 +41,6 @@ ExternalProject_Add(
 
 install(PROGRAMS "${PROJECT_BINARY_DIR}/falcoctl-prefix/src/falcoctl/falcoctl" DESTINATION "${FALCO_BIN_DIR}" COMPONENT "${FALCO_COMPONENT_NAME}")
 install(DIRECTORY DESTINATION "${FALCO_ABSOLUTE_SHARE_DIR}/plugins" COMPONENT "${FALCO_COMPONENT_NAME}")
+else()
+    message(STATUS "Won't build with falcoctl")
+endif()

--- a/cmake/modules/rules.cmake
+++ b/cmake/modules/rules.cmake
@@ -15,6 +15,7 @@
 include(GNUInstallDirs)
 include(ExternalProject)
 
+if(NOT DEFINED FALCOSECURITY_RULES_FALCO_PATH)
 # falco_rules.yaml
 set(FALCOSECURITY_RULES_FALCO_VERSION "falco-rules-3.1.0")
 set(FALCOSECURITY_RULES_FALCO_CHECKSUM "SHA256=3b617920c0b66128627613e591a954eb9572747a4c287bc13b53b38786250162")
@@ -28,10 +29,13 @@ ExternalProject_Add(
   INSTALL_COMMAND ""
   TEST_COMMAND ""
 )
+endif()
 
+if(NOT DEFINED FALCOSECURITY_RULES_LOCAL_PATH)
 # falco_rules.local.yaml
 set(FALCOSECURITY_RULES_LOCAL_PATH "${PROJECT_BINARY_DIR}/falcosecurity-rules-local-prefix/falco_rules.local.yaml")
 file(WRITE "${FALCOSECURITY_RULES_LOCAL_PATH}" "# Your custom rules!\n")
+endif()
 
 if(NOT DEFINED FALCO_ETC_DIR)
 	set(FALCO_ETC_DIR "${CMAKE_INSTALL_FULL_SYSCONFDIR}/falco")


### PR DESCRIPTION
There are systems, like Nix derivations where the build process does not have network access in order to enforce reproducibility. This patch allows people building Falco to optionally skip the build of falcoctl with `-DADD_FALCOCTL_DEPENDENCY=OFF` and point to their own self-backed, or pre-fetched rules files with `-DFALCOSECURITY_RULES_FALCO_PATH=<some-path>` and `-DFALCOSECURITY_RULES_LOCAL_PATH=<some-path>`.

For context, I needed to apply these patches while building the project with Nix in https://github.com/tembleking/falco-nix but I think that would be benefitial for the community to have also these options open, and that would also make Falco feasible to be added to the nixpkgs repository at https://github.com/nixos/nixpkgs

/kind feature
/kind release
/area build

```release-note
- When building Falco, users can now disable the build of `falcoctl` with the engine, by specifying the CMake flag `-DADD_FALCOCTL_DEPENDENCY=OFF`.
- When building Falco, users can now specify the source paths of both the rules files, and the local rules files with the CMake flags `-DFALCOSECURITY_RULES_FALCO_PATH=<some-path>` and `-DFALCOSECURITY_RULES_LOCAL_PATH=<some-path>`.
```
