### PR TITLE
new(falco): enable CLI options with -o key={object}

### DIFF
--- a/unit_tests/falco/test_configuration_rule_selection.cpp
+++ b/unit_tests/falco/test_configuration_rule_selection.cpp
@@ -21,7 +21,7 @@ limitations under the License.
 TEST(ConfigurationRuleSelection, parse_yaml)
 {
 	falco_configuration falco_config;
-	EXPECT_NO_THROW(falco_config.init_from_content(R"(
+	ASSERT_NO_THROW(falco_config.init_from_content(R"(
 rules:
   - enable:
       rule: 'Terminal Shell in Container'
@@ -33,28 +33,42 @@ rules:
       rule: 'hello*'
 	)", {}));
 
-	ASSERT_EQ(falco_config.m_rules_selection.size(), 3);
+	EXPECT_EQ(falco_config.m_rules_selection.size(), 3);
 
-	ASSERT_EQ(falco_config.m_rules_selection[0].m_op, falco_configuration::rule_selection_operation::enable);
-	ASSERT_EQ(falco_config.m_rules_selection[0].m_rule, "Terminal Shell in Container");
+	EXPECT_EQ(falco_config.m_rules_selection[0].m_op, falco_configuration::rule_selection_operation::enable);
+	EXPECT_EQ(falco_config.m_rules_selection[0].m_rule, "Terminal Shell in Container");
 
-	ASSERT_EQ(falco_config.m_rules_selection[1].m_op, falco_configuration::rule_selection_operation::disable);
-	ASSERT_EQ(falco_config.m_rules_selection[1].m_tag, "experimental");
+	EXPECT_EQ(falco_config.m_rules_selection[1].m_op, falco_configuration::rule_selection_operation::disable);
+	EXPECT_EQ(falco_config.m_rules_selection[1].m_tag, "experimental");
 
-	ASSERT_EQ(falco_config.m_rules_selection[2].m_op, falco_configuration::rule_selection_operation::enable);
-	ASSERT_EQ(falco_config.m_rules_selection[2].m_rule, "hello*");
+	EXPECT_EQ(falco_config.m_rules_selection[2].m_op, falco_configuration::rule_selection_operation::enable);
+	EXPECT_EQ(falco_config.m_rules_selection[2].m_rule, "hello*");
 }
 
 TEST(ConfigurationRuleSelection, cli_options)
 {
 	falco_configuration falco_config;
-	EXPECT_NO_THROW(falco_config.init_from_content("", std::vector<std::string>{"rules[].disable.tag=maturity_incubating", "rules[].enable.rule=Adding ssh keys to authorized_keys"}));
+	ASSERT_NO_THROW(falco_config.init_from_content("", std::vector<std::string>{"rules[].disable.tag=maturity_incubating", "rules[].enable.rule=Adding ssh keys to authorized_keys"}));
 
-	ASSERT_EQ(falco_config.m_rules_selection.size(), 2);
+	EXPECT_EQ(falco_config.m_rules_selection.size(), 2);
 
-	ASSERT_EQ(falco_config.m_rules_selection[0].m_op, falco_configuration::rule_selection_operation::disable);
-	ASSERT_EQ(falco_config.m_rules_selection[0].m_tag, "maturity_incubating");
+	EXPECT_EQ(falco_config.m_rules_selection[0].m_op, falco_configuration::rule_selection_operation::disable);
+	EXPECT_EQ(falco_config.m_rules_selection[0].m_tag, "maturity_incubating");
 
-	ASSERT_EQ(falco_config.m_rules_selection[1].m_op, falco_configuration::rule_selection_operation::enable);
-	ASSERT_EQ(falco_config.m_rules_selection[1].m_rule, "Adding ssh keys to authorized_keys");
+	EXPECT_EQ(falco_config.m_rules_selection[1].m_op, falco_configuration::rule_selection_operation::enable);
+	EXPECT_EQ(falco_config.m_rules_selection[1].m_rule, "Adding ssh keys to authorized_keys");
+}
+
+TEST(ConfigurationRuleSelection, cli_options_object)
+{
+	falco_configuration falco_config;
+	ASSERT_NO_THROW(falco_config.init_from_content("", std::vector<std::string>{R"(rules[]={"disable": {"tag": "maturity_incubating"}})", R"(rules[]={"enable": {"rule": "Adding ssh keys to authorized_keys"}})"}));
+
+	EXPECT_EQ(falco_config.m_rules_selection.size(), 2);
+
+	EXPECT_EQ(falco_config.m_rules_selection[0].m_op, falco_configuration::rule_selection_operation::disable);
+	EXPECT_EQ(falco_config.m_rules_selection[0].m_tag, "maturity_incubating");
+
+	EXPECT_EQ(falco_config.m_rules_selection[1].m_op, falco_configuration::rule_selection_operation::enable);
+	EXPECT_EQ(falco_config.m_rules_selection[1].m_rule, "Adding ssh keys to authorized_keys");
 }

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -84,8 +84,8 @@ falco_configuration::falco_configuration():
 	m_metrics_convert_memory_to_mb(true),
 	m_metrics_include_empty_values(false),
 	m_container_engines_mask(0),
-	m_container_engines_cri_socket_paths({"/run/containerd/containerd.sock", "/run/crio/crio.sock","/run/k3s/containerd/containerd.sock"}),
-	m_container_engines_disable_cri_async(false)
+	m_container_engines_disable_cri_async(false),
+	m_container_engines_cri_socket_paths({"/run/containerd/containerd.sock", "/run/crio/crio.sock","/run/k3s/containerd/containerd.sock"})
 {
 	m_config_schema = nlohmann::json::parse(schema_json_string);
 }
@@ -749,5 +749,12 @@ void falco_configuration::set_cmdline_option(const std::string &opt)
 		throw std::logic_error("Error parsing config option \"" + opt + "\". Must be of the form key=val or key.subkey=val");
 	}
 
-	m_config.set_scalar(keyval.first, keyval.second);
+	if (keyval.second[0] == '{' && keyval.second[keyval.second.size() - 1] == '}')
+	{
+		YAML::Node node = YAML::Load(keyval.second);
+		m_config.set_object(keyval.first, node);
+	} else
+	{
+		m_config.set_scalar(keyval.first, keyval.second);
+	}
 }

--- a/userspace/falco/yaml_helper.h
+++ b/userspace/falco/yaml_helper.h
@@ -178,6 +178,16 @@ public:
 	}
 
 	/**
+	 * Set the node identified by key to an object value
+	 */
+	void set_object(const std::string& key, const YAML::Node& value)
+	{
+		YAML::Node node;
+		get_node(node, key, true);
+		node = value;
+	}
+
+	/**
 	* Get the sequence value from the node identified by key.
 	*/
 	template<typename T>
@@ -482,5 +492,6 @@ namespace YAML {
 
 			return true;
 		}
+		// The "encode" function is not needed here, in fact you can simply YAML::load any json string.
 	};
 }


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

In https://github.com/falcosecurity/falco/pull/3308 we add a new configuration option such as:
```yaml
append_output:
  - source: syscall
    tag: persistence
    rule: some rule name
    format: "gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4]"
```

Given its format, it is not possible to specify it on the command line with a `-o` option unless we enable a syntax like `-o key={object}`, or `-o key[]={object}`. Example: `-o append_output[]={"source": "syscall", "tag": "persistence", "rule": "some rule name", "format": "gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4]"}`. This PR does exactly that.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

For now, we are not enabling lists here but they can be allowed as well.

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
new(falco): enable CLI options with -o key={object}
```