### PR TITLE
update(build): relax dkms dependencies to suggestions in DEB and RPM packages

### DIFF
--- a/cmake/modules/CPackConfig.cmake
+++ b/cmake/modules/CPackConfig.cmake
@@ -72,7 +72,7 @@ if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
 	set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "arm64")
 endif()
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://www.falco.org")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "dkms (>= 2.1.0.0)")
+set(CPACK_DEBIAN_PACKAGE_SUGGESTS "dkms (>= 2.1.0.0)")
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
 	"${CMAKE_BINARY_DIR}/scripts/debian/postinst;${CMAKE_BINARY_DIR}/scripts/debian/prerm;${CMAKE_BINARY_DIR}/scripts/debian/postrm;${PROJECT_SOURCE_DIR}/cmake/cpack/debian/conffiles"
 )
@@ -80,7 +80,8 @@ set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
 set(CPACK_RPM_PACKAGE_LICENSE "Apache v2.0")
 set(CPACK_RPM_PACKAGE_ARCHITECTURE, "amd64")
 set(CPACK_RPM_PACKAGE_URL "https://www.falco.org")
-set(CPACK_RPM_PACKAGE_REQUIRES "dkms, kernel-devel, systemd")
+set(CPACK_RPM_PACKAGE_REQUIRES "systemd")
+set(CPACK_RPM_PACKAGE_SUGGESTS "dkms, kernel-devel")
 set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_BINARY_DIR}/scripts/rpm/postinstall")
 set(CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${CMAKE_BINARY_DIR}/scripts/rpm/preuninstall")
 set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${CMAKE_BINARY_DIR}/scripts/rpm/postuninstall")


### PR DESCRIPTION
Using Falco with the modern_ebpf driver does not require kernel build dependencies. This PR updates the cmake configuration to make the `dkms` and `kernel-devel` package requirements into suggestions.

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This makes the `kernel-devel` and `dkms` dependencies optional when installing the `falco` package, significantly reducing the number of packages installed when running in modern_ebpf mode.

On Alma 8, installing Falco 0.39.2 from RPM requires `dkms` and `kernel-devel`, which adds many dependencies for a total of 76 packages on my minimal test VM. After converting the `dkms` and `kernel-devel` requirements to suggestions with rpmrebuild, no additional dependencies beyond `falco` itself were required, and Falco appears to run fine with modern_ebpf. This PR should have the same effect on packages generated by cmake.

**Does this PR introduce a user-facing change?**:

YES

```release-note
update(build): DEB and RPM package requirements for dkms and kernel-devel are now suggestions
```
