### PR TITLE
fix(userspace/falco): init cmdline options after loading all config files

### DIFF
--- a/unit_tests/falco/test_configuration_config_files.cpp
+++ b/unit_tests/falco/test_configuration_config_files.cpp
@@ -466,6 +466,9 @@ TEST(Configuration, configuration_config_files_cmdline) {
 	std::vector<std::string> cmdline_config_options;
 	cmdline_config_options.push_back((yaml_helper::configs_key + "=conf_2.yaml"));
 
+	// Override foo2 value from cli
+	cmdline_config_options.push_back(("foo2=bar22"));
+
 	falco_configuration falco_config;
 	config_loaded_res res;
 	ASSERT_NO_THROW(res = falco_config.init_from_file("main.yaml", cmdline_config_options));
@@ -480,7 +483,7 @@ TEST(Configuration, configuration_config_files_cmdline) {
 	ASSERT_TRUE(falco_config.m_config.is_defined("base_value.name"));
 	ASSERT_EQ(falco_config.m_config.get_scalar<std::string>("base_value.name", ""), "foo");
 	ASSERT_TRUE(falco_config.m_config.is_defined("foo2"));
-	ASSERT_EQ(falco_config.m_config.get_scalar<std::string>("foo2", ""), "bar2");
+	ASSERT_EQ(falco_config.m_config.get_scalar<std::string>("foo2", ""), "bar22");
 	ASSERT_TRUE(falco_config.m_config.is_defined("base_value_2.id"));
 	ASSERT_EQ(falco_config.m_config.get_scalar<int>("base_value_2.id", 0), 2);
 

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -221,6 +221,8 @@ private:
 	void init_logger();
 	void load_engine_config(const std::string& config_name);
 	void init_cmdline_options(const std::vector<std::string>& cmdline_options);
+	void load_cmdline_config_files(const std::vector<std::string>& cmdline_options);
+
 	/**
 	 * Given a <key>=<value> specifier, set the appropriate option
 	 * in the underlying yaml config. <key> can contain '.'


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Since I introduced Falco sub-config files, since sub-config files were loaded **after** considering the `-o` cmdline override flags, their overridden config entries would win on the `-o` flags.
This PR fixes the behavior.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(userspace/falco): init cmdline options after loading all config files
```
