### PR TITLE
fix(engine): sync outputs before printing stats at shutdown

### DIFF
--- a/userspace/falco/app/actions/process_events.cpp
+++ b/userspace/falco/app/actions/process_events.cpp
@@ -585,6 +585,12 @@ falco::app::run_result falco::app::actions::process_events(falco::app::state& s)
 		}
 	}
 
+	// By deleting s.outputs, we make sure that the engine will wait until
+	// regular output has been completely sent before printing stats, avoiding
+	// intermixed stats with output.
+	// Note that this will only work if this is the last reference held by the
+	// shared pointer.
+	s.outputs.reset();
 	s.engine->print_stats();
 
 	return res;


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Alternate fix for https://github.com/falcosecurity/falco/pull/3333 , checking that testing passes.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(engine): sync outputs before printing stats at shutdown
```
