### PR TITLE
update(engine)!: print stats to stderr

### DIFF
--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -927,7 +927,7 @@ void falco_engine::print_stats() const
 	std::string out;
 	m_rule_stats_manager.format(m_rules, out);
 	// todo(jasondellaluce): introduce a logging callback in Falco
-	fprintf(stdout, "%s", out.c_str());
+	fprintf(stderr, "%s", out.c_str());
 }
 
 const stats_manager& falco_engine::get_rule_stats_manager() const


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

We have noticed a non-deterministic testing failure:

```
{"deadline":180000000000,"level":"info","msg":"running falco with runner","time":"2024-09-18T10:58:52Z"}
{"cmd":"/usr/bin/falco -c stdout_output.yaml -o json_output=true -r single_rule_with_tags.yaml -o engine.kind=replay -o engine.replay.capture_file=cat_write.scap -o time_format_iso_8601=true -o json_include_output_property=true -o json_include_tags_property=true -o log_level=debug -o log_stderr=true -o log_syslog=false -o stdout_output.enabled=true","level":"debug","msg":"executing command","time":"2024-09-18T10:58:52Z"}
{"error":"error code 1","level":"warning","msg":"error running falco with runner","time":"2024-09-18T10:58:52Z"}
    legacy_test.go:156: 
        	Error Trace:	/home/runner/actions-runner/_work/_actions/falcosecurity/testing/main/legacy_test.go:156
        	Error:      	Input ('Events detected: 8') needs to be valid json.
        	            	JSON parsing error: 'invalid character 'E' looking for beginning of value'
        	Test:       	TestFalco_Legacy_StdoutOutputJsonStrict
```

The problem here is that when you shut down Falco (or when the end of output is reached) there is a stat message that is written to stdout and is not synchronized with the Falco output queue. Example:

```
Events detected: 8
Rule counts by severity:
   WARNING: 8
Triggered rules by rule name:
   open_from_cat: 8
```

This means that this output can be intermixed with the regular Falco output. If you were expecting json you will find something else. There are more messages that are printed but those are on stderr. I have discussed this with @jasondellaluce , and we agree that it makes sense to put all of that to stderr.

This is however a breaking change in some ways, so if someone (e.g. @leogr ) can think of a reason why we shouldn't do it maybe we need to better synchronize this, although it is not as trivial.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
update(engine)!: print stats to stderr
```
