### PR TITLE
new(ci): use `zig` compiler instead of relying on centos7.

### DIFF
--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -52,44 +52,17 @@ jobs:
           retention-days: 1
 
   build-packages:
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     # See https://github.com/actions/runner/issues/409#issuecomment-1158849936
     runs-on: ${{ (inputs.arch == 'aarch64' && 'actuated-arm64-8cpu-16gb') || 'ubuntu-latest' }}
     needs: [build-modern-bpf-skeleton]
-    container: centos:7
     steps:
       # Always install deps before invoking checkout action, to properly perform a full clone.
-      - name: Fix mirrors to use vault.centos.org
-        run: |
-          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-          sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
-          sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
-
-      - name: Install scl repos
-        run: |
-          yum -y install centos-release-scl
-
-      - name: Fix new mirrors to use vault.centos.org
-        run: |
-          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-          sed -i s/^#.*baseurl=http/baseurl=https/g /etc/yum.repos.d/*.repo
-          sed -i s/^mirrorlist=http/#mirrorlist=https/g /etc/yum.repos.d/*.repo
-
-      - name: Fix arm64 scl repos to use correct mirror
-        if: inputs.arch == 'aarch64'
-        run: |
-          sed -i 's/vault.centos.org\/centos/vault.centos.org\/altarch/g' /etc/yum.repos.d/CentOS-SCLo-scl*.repo
-
       - name: Install build deps
         run: |
-          yum -y install devtoolset-9-gcc devtoolset-9-gcc-c++
-          source /opt/rh/devtoolset-9/enable
-          yum install -y wget git make m4 rpm-build elfutils-libelf-devel perl-IPC-Cmd devtoolset-9-libasan-devel devtoolset-9-libubsan-devel
+          sudo apt update && sudo apt install -y --no-install-recommends ca-certificates cmake curl wget build-essential git pkg-config autoconf automake libtool libelf-dev m4 rpm
 
       - name: Checkout
-        # It is not possible to upgrade the checkout action to versions >= v4.0.0 because of incompatibilities with centos 7's libc.
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       - name: Download skeleton
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
@@ -97,14 +70,12 @@ jobs:
           name: bpf_probe_${{ inputs.arch }}.skel.h
           path: /tmp
 
-      - name: Install updated cmake
-        run: |
-          curl -L https://github.com/Kitware/CMake/releases/download/v3.22.5/cmake-3.22.5-linux-$(uname -m).tar.gz \
-            | tar --directory=/usr --strip-components=1 -xzp
+      - name: Install zig
+        if: inputs.sanitizers == false
+        uses: falcosecurity/libs/.github/actions/install-zig@master
 
       - name: Prepare project
         run: |
-          source /opt/rh/devtoolset-9/enable
           cmake -B build -S . \
               -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} \
               -DUSE_BUNDLED_DEPS=On \
@@ -117,12 +88,10 @@ jobs:
 
       - name: Build project
         run: |
-          source /opt/rh/devtoolset-9/enable
           cmake --build build --target falco -j6
 
       - name: Build packages
         run: |
-          source /opt/rh/devtoolset-9/enable
           cmake --build build --target package
 
       - name: Upload Falco tar.gz package

--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -35,9 +35,9 @@ else()
 	# FALCOSECURITY_LIBS_VERSION. In case you want to test against another driver version (or
 	# branch, or commit) just pass the variable - ie., `cmake -DDRIVER_VERSION=dev ..`
 	if(NOT DRIVER_VERSION)
-		set(DRIVER_VERSION "7.3.0+driver")
+		set(DRIVER_VERSION "aeb87935dcdd6b3bffb50302269353f2468f612c")
 		set(DRIVER_CHECKSUM
-			"SHA256=8f572d9a83feda635a3fa53b859d61e37af127c241e35068aadee3bc50d212c0"
+			"SHA256=fc2f18ed2f9e4bdcb93f32eee326a813a3614af50b82d30a7ccf96ac2a7cfbf0"
 		)
 	endif()
 

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -42,9 +42,9 @@ else()
 	# version (or branch, or commit) just pass the variable - ie., `cmake
 	# -DFALCOSECURITY_LIBS_VERSION=dev ..`
 	if(NOT FALCOSECURITY_LIBS_VERSION)
-		set(FALCOSECURITY_LIBS_VERSION "0.18.1")
+		set(FALCOSECURITY_LIBS_VERSION "aeb87935dcdd6b3bffb50302269353f2468f612c")
 		set(FALCOSECURITY_LIBS_CHECKSUM
-			"SHA256=1812e8236c4cb51d3fe5dd066d71be99f25da7ed22d8feeeebeed09bdc26325f"
+			"SHA256=fc2f18ed2f9e4bdcb93f32eee326a813a3614af50b82d30a7ccf96ac2a7cfbf0"
 		)
 	endif()
 
