### PR TITLE
fix(cmake,docker): avoid cpp-httplib requiring brotli.

### DIFF
--- a/cmake/modules/cpp-httplib.cmake
+++ b/cmake/modules/cpp-httplib.cmake
@@ -16,6 +16,8 @@
 option(USE_BUNDLED_CPPHTTPLIB "Enable building of the bundled cpp-httplib" ${USE_BUNDLED_DEPS})
 
 if(USE_BUNDLED_CPPHTTPLIB)
+	set(HTTPLIB_USE_BROTLI_IF_AVAILABLE OFF)
+	set(HTTPLIB_REQUIRE_BROTLI OFF)
 	include(FetchContent)
 	FetchContent_Declare(
 		cpp-httplib

--- a/docker/falco/Dockerfile
+++ b/docker/falco/Dockerfile
@@ -14,15 +14,7 @@ ENV VERSION_BUCKET=${VERSION_BUCKET}
 ENV HOST_ROOT /host
 ENV HOME /root
 
-RUN apk update && apk add \
-    ca-certificates \
-    libstdc++ \
-    libelf \
-    llibbrotlicommon1 \
-    libbrotlidec1 \
-    libbrotlienc1 \
-    curl \
-    jq
+RUN apk update && apk add curl ca-certificates jq libelf libstdc++
 
 WORKDIR /
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Since we started using ubuntu runner as builder (instead of relying on centos:7, see https://github.com/falcosecurity/falco/pull/3307), `cpp-httplib` started using `brotli` dep found in the system (that was not present on centos:7) since it defaults `HTTPLIB_USE_BROTLI_IF_AVAILABLE` to `ON`: https://github.com/yhirose/cpp-httplib/blob/master/CMakeLists.txt#L6

Disable this behavior since we do not want the added dep.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
