### PR TITLE
fix(ci): fixed shasum computation for bump-libs CI.

### DIFF
--- a/.github/workflows/bump-libs.yaml
+++ b/.github/workflows/bump-libs.yaml
@@ -25,9 +25,11 @@ jobs:
       - name: Store libs hash and shasum
         id: store
         run: |
-          echo "SHASUM=$(sha256sum master.tar.gz | awk '{print $1}')" >> "$GITHUB_OUTPUT"
           gunzip -c master.tar.gz > master.tar
-          echo "COMMIT=$(cat master.tar | git get-tar-commit-id)" >> "$GITHUB_OUTPUT"
+          commit=$(cat master.tar | git get-tar-commit-id)
+          echo "COMMIT=$commit" >> "$GITHUB_OUTPUT"
+          wget https://github.com/falcosecurity/libs/archive/$commit.tar.gz
+          echo "SHASUM=$(sha256sum $commit.tar.gz | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

As seen in #3378 , we are computing the wrong shasum in bump-libs CI; that is because we are computing the shasum of https://github.com/falcosecurity/libs/archive/refs/heads/master.tar.gz and not https://github.com/falcosecurity/libs/archive/${commit-hash}.tar.gz; even if commit hash is of course the same.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
