### PR TITLE
chore(ci): build Falco in RelWithDebInfo, and upload Falco debug symbols as github artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -163,18 +163,18 @@ jobs:
       - name: Download debug symbols for Falco x86_64
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: falco-${{ inputs.version }}-x86_64.debug
+          name: falco-${{ github.event.release.tag_name }}-x86_64.debug
 
       - name: Rename x86_64 debug symbols
-        run: mv falco.debug falco_x86_64.debug
+        run: mv falco.debug falco-x86_64.debug
 
       - name: Download debug symbols for Falco aarch64
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: falco-${{ inputs.version }}-aarch64.debug
+          name: falco-${{ github.event.release.tag_name }}-aarch64.debug
 
       - name: Rename aarch64 debug symbols
-        run: mv falco.debug falco_aarch64.debug
+        run: mv falco.debug falco-aarch64.debug
 
       - name: Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,9 +160,28 @@ jobs:
           echo "" >> release-body.md
           echo "#### Release Manager @${{ github.event.release.author.login }}" >> release-body.md
 
+      - name: Download debug symbols for Falco x86_64
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: falco-${{ inputs.version }}-x86_64.debug
+
+      - name: Rename x86_64 debug symbols
+        run: mv falco.debug falco_x86_64.debug
+
+      - name: Download debug symbols for Falco aarch64
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: falco-${{ inputs.version }}-aarch64.debug
+
+      - name: Rename aarch64 debug symbols
+        run: mv falco.debug falco_aarch64.debug
+
       - name: Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           body_path: ./release-body.md
           tag_name: ${{ github.event.release.tag_name }}
           name: ${{ github.event.release.name }}
+          files: |
+            falco-x86_64.debug
+            falco-aarch64.debug

--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Prepare project
         run: |
           cmake -B build -S . \
-              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               -DUSE_BUNDLED_DEPS=On \
               -DFALCO_ETC_DIR=/etc/falco \
               -DMODERN_BPF_SKEL_DIR=/tmp \
@@ -113,7 +113,14 @@ jobs:
         with:
           name: falco-${{ inputs.version }}-${{ inputs.arch }}.rpm
           path: |
-            ${{ github.workspace }}/build/falco-*.rpm          
+            ${{ github.workspace }}/build/falco-*.rpm
+
+      - name: Upload Falco debug symbols
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: falco-${{ inputs.version }}-${{ inputs.arch }}.debug
+          path: |
+            ${{ github.workspace }}/build/userspace/falco/falco.debug
 
   build-packages-debug:
     # See https://github.com/actions/runner/issues/409#issuecomment-1158849936


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

https://github.com/falcosecurity/falco/pull/3440 allows us to build Falco in RelWithDebInfo target.
Use the new target and upload the debug symbols as github artifacts.
Then, as part of the release CI, use these artifacts and upload them as github assets.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
chore(ci): build Falco in RelWithDebInfo, and upload Falco debug symbols as github artifacts
```
