### PR TITLE
docs(falco.yaml): correct `buffered_outputs` description

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -549,9 +549,14 @@ json_include_tags_property: true
 
 # [Stable] `buffered_outputs`
 #
-# Enabling buffering for the output queue can offer performance optimization,
-# efficient resource usage, and smoother data flow, resulting in a more reliable
-# output mechanism. By default, buffering is disabled (false).
+# Global buffering option for output channels. When disabled, the output channel
+# that supports buffering flushes the output buffer on every alert. This can lead to 
+# increased CPU usage but is useful when piping outputs to another process or script. 
+# Buffering is currently supported by `file_output`, `program_output`, and `std_output`. 
+# Some output channels may implement buffering strategies you cannot control. 
+# Additionally, this setting is separate from the `output_queue` option. The output queue 
+# sits between the rule engine and the output channels, while output buffering occurs 
+# afterward once the specific channel implementation outputs the formatted message.
 buffered_outputs: false
 
 # [Incubating] `rule_matching`


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

/kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.40.0

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
