### PR TITLE
fix(userspace/falco): properly account for plugin with CAP_PARSING when computing interesting sc set

### DIFF
--- a/userspace/falco/app/actions/init_inspectors.cpp
+++ b/userspace/falco/app/actions/init_inspectors.cpp
@@ -163,11 +163,6 @@ falco::app::run_result falco::app::actions::init_inspectors(falco::app::state& s
 	std::unordered_set<std::string> used_plugins;
 	const auto& all_plugins = s.offline_inspector->get_plugin_manager()->plugins();
 
-	if((s.config->m_metrics_flags & METRICS_V2_STATE_COUNTERS))
-	{
-
-	}
-
 	for (const auto &src : s.loaded_sources)
 	{
 		auto src_info = s.source_infos.at(src);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Previously, we were not accounting for plugins with parsing capability while computing the interesting sc set.
This means that we gave no guarantees to plugins writers that the required syscalls (for parsing by the plugin) were actually enabled in the drivers.
This PR fixes that.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(userspace/falco): properly account for plugin with CAP_PARSING when computing interesting sc set
```
