### PR TITLE
new(ci): add a workflow to automatically bump libs on each monday.

### DIFF
--- a/.github/workflows/bump-libs.yaml
+++ b/.github/workflows/bump-libs.yaml
@@ -1,0 +1,61 @@
+---
+name: Bump Libs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 6 * * 1' # on each monday 6:30
+
+# Checks if any concurrent jobs is running for kernels CI and eventually cancel it.
+concurrency:
+  group: bump-libs-ci
+  cancel-in-progress: true
+
+jobs:
+  bump-libs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Download libs master tar.gz
+        run: |
+          wget https://github.com/falcosecurity/libs/archive/refs/heads/master.tar.gz
+
+      - name: Store libs hash and shasum
+        id: store
+        run: |
+          echo "COMMIT=$(gunzip < libs-master.tar.gz | git get-tar-commit-id)" >> "$GITHUB_OUTPUT"
+          echo "SHASUM=$(sha256sum libs-master.tar.gz)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          path: falco
+
+      - name: Bump libs version and hash
+        run: |
+          cd falco
+          sed -i -E '45s/FALCOSECURITY_LIBS_VERSION "(.+)"/FALCOSECURITY_LIBS_VERSION "${{ steps.commit.outputs.COMMIT }}"/' cmake/modules/falcosecurity-libs.cmake
+          sed -i -E '47s/SHA256="(.+)"/SHA256="${{ steps.store.outputs.SHASUM }}"/' cmake/modules/falcosecurity-libs.cmake
+ 
+          sed -i -E '38s/DRIVER_VERSION "(.+)"/DRIVER_VERSION "${{ steps.commit.outputs.COMMIT }}"/' cmake/modules/driver.cmake
+          sed -i -E '40s/SHA256="(.+)"/SHA256="${{ steps.store.outputs.SHASUM }}"/' cmake/modules/driver.cmake
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
+        with:
+          path: falco
+          signoff: true
+          base: master
+          branch: update/libs
+          title: 'update(cmake): update libs and driver to latest master'
+          body: |
+            This PR updates libs and driver to latest commit.
+            /kind release
+            /area build
+            ```release-note
+            NONE
+            ```
+          commit-message: 'update(cmake): update libs and driver to latest master.'
+          token: ${{ secrets.GITHUB_TOKEN }}	  


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

This PR adds a workflow that creates  a PR on each monday to bump libs to latest master.
This is super useful together with the `zig` build, since the usage of a modern clang compiler helped us spot at least 3 UBs in the libs code; therefore by having an automatic PR, we can have helpful insights on the recent libs development.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