@@ -73,7 +73,6 @@ set(LIBS_PACKAGE_NAME "falcosecurity")
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	add_definitions(-D_GNU_SOURCE)
-	add_definitions(-DHAS_CAPTURE)
 endif()
 
 if(MUSL_OPTIMIZED_BUILD)

--- a/userspace/engine/rule_loader.h
+++ b/userspace/engine/rule_loader.h
@@ -250,7 +250,7 @@ public:
 	                 const context& ctx);
 
 	void set_schema_validation_status(const std::vector<std::string>& status);
-	std::string schema_validation();
+	std::string schema_validation() override;
 
 protected:
 	const std::string& as_summary_string();

--- a/userspace/falco/stats_writer.cpp
+++ b/userspace/falco/stats_writer.cpp
@@ -360,7 +360,9 @@ void stats_writer::collector::get_metrics_output_fields_wrapper(
 		output_fields["evt.hostname"] =
 		        machine_info->hostname; /* Explicitly add hostname to log msg in case hostname rule
 		                                   output field is disabled. */
-		output_fields["falco.host_boot_ts"] = machine_info->boot_ts_epoch;
+		// This line generates a SIGTRAP in zig debug builds if the casting is removed.
+		// It seems caused by the pragma pack for the scap_machine_info structure.
+		output_fields["falco.host_boot_ts"] = (uint64_t)machine_info->boot_ts_epoch;
 		output_fields["falco.host_num_cpus"] = machine_info->num_cpus;
 	}
 	output_fields["falco.outputs_queue_num_drops"] =


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

This PR drops centos7 from our CI by instead relying on zig compiler to provide glibc 2.17 compatible builds for us.

**Which issue(s) this PR fixes**:

Fixes #3270

**Special notes for your reviewer**:

Linked libs PRs:
* https://github.com/falcosecurity/libs/pull/2034 -> new c-ares builds with zig 
* https://github.com/falcosecurity/libs/pull/2036 -> libanl is not present under zig; fixes build
* https://github.com/falcosecurity/libs/pull/2037 -> title says it all
* https://github.com/falcosecurity/libs/pull/2043 -> avoids Falco linking issue `undefined symbol: google::protobuf::internal::InternalMetadata::~InternalMetadata()`
* https://github.com/falcosecurity/libs/pull/2045 -> fixes arm64 `Trace/breakpoint trap` issue for threadinfo and k8saudit plugin opening (source_plugin.c UB)
* https://github.com/falcosecurity/libs/pull/2049 -> cmake patches for libelf and grpc to support zig build
* https://github.com/falcosecurity/libs/pull/2088 -> more UBs fixes for libs

TODO:
- [x] sanitizer build fails at cmake configure step, because of: https://github.com/ziglang/zig/issues/11403. **Workaround: disable `zig` for sanitizer builds, ie: only use it for to-be-shipped artifacts.**
- [x] arm64 build is failing while building abseil randen_hwaes.cc file, since their cmake tries to detect platform features and enforces `-march=armv8-a+crypto`, but `armv8` is unsupported by zig. **Workaround: patch https://github.com/abseil/abseil-cpp/blob/1031858eb2b87a5d47f236d8eac11d8b05c535d5/absl/copts/GENERATED_AbseilCopts.cmake#L225 to use a supported arch name.** 
- [x] fix `test-dev-packages-arm64` -> it seems like a `Trace/breakpoint trap` is caught during `sinsp::open...` methods calls:
```
Tue Sep  3 10:46:35 2024: Loaded event sources: syscall
Tue Sep  3 10:46:35 2024: Enabled event sources: syscall
Tue Sep  3 10:46:35 2024: Opening 'syscall' source with Kernel module
Trace/breakpoint trap
```
- [x] fix `test-dev-packages-arm64` -> it seems like a `Trace/breakpoint trap` is caught related to stats_writer line: `output_fields["falco.host_boot_ts"] = machine_info->boot_ts_epoch;` -> bca6f31e94f5417ecf07975ab65e520c46656fac
- [x] fix `test-dev-packages-arm64` -> it seems like a `Trace/breakpoint trap` is caught related to k8saudit opening 
- [x] libelf is built bundled

**Does this PR introduce a user-facing change?**:

```release-note
new(ci): use `zig` compiler instead of relying on centos7.
```
