### PR TITLE
cleanup(userspace/falco)!: drop deprecated -t,-T,-D options.

### DIFF
--- a/userspace/falco/app/actions/load_rules_files.cpp
+++ b/userspace/falco/app/actions/load_rules_files.cpp
@@ -131,39 +131,6 @@ falco::app::run_result falco::app::actions::load_rules_files(falco::app::state& 
 		return run_result::fatal(err);
 	}
 
-	if((!s.options.disabled_rule_substrings.empty() || !s.options.disabled_rule_tags.empty() || !s.options.enabled_rule_tags.empty()) &&
-		!s.config->m_rules_selection.empty())
-	{
-		return run_result::fatal("Specifying -D, -t, -T command line options together with \"rules:\" configuration or -o \"rules...\" is not supported.");
-	}
-
-	for (const auto& substring : s.options.disabled_rule_substrings)
-	{
-		falco_logger::log(falco_logger::level::INFO, "Disabling rules matching substring: " + substring + "\n");
-		s.engine->enable_rule(substring, false);
-	}
-
-	if(!s.options.disabled_rule_tags.empty())
-	{
-		for(const auto &tag : s.options.disabled_rule_tags)
-		{
-			falco_logger::log(falco_logger::level::INFO, "Disabling rules with tag: " + tag + "\n");
-		}
-		s.engine->enable_rule_by_tag(s.options.disabled_rule_tags, false);
-	}
-
-	if(!s.options.enabled_rule_tags.empty())
-	{
-		// Since we only want to enable specific
-		// rules, first disable all rules.
-		s.engine->enable_rule(all_rules, false);
-		for(const auto &tag : s.options.enabled_rule_tags)
-		{
-			falco_logger::log(falco_logger::level::INFO, "Enabling rules with tag: " + tag + "\n");
-		}
-		s.engine->enable_rule_by_tag(s.options.enabled_rule_tags, true);
-	}
-
 	for(const auto& sel : s.config->m_rules_selection)
 	{
 		bool enable = sel.m_op == falco_configuration::rule_selection_operation::enable;

--- a/userspace/falco/app/options.h
+++ b/userspace/falco/app/options.h
@@ -46,7 +46,6 @@ public:
 	std::vector<std::string> cri_socket_paths;
 	bool disable_cri_async = false;
 	std::vector<std::string> disable_sources;
-	std::vector<std::string> disabled_rule_substrings;
 	std::vector<std::string> enable_sources;
 	std::string gvisor_generate_config_with_socket;
 	bool describe_all_rules = false;
@@ -67,8 +66,6 @@ public:
 	std::list<std::string> rules_filenames;
 	uint64_t snaplen = 0;
 	bool print_support = false;
-	std::set<std::string> disabled_rule_tags;
-	std::set<std::string> enabled_rule_tags;
 	bool unbuffered_outputs = false;
 	std::vector<std::string> validate_rules_filenames;
 	bool verbose = false;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

https://github.com/falcosecurity/falco/pull/3193 deprecated 3 options for 0.38.0.
It's time to drop them for the 0.39.0 release.

Refs https://github.com/falcosecurity/falco/issues/3045.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
cleanup(userspace/falco)!: drop deprecated -t,-T,-D options.
```
