### PR TITLE
fix(falco): allow plugin init_config map in json schema

### DIFF
--- a/unit_tests/falco/test_configuration_schema.cpp
+++ b/unit_tests/falco/test_configuration_schema.cpp
@@ -97,6 +97,34 @@ TEST(Configuration, schema_wrong_embedded_key)
 	EXPECT_VALIDATION_STATUS(res, yaml_helper::validation_failed);
 }
 
+TEST(Configuration, plugin_init_config)
+{
+	falco_configuration falco_config;
+	config_loaded_res res;
+
+	std::string config = R"(
+plugins:
+  - name: k8saudit
+    library_path: libk8saudit.so
+    init_config:
+      maxEventSize: 262144
+      sslCertificate: /etc/falco/falco.pem
+)";
+
+	EXPECT_NO_THROW(res = falco_config.init_from_content(config, {}));
+	EXPECT_VALIDATION_STATUS(res, yaml_helper::validation_ok);
+
+	config = R"(
+plugins:
+  - name: k8saudit
+    library_path: libk8saudit.so
+    init_config: '{"maxEventSize": 262144, "sslCertificate": "/etc/falco/falco.pem"}'
+)";
+
+	EXPECT_NO_THROW(res = falco_config.init_from_content(config, {}));
+	EXPECT_VALIDATION_STATUS(res, yaml_helper::validation_ok);
+}
+
 TEST(Configuration, schema_yaml_helper_validator)
 {
 	yaml_helper conf;

--- a/userspace/falco/config_json_schema.h
+++ b/userspace/falco/config_json_schema.h
@@ -587,7 +587,14 @@ const char config_schema_string[] = LONG_STRING_CONST(
                     "type": "string"
                 },
                 "init_config": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
                 },
                 "open_params": {
                     "type": "string"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

It is possible to specify plugin init config like:

```yaml
plugins:
  - name: k8saudit
    library_path: libk8saudit.so
    init_config:
      maxEventSize: 262144
      sslCertificate: /etc/falco/falco.pem
```

or

```yaml
plugins:
  - name: k8saudit
    library_path: libk8saudit.so
    init_config: '{"maxEventSize": 262144, "sslCertificate": "/etc/falco/falco.pem"}'
```

But json schema didn't allow that and only accepted a string. This PR adds the map option to the schema.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(falco): allow plugin init_config map in json schema
```
