### PR TITLE
fix(userspace/falco): use correct filtercheck_field_info.

### DIFF
--- a/userspace/falco/app/actions/init_falco_engine.cpp
+++ b/userspace/falco/app/actions/init_falco_engine.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 using namespace falco::app;
 using namespace falco::app::actions;
 
-static inline std::string format_suggested_field(const filter_check_info* info) {
+static inline std::string format_suggested_field(const filtercheck_field_info* info) {
 	std::ostringstream out;
 
 	// Replace "foo.bar" with "foo_bar"
@@ -46,12 +46,15 @@ static void add_suggested_output(const falco::app::state& s,
 	std::vector<const filter_check_info*> fields;
 	filterchecks.get_all_fields(fields);
 	for(const auto& fld : fields) {
-		if(fld->m_fields->is_format_suggested()) {
-			s.engine->add_extra_output_format(format_suggested_field(fld),
-			                                  src,
-			                                  eo.m_tags,
-			                                  eo.m_rule,
-			                                  false);
+		for(int i = 0; i < fld->m_nfields; i++) {
+			const auto* fldinfo = &fld->m_fields[i];
+			if(fldinfo->is_format_suggested()) {
+				s.engine->add_extra_output_format(format_suggested_field(fldinfo),
+				                                  src,
+				                                  eo.m_tags,
+				                                  eo.m_rule,
+				                                  false);
+			}
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Fix on top of #3388: `filter_check_info->m_name` is the global name of the list of checks, eg: `container (plugin)`.
Instead, we need to loop on each field info.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
