### PR TITLE
fix(engine): disable comma separated vectors in cxxopts

### DIFF
--- a/userspace/falco/app/options.cpp
+++ b/userspace/falco/app/options.cpp
@@ -19,6 +19,9 @@ limitations under the License.
 #include "../configuration.h"
 #include "config_falco.h"
 
+// disable cxxopts vector delimiter, meaning that
+// -o test1,test2,test3 won't be treated like -o test1 -o test2 -o test3
+#define CXXOPTS_VECTOR_DELIMITER '\0'
 #include <cxxopts.hpp>
 
 #include <fstream>


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

There was a missed configuration option in this PR https://github.com/falcosecurity/falco/pull/3310 , which sadly made the `-o append_output[]={"source": "syscall", "tag": "persistence", "rule": "some rule name", "format": "gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4]"}` style options non functional due to the fact that cxxopts is trying to parse commas in the json object. Sadly I only realized after release. This PR fixes it.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(engine): fix parsing issues in -o key={object} when the object definition contains a comma
```
