### PR TITLE
chore: ignore_some_files for clang format

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,1 +1,3 @@
-# Add here new files to ignore
+# These files contain some JSON schema definitions that are not C++ code
+userspace/falco/config_json_schema.h
+userspace/engine/rule_json_schema.h


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This PR avoids the following error https://lists.llvm.org/pipermail/llvm-bugs/2018-May/064824.html when running clang-format on these files

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:



```release-note
NONE
```
