### PR TITLE
feat(falco/app): move actions not using config before `load_config`

### DIFF
--- a/userspace/falco/app/app.cpp
+++ b/userspace/falco/app/app.cpp
@@ -53,17 +53,17 @@ bool falco::app::run(falco::app::state& s, bool& restart, std::string& errstr) {
 	// called. Before changing the order, ensure that all
 	// dependencies are honored (e.g. don't process events before
 	// loading plugins, opening inspector, etc.).
-	std::list<app_action> run_steps = {
+	std::list<app_action> const run_steps = {
+	        falco::app::actions::print_help,
 	        falco::app::actions::print_config_schema,
 	        falco::app::actions::print_rule_schema,
-	        falco::app::actions::load_config,
-	        falco::app::actions::print_help,
-	        falco::app::actions::print_kernel_version,
-	        falco::app::actions::print_version,
-	        falco::app::actions::print_page_size,
 	        falco::app::actions::print_generated_gvisor_config,
 	        falco::app::actions::print_ignored_events,
 	        falco::app::actions::print_syscall_events,
+	        falco::app::actions::load_config,
+	        falco::app::actions::print_kernel_version,
+	        falco::app::actions::print_version,
+	        falco::app::actions::print_page_size,
 	        falco::app::actions::require_config_file,
 	        falco::app::actions::print_plugin_info,
 	        falco::app::actions::list_plugins,
@@ -87,7 +87,7 @@ bool falco::app::run(falco::app::state& s, bool& restart, std::string& errstr) {
 	        falco::app::actions::process_events,
 	};
 
-	std::list<app_action> teardown_steps = {
+	std::list<app_action> const teardown_steps = {
 	        falco::app::actions::unregister_signal_handlers,
 	        falco::app::actions::stop_grpc_server,
 	        falco::app::actions::stop_webserver,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR moves, before the `load_config` action, all actions not requiring the config to be loaded. This avoid resources waste. Notably, it promotes `print_help` as first executed action. Moreover, it sets actions lists to constant expressions.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
