### PR TITLE
fix(userspace/falco): use container_engines.cri.sockets in load_yaml

### DIFF
--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -701,7 +701,7 @@ void falco_configuration::load_yaml(const std::string &config_name) {
 		m_container_engines_mask |= ((1 << CT_CRI) | (1 << CT_CRIO) | (1 << CT_CONTAINERD));
 		m_container_engines_cri_socket_paths.clear();
 		m_config.get_sequence<std::vector<std::string>>(m_container_engines_cri_socket_paths,
-		                                                "container_engines.cri.cri");
+		                                                "container_engines.cri.sockets");
 		m_container_engines_disable_cri_async =
 		        m_config.get_scalar<bool>("container_engines.cri.disable-cri-async", false);
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area engine

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Since falco 0.39.0, the cri flag is deprecated but the recommended flag `-o container_engines.cri.sockets[]=<socket_path>` or the config file sockets values are not being applied since falco is trying to load the values from `container_engines.cri.cri`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->
Yes

```release-note
fix(userspace/falco): fix container_engines.cri.sockets not loading from config file
```
