### PR TITLE
chore(ci): bumped actions/upload-download-artifact.

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Upload the git diff artifact 📦
         if: failure()
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: format_diff.patch
           path: ./format_diff.patch

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -161,7 +161,7 @@ jobs:
           echo "#### Release Manager @${{ github.event.release.author.login }}" >> release-body.md
 
       - name: Download debug symbols for Falco x86_64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: falco-${{ github.event.release.tag_name }}-x86_64.debug
 
@@ -169,7 +169,7 @@ jobs:
         run: mv falco.debug falco-x86_64.debug
 
       - name: Download debug symbols for Falco aarch64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: falco-${{ github.event.release.tag_name }}-aarch64.debug
 

--- a/.github/workflows/reusable_build_dev.yaml
+++ b/.github/workflows/reusable_build_dev.yaml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   build-and-test:
     # See https://github.com/actions/runner/issues/409#issuecomment-1158849936
-    runs-on: ${{ (inputs.arch == 'aarch64' && 'github-aarch64-4cpu-16gb') || 'ubuntu-22.04' }}
+    runs-on: ${{ (inputs.arch == 'aarch64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
     outputs:
       cmdout: ${{ steps.run_cmd.outputs.out }}
     steps:

--- a/.github/workflows/reusable_build_docker.yaml
+++ b/.github/workflows/reusable_build_docker.yaml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   build-docker:
     # See https://github.com/actions/runner/issues/409#issuecomment-1158849936
-    runs-on: ${{ (inputs.arch == 'aarch64' && 'github-aarch64-4cpu-16gb') || 'ubuntu-latest' }}
+    runs-on: ${{ (inputs.arch == 'aarch64' && 'ubuntu-22.04-arm') || 'ubuntu-latest' }}
     env:
       TARGETARCH: ${{ (inputs.arch == 'aarch64' && 'arm64') || 'amd64' }}
     steps:

--- a/.github/workflows/reusable_build_docker.yaml
+++ b/.github/workflows/reusable_build_docker.yaml
@@ -81,7 +81,7 @@ jobs:
             docker save docker.io/falcosecurity/falco-driver-loader:${{ inputs.arch }}-${{ inputs.tag }}-buster --output /tmp/falco-driver-loader-${{ inputs.arch }}-buster.tar
 
       - name: Upload images tarballs
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: falco-images
           path: /tmp/falco-*.tar

--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   build-modern-bpf-skeleton:
     # See https://github.com/actions/runner/issues/409#issuecomment-1158849936
-    runs-on: ${{ (inputs.arch == 'aarch64' && 'github-aarch64-4cpu-16gb') || 'ubuntu-latest' }}
+    runs-on: ${{ (inputs.arch == 'aarch64' && 'ubuntu-22.04-arm') || 'ubuntu-latest' }}
     container: fedora:latest
     steps:
       # Always install deps before invoking checkout action, to properly perform a full clone.
@@ -53,7 +53,7 @@ jobs:
 
   build-packages-release:
     # See https://github.com/actions/runner/issues/409#issuecomment-1158849936
-    runs-on: ${{ (inputs.arch == 'aarch64' && 'github-aarch64-4cpu-16gb') || 'ubuntu-latest' }}
+    runs-on: ${{ (inputs.arch == 'aarch64' && 'ubuntu-22.04-arm') || 'ubuntu-latest' }}
     needs: [build-modern-bpf-skeleton]
     steps:
       # Always install deps before invoking checkout action, to properly perform a full clone.
@@ -124,7 +124,7 @@ jobs:
 
   build-packages-debug:
     # See https://github.com/actions/runner/issues/409#issuecomment-1158849936
-    runs-on: ${{ (inputs.arch == 'aarch64' && 'github-aarch64-4cpu-16gb') || 'ubuntu-22.04' }}
+    runs-on: ${{ (inputs.arch == 'aarch64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
     if: ${{ inputs.enable_debug == true }}
     needs: [build-modern-bpf-skeleton]
     steps:
@@ -175,7 +175,7 @@ jobs:
 
   build-packages-sanitizers:
     # See https://github.com/actions/runner/issues/409#issuecomment-1158849936
-    runs-on: ${{ (inputs.arch == 'aarch64' && 'github-aarch64-4cpu-16gb') || 'ubuntu-latest' }}
+    runs-on: ${{ (inputs.arch == 'aarch64' && 'ubuntu-22.04-arm') || 'ubuntu-latest' }}
     if: ${{ inputs.enable_sanitizers == true }}
     needs: [build-modern-bpf-skeleton]
     steps:

--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -45,7 +45,7 @@ jobs:
           cmake --build skeleton-build --target ProbeSkeleton -j6
 
       - name: Upload skeleton
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: bpf_probe_${{ inputs.arch }}.skel.h
           path: skeleton-build/skel_dir/bpf_probe.skel.h
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       - name: Download skeleton
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: bpf_probe_${{ inputs.arch }}.skel.h
           path: /tmp
@@ -95,28 +95,28 @@ jobs:
           cmake --build build --target package
 
       - name: Upload Falco tar.gz package
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: falco-${{ inputs.version }}-${{ inputs.arch }}.tar.gz
           path: |
             ${{ github.workspace }}/build/falco-*.tar.gz
 
       - name: Upload Falco deb package
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: falco-${{ inputs.version }}-${{ inputs.arch }}.deb
           path: |
             ${{ github.workspace }}/build/falco-*.deb
 
       - name: Upload Falco rpm package
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: falco-${{ inputs.version }}-${{ inputs.arch }}.rpm
           path: |
             ${{ github.workspace }}/build/falco-*.rpm
 
       - name: Upload Falco debug symbols
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: falco-${{ inputs.version }}-${{ inputs.arch }}.debug
           path: |
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       - name: Download skeleton
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: bpf_probe_${{ inputs.arch }}.skel.h
           path: /tmp
@@ -167,7 +167,7 @@ jobs:
           cmake --build build --target package
 
       - name: Upload Falco tar.gz package
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: falco-${{ inputs.version }}-${{ inputs.arch }}-debug.tar.gz
           path: |
@@ -188,7 +188,7 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       - name: Download skeleton
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: bpf_probe_${{ inputs.arch }}.skel.h
           path: /tmp
@@ -216,7 +216,7 @@ jobs:
           cmake --build build --target package
 
       - name: Upload Falco tar.gz package
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: falco-${{ inputs.version }}-${{ inputs.arch }}-sanitizers.tar.gz
           path: |
@@ -268,7 +268,7 @@ jobs:
           mv falco-${{ inputs.version }}-x86_64.tar.gz falco-${{ inputs.version }}-static-x86_64.tar.gz
 
       - name: Upload Falco static package
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: falco-${{ inputs.version }}-static-x86_64.tar.gz
           path: |
@@ -319,7 +319,7 @@ jobs:
           emmake make -j6 package
 
       - name: Upload Falco WASM package
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: falco-${{ inputs.version }}-wasm.tar.gz
           path: |
@@ -348,13 +348,13 @@ jobs:
           build/unit_tests/Release/falco_unit_tests.exe
 
       - name: Upload Falco win32 installer
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: falco-installer-Release-win32.exe
           path: build/falco-*.exe
 
       - name: Upload Falco win32 package
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: falco-Release-win32.exe
           path: |
@@ -383,7 +383,7 @@ jobs:
           sudo build/unit_tests/falco_unit_tests
 
       - name: Upload Falco macos package
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: falco-${{ inputs.version }}-macos
           path: |

--- a/.github/workflows/reusable_publish_docker.yaml
+++ b/.github/workflows/reusable_publish_docker.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
       - name: Download images tarballs
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: falco-images
           path: /tmp/falco-images

--- a/.github/workflows/reusable_publish_packages.yaml
+++ b/.github/workflows/reusable_publish_packages.yaml
@@ -42,37 +42,37 @@ jobs:
           aws-region: ${{ env.AWS_S3_REGION }}    
           
       - name: Download RPM x86_64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: falco-${{ inputs.version }}-x86_64.rpm
           path: /tmp/falco-build-rpm
 
       - name: Download RPM aarch64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: falco-${{ inputs.version }}-aarch64.rpm
           path: /tmp/falco-build-rpm
 
       - name: Download binary x86_64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: falco-${{ inputs.version }}-x86_64.tar.gz
           path: /tmp/falco-build-bin
 
       - name: Download binary aarch64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: falco-${{ inputs.version }}-aarch64.tar.gz
           path: /tmp/falco-build-bin
 
       - name: Download static binary x86_64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: falco-${{ inputs.version }}-static-x86_64.tar.gz
           path: /tmp/falco-build-bin-static
 
       - name: Download WASM package
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: falco-${{ inputs.version }}-wasm.tar.gz
           path: /tmp/falco-wasm
@@ -125,13 +125,13 @@ jobs:
           aws-region: ${{ env.AWS_S3_REGION }}     
       
       - name: Download deb x86_64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: falco-${{ inputs.version }}-x86_64.deb
           path: /tmp/falco-build-deb
 
       - name: Download deb aarch64
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: falco-${{ inputs.version }}-aarch64.deb
           path: /tmp/falco-build-deb

--- a/.github/workflows/reusable_test_packages.yaml
+++ b/.github/workflows/reusable_test_packages.yaml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   test-packages:
     # See https://github.com/actions/runner/issues/409#issuecomment-1158849936
-    runs-on: ${{ (inputs.arch == 'aarch64' && 'github-aarch64-4cpu-16gb') || 'ubuntu-latest' }}
+    runs-on: ${{ (inputs.arch == 'aarch64' && 'ubuntu-22.04-arm') || 'ubuntu-latest' }}
     steps:
       - name: Download binary
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8

--- a/.github/workflows/reusable_test_packages.yaml
+++ b/.github/workflows/reusable_test_packages.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ (inputs.arch == 'aarch64' && 'github-aarch64-4cpu-16gb') || 'ubuntu-latest' }}
     steps:
       - name: Download binary
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: falco-${{ inputs.version }}${{ inputs.static && '-static' || '' }}-${{ inputs.arch }}${{ inputs.sanitizers == true && '-sanitizers' || '' }}.tar.gz
       

--- a/.github/workflows/reusable_test_packages.yaml
+++ b/.github/workflows/reusable_test_packages.yaml
@@ -43,7 +43,6 @@ jobs:
      
       # We only run driver loader tests on x86_64
       - name: Install kernel headers for falco-driver-loader tests
-        if: ${{ inputs.arch == 'x86_64' }}
         run: |
           sudo apt update -y
           sudo apt install -y --no-install-recommends linux-headers-$(uname -r)
@@ -64,6 +63,6 @@ jobs:
           test-k8saudit: 'true'
           test-dummy: 'true'
           static: ${{ inputs.static && 'true' || 'false' }}
-          test-drivers: ${{ inputs.arch == 'x86_64' && 'true' || 'false' }}
+          test-drivers: 'true'
           show-all: 'true'
           report-name-suffix: ${{ inputs.static && '-static' || '' }}${{ inputs.sanitizers && '-sanitizers' || '' }}

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -65,7 +65,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/staticanalysis.yaml
+++ b/.github/workflows/staticanalysis.yaml
@@ -29,7 +29,7 @@ jobs:
           cmake --build build -j4 --target cppcheck_htmlreport
 
       - name: Upload reports ⬆️
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: static-analysis-reports
           path: ./build/static-analysis-reports


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

In #3453 the CI is failing because we need to bump actions/{download,upload}-artifact actions.
See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: a8a3f3ad30e3422c9c7b888a15615d19a852ae32`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Also, while at it, i ported our CI to use the shiny new github provided ARM runners: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Given i am a really optimistic person, i also enabled `test-drivers` option in our testing framework :laughing: 


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
