### PR TITLE
new(userspace): honor new plugins exposed suggested output formats

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -571,12 +571,6 @@ buffered_outputs: false
 # deploying it in production.
 rule_matching: first
 
-# [Incubating] `suggested_formats`
-#
-# When enabled, Falco will honor requests by extractor plugins
-# that suggest certain fields to be part of outputs.
-suggested_formats: true
-
 # [Stable] `outputs_queue`
 #
 # Falco utilizes tbb::concurrent_bounded_queue for handling outputs, and this parameter
@@ -624,6 +618,7 @@ outputs_queue:
 #             affect the regular Falco message in any way. These can be specified as a
 #             custom name with a custom format or as any supported field
 #             (see: https://falco.org/docs/reference/rules/supported-fields/)
+#   `suggested_output`: enable the use of extractor plugins suggested fields for the matching source output.
 #
 # Example:
 # 
@@ -639,6 +634,13 @@ outputs_queue:
 # at the end telling the CPU number. In addition, if `json_output` is true, in the "output_fields"
 # property you will find three new ones: "evt.cpu", "home_directory" which will contain the value of the
 # environment variable $HOME, and "evt.hostname" which will contain the hostname.
+
+# By default, we enable suggested_output for any source.
+# This means that any extractor plugin that indicates some of its fields
+# as suggested output formats, will see these fields in the output
+# in the form "foo_bar=$foo.bar"
+append_output:
+  - suggested_output: true
 
 
 ##########################

--- a/falco.yaml
+++ b/falco.yaml
@@ -571,6 +571,12 @@ buffered_outputs: false
 # deploying it in production.
 rule_matching: first
 
+# [Incubating] `suggested_formats`
+#
+# When enabled, Falco will honor requests by extractor plugins
+# that suggest certain fields to be part of outputs.
+suggested_formats: true
+
 # [Stable] `outputs_queue`
 #
 # Falco utilizes tbb::concurrent_bounded_queue for handling outputs, and this parameter

--- a/userspace/falco/config_json_schema.h
+++ b/userspace/falco/config_json_schema.h
@@ -101,9 +101,6 @@ const char config_schema_string[] = LONG_STRING_CONST(
                 "buffered_outputs": {
                     "type": "boolean"
                 },
-                "suggested_formats": {
-                    "type": "boolean"
-                },
                 "rule_matching": {
                     "type": "string"
                 },
@@ -276,6 +273,9 @@ const char config_schema_string[] = LONG_STRING_CONST(
                             }
                         ]
                     }
+                },
+                "suggested_output": {
+                    "type": "boolean"
                 }
             }
         },

--- a/userspace/falco/config_json_schema.h
+++ b/userspace/falco/config_json_schema.h
@@ -101,6 +101,9 @@ const char config_schema_string[] = LONG_STRING_CONST(
                 "buffered_outputs": {
                     "type": "boolean"
                 },
+                "suggested_formats": {
+                    "type": "boolean"
+                },
                 "rule_matching": {
                     "type": "string"
                 },

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -72,6 +72,7 @@ falco_configuration::falco_configuration():
         m_rule_matching(falco_common::rule_matching::FIRST),
         m_watch_config_files(true),
         m_buffered_outputs(false),
+        m_suggested_formats(true),
         m_outputs_queue_capacity(DEFAULT_OUTPUTS_QUEUE_CAPACITY_UNBOUNDED_MAX_LONG_VALUE),
         m_time_format_iso_8601(false),
         m_buffer_format_base64(false),
@@ -483,6 +484,7 @@ void falco_configuration::load_yaml(const std::string &config_name) {
 	}
 
 	m_buffered_outputs = m_config.get_scalar<bool>("buffered_outputs", false);
+	m_suggested_formats = m_config.get_scalar<bool>("suggested_formats", true);
 	m_outputs_queue_capacity =
 	        m_config.get_scalar<size_t>("outputs_queue.capacity",
 	                                    DEFAULT_OUTPUTS_QUEUE_CAPACITY_UNBOUNDED_MAX_LONG_VALUE);

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -72,7 +72,6 @@ falco_configuration::falco_configuration():
         m_rule_matching(falco_common::rule_matching::FIRST),
         m_watch_config_files(true),
         m_buffered_outputs(false),
-        m_suggested_formats(true),
         m_outputs_queue_capacity(DEFAULT_OUTPUTS_QUEUE_CAPACITY_UNBOUNDED_MAX_LONG_VALUE),
         m_time_format_iso_8601(false),
         m_buffer_format_base64(false),
@@ -484,7 +483,6 @@ void falco_configuration::load_yaml(const std::string &config_name) {
 	}
 
 	m_buffered_outputs = m_config.get_scalar<bool>("buffered_outputs", false);
-	m_suggested_formats = m_config.get_scalar<bool>("suggested_formats", true);
 	m_outputs_queue_capacity =
 	        m_config.get_scalar<size_t>("outputs_queue.capacity",
 	                                    DEFAULT_OUTPUTS_QUEUE_CAPACITY_UNBOUNDED_MAX_LONG_VALUE);

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -155,6 +155,7 @@ public:
 	bool m_time_format_iso_8601;
 	bool m_buffer_format_base64;
 	uint32_t m_output_timeout;
+	bool m_suggested_formats;
 
 	bool m_grpc_enabled;
 	uint32_t m_grpc_threadiness;

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -100,6 +100,7 @@ public:
 		std::set<std::string> m_tags;
 		std::string m_rule;
 		std::string m_format;
+		bool m_suggested_output = false;
 		std::unordered_map<std::string, std::string> m_formatted_fields;
 		std::set<std::string> m_raw_fields;
 	};
@@ -155,7 +156,6 @@ public:
 	bool m_time_format_iso_8601;
 	bool m_buffer_format_base64;
 	uint32_t m_output_timeout;
-	bool m_suggested_formats;
 
 	bool m_grpc_enabled;
 	uint32_t m_grpc_threadiness;
@@ -289,6 +289,10 @@ struct convert<falco_configuration::append_output_config> {
 					return false;
 				}
 			}
+		}
+
+		if(node["suggested_output"]) {
+			rhs.m_suggested_output = node["suggested_output"].as<bool>();
 		}
 
 		return true;


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Since https://github.com/falcosecurity/libs/pull/2116, the plugin API now exposes a way for extractor plugins to declare that certain fields should be used as output formats.
Honor the request, and add a `suggested_formats` config option to eventually disable the suggested formats.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
new(userspace,cmake): honor new plugins exposed suggested output formats
```
