### PR TITLE
cleanup(userspace/falco): drop deprecated in 0.40.0 CLI flags.

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -1277,6 +1277,7 @@ metrics:
 base_syscalls:
   custom_set: []
   repair: false
+  all: false
 
 ##############
 # Falco libs #

--- a/unit_tests/falco/app/actions/test_configure_interesting_sets.cpp
+++ b/unit_tests/falco/app/actions/test_configure_interesting_sets.cpp
@@ -116,7 +116,6 @@ TEST_F(test_falco_engine, preconditions_postconditions) {
 
 	s1.engine = nullptr;
 	s1.config = std::make_shared<falco_configuration>();
-	s1.options.all_events = false;
 	auto result = falco::app::actions::configure_interesting_sets(s1);
 	ASSERT_FALSE(result.success);
 	ASSERT_NE(result.errstr, "");
@@ -199,9 +198,8 @@ TEST_F(test_falco_engine, selection_not_allevents) {
 	falco::app::state s2;
 	// run app action with fake engine and without the `-A` option
 	s2.engine = m_engine;
-	s2.options.all_events = false;
+	s2.config->m_base_syscalls_all = false;
 
-	ASSERT_EQ(s2.options.all_events, false);
 	auto result = falco::app::actions::configure_interesting_sets(s2);
 	ASSERT_TRUE(result.success);
 	ASSERT_EQ(result.errstr, "");
@@ -256,7 +254,8 @@ TEST_F(test_falco_engine, selection_allevents) {
 	falco::app::state s3;
 	// run app action with fake engine and with the `-A` option
 	s3.engine = m_engine;
-	s3.options.all_events = true;
+	s3.config->m_base_syscalls_all = true;
+
 	auto result = falco::app::actions::configure_interesting_sets(s3);
 	ASSERT_TRUE(result.success);
 	ASSERT_EQ(result.errstr, "");
@@ -299,8 +298,8 @@ TEST_F(test_falco_engine, selection_allevents) {
 
 TEST_F(test_falco_engine, selection_generic_evts) {
 	falco::app::state s4;
-	// run app action with fake engine and without the `-A` option
-	s4.options.all_events = false;
+	// run app action with fake engine and without the `m_base_syscalls_all` option
+
 	auto filters = s_sample_filters;
 	filters.insert(s_sample_generic_filters.begin(), s_sample_generic_filters.end());
 	load_rules(ruleset_from_filters(filters), "dummy_ruleset.yaml");
@@ -347,8 +346,7 @@ TEST_F(test_falco_engine, selection_custom_base_set) {
 	load_rules(ruleset_from_filters(s_sample_filters), "dummy_ruleset.yaml");
 
 	falco::app::state s5;
-	// run app action with fake engine and without the `-A` option
-	s5.options.all_events = true;
+	s5.config->m_base_syscalls_all = true;
 	s5.engine = m_engine;
 	auto default_base_set = libsinsp::events::sinsp_state_sc_set();
 
@@ -425,8 +423,8 @@ TEST_F(test_falco_engine, selection_custom_base_set) {
 	expected_sc_names.erase("accept4");
 	ASSERT_NAMES_EQ(selected_sc_names, expected_sc_names);
 
-	// non-empty custom base set (positive, without -A)
-	s5.options.all_events = false;
+	// non-empty custom base set (positive, disable all syscalls)
+	s5.config->m_base_syscalls_all = false;
 	s5.config->m_base_syscalls_custom_set = {"read"};
 	result = falco::app::actions::configure_interesting_sets(s5);
 	ASSERT_TRUE(result.success);
@@ -453,8 +451,8 @@ TEST_F(test_falco_engine, selection_custom_base_set_repair) {
 	load_rules(ruleset_from_filters(s_sample_filters), "dummy_ruleset.yaml");
 
 	falco::app::state s6;
-	// run app action with fake engine and without the `-A` option
-	s6.options.all_events = false;
+	// run app action with fake engine and without the `all syscalls` option
+	s6.config->m_base_syscalls_all = false;
 	s6.engine = m_engine;
 
 	// note: here we use file syscalls (e.g. open, openat) and have a custom
@@ -494,8 +492,8 @@ TEST_F(test_falco_engine, selection_empty_custom_base_set_repair) {
 	load_rules(ruleset_from_filters(s_sample_filters), "dummy_ruleset.yaml");
 
 	falco::app::state s7;
-	// run app action with fake engine and with the `-A` option
-	s7.options.all_events = true;
+	// run app action with fake engine and with the `all syscalls` option
+	s7.config->m_base_syscalls_all = true;
 	s7.engine = m_engine;
 
 	// simulate empty custom set but repair option set.

--- a/userspace/falco/app/actions/configure_interesting_sets.cpp
+++ b/userspace/falco/app/actions/configure_interesting_sets.cpp
@@ -200,22 +200,12 @@ static void select_event_set(falco::app::state& s,
 		                          concat_set_in_order(non_rules_sc_set_names) + "\n");
 	}
 
-	/* base_syscall.all / -A flag behavior:
+	/* base_syscall.all behavior:
 	 * (1) default: all syscalls in rules included, sinsp state enforcement
 	       without high volume syscalls
 	 * (2) set: all syscalls in rules included, sinsp state enforcement
 	       and allowing high volume syscalls */
-	bool all_events = false;
-	if(s.options.all_events) {
-		falco_logger::log(falco_logger::level::WARNING,
-		                  "The -A option is deprecated and will be removed. Use -o "
-		                  "base_syscalls.all=true instead.");
-		all_events = true;
-	}
-	if(s.config->m_base_syscalls_all) {
-		all_events = true;
-	}
-	if(!(s.options.all_events || s.config->m_base_syscalls_all)) {
+	if(!s.config->m_base_syscalls_all) {
 		auto ignored_sc_set = falco::app::ignored_sc_set();
 		auto erased_sc_set = s.selected_sc_set.intersect(ignored_sc_set);
 		s.selected_sc_set = s.selected_sc_set.diff(ignored_sc_set);

--- a/userspace/falco/app/actions/init_inspectors.cpp
+++ b/userspace/falco/app/actions/init_inspectors.cpp
@@ -27,12 +27,6 @@ using namespace falco::app::actions;
 
 static void init_syscall_inspector(falco::app::state& s, std::shared_ptr<sinsp> inspector) {
 	sinsp_evt::param_fmt event_buffer_format = sinsp_evt::PF_NORMAL;
-	if(s.options.print_base64) {
-		falco_logger::log(falco_logger::level::WARNING,
-		                  "The -b/--print-base64 option is deprecated and will be removed. Use -o "
-		                  "buffer_format_base64=true instead.");
-		event_buffer_format = sinsp_evt::PF_BASE64;
-	}
 	if(s.config->m_buffer_format_base64) {
 		event_buffer_format = sinsp_evt::PF_BASE64;
 	}
@@ -86,16 +80,9 @@ static void init_syscall_inspector(falco::app::state& s, std::shared_ptr<sinsp> 
 
 	//
 	// If required, set the snaplen.
-	// In case both config and CLI options are specified, CLI takes precedence.
 	//
 	if(s.config->m_falco_libs_snaplen != 0) {
 		inspector->set_snaplen(s.config->m_falco_libs_snaplen);
-	}
-	if(s.options.snaplen != 0) {
-		inspector->set_snaplen(s.options.snaplen);
-		falco_logger::log(falco_logger::level::WARNING,
-		                  "The -S/--snaplen option is deprecated and will be removed. Use -o "
-		                  "falco_libs.snaplen=<len> instead.");
 	}
 
 	if(s.is_driver_drop_failed_exit_enabled()) {

--- a/userspace/falco/app/options.cpp
+++ b/userspace/falco/app/options.cpp
@@ -73,10 +73,6 @@ bool options::parse(int argc, char **argv, std::string &errstr) {
 		}
 	}
 
-	if(m_cmdline_parsed.count("b") > 0) {
-		print_base64 = true;
-	}
-
 	if(m_cmdline_parsed.count("r") > 0) {
 		for(auto &path : m_cmdline_parsed["r"].as<std::vector<std::string>>()) {
 			rules_filenames.push_back(path);
@@ -104,15 +100,13 @@ void options::define(cxxopts::Options& opts)
 #endif
 		("config-schema",            "Print the config json schema and exit.", cxxopts::value(print_config_schema)->default_value("false"))
 		("rule-schema",              "Print the rule json schema and exit.", cxxopts::value(print_rule_schema)->default_value("false"))
-		("A",                        "DEPRECATED: use -o base_syscalls.all=true instead. Monitor all events supported by Falco and defined in rules and configs. Some events are ignored by default when -A is not specified (the -i option lists these events ignored). Using -A can impact performance. This option has no effect when reproducing events from a capture file.", cxxopts::value(all_events)->default_value("false"))
-		("b,print-base64",           "DEPRECATED: use -o buffer_format_base64=true. Print data buffers in base64. This is useful for encoding binary data that needs to be used over media designed to consume this format.")
 		("disable-source",           "Turn off a specific <event_source>. By default, all loaded sources get enabled. Available sources are 'syscall' plus all sources defined by loaded plugins supporting the event sourcing capability. This option can be passed multiple times, but turning off all event sources simultaneously is not permitted. This option can not be mixed with --enable-source. This option has no effect when reproducing events from a capture file.", cxxopts::value(disable_sources), "<event_source>")
 		("dry-run",                  "Run Falco without processing events. It can help check that the configuration and rules do not have any errors.", cxxopts::value(dry_run)->default_value("false"))
 		("enable-source",            "Enable a specific <event_source>. By default, all loaded sources get enabled. Available sources are 'syscall' plus all sources defined by loaded plugins supporting the event sourcing capability. This option can be passed multiple times. When using this option, only the event sources specified by it will be enabled. This option can not be mixed with --disable-source. This option has no effect when reproducing events from a capture file.", cxxopts::value(enable_sources), "<event_source>")
 #ifdef HAS_GVISOR
 		("gvisor-generate-config",   "Generate a configuration file that can be used for gVisor and exit. See --gvisor-config for more details.", cxxopts::value<std::string>(gvisor_generate_config_with_socket)->implicit_value("/run/falco/gvisor.sock"), "<socket_path>")
 #endif
-		("i",                        "Print those events that are ignored by default for performance reasons and exit. See -A for more details.", cxxopts::value(print_ignored_events)->default_value("false"))
+		("i",                        "Print those events that are ignored by default for performance reasons and exit.", cxxopts::value(print_ignored_events)->default_value("false"))
 		("L",                        "Show the name and description of all rules and exit. If json_output is set to true, it prints details about all rules, macros, and lists in JSON format.", cxxopts::value(describe_all_rules)->default_value("false"))
 		("l",                        "Show the name and description of the rule specified <rule> and exit. If json_output is set to true, it prints details about the rule in JSON format.", cxxopts::value(describe_rule), "<rule>")
 		("list",                     "List all defined fields and exit. If <source> is provided, only list those fields for the source <source>. Current values for <source> are \"syscall\" or any source from a configured plugin with event sourcing capability.", cxxopts::value(list_source_fields)->implicit_value(""), "<source>")
@@ -126,7 +120,6 @@ void options::define(cxxopts::Options& opts)
 		("p,print",                  "Print (or replace) additional information in the rule's output.\nUse -pc or -pcontainer to append container details to syscall events.\nUse -pk or -pkubernetes to add both container and Kubernetes details to syscall events.\nIf using gVisor, choose -pcg or -pkg variants (or -pcontainer-gvisor and -pkubernetes-gvisor, respectively).\nIf a syscall rule's output contains %container.info, it will be replaced with the corresponding details. Otherwise, these details will be directly appended to the rule's output.\nAlternatively, use -p <output_format> for a custom format. In this case, the given <output_format> will be appended to the rule's output without any replacement to all events, including plugin events.", cxxopts::value(print_additional), "<output_format>")
 		("P,pidfile",                "Write PID to specified <pid_file> path. By default, no PID file is created.", cxxopts::value(pidfilename)->default_value(""), "<pid_file>")
 		("r",                        "Rules file or directory to be loaded. This option can be passed multiple times. Falco defaults to the values in the configuration file when this option is not specified.", cxxopts::value<std::vector<std::string>>(), "<rules_file>")
-		("S,snaplen",                "DEPRECATED: use -o falco_libs.snaplen=<len> instead. Collect only the first <len> bytes of each I/O buffer for 'syscall' events. By default, the first 80 bytes are collected by the driver and sent to the user space for processing. Use this option with caution since it can have a strong performance impact.", cxxopts::value(snaplen)->default_value("0"), "<len>")
 		("support",                  "Print support information, including version, rules files used, loaded configuration, etc., and exit. The output is in JSON format.", cxxopts::value(print_support)->default_value("false"))
 		("U,unbuffered",             "Turn off output buffering for configured outputs. This causes every single line emitted by Falco to be flushed, which generates higher CPU usage but is useful when piping those outputs into another process or a script.", cxxopts::value(unbuffered_outputs)->default_value("false"))
 		("V,validate",               "Read the contents of the specified <rules_file> file(s), validate the loaded rules, and exit. This option can be passed multiple times to validate multiple files.", cxxopts::value(validate_rules_filenames), "<rules_file>")

--- a/userspace/falco/app/options.h
+++ b/userspace/falco/app/options.h
@@ -45,9 +45,7 @@ public:
 	bool print_config_schema = false;
 	bool print_rule_schema = false;
 	std::string conf_filename;
-	bool all_events = false;
 	sinsp_evt::param_fmt event_buffer_format = sinsp_evt::PF_NORMAL;
-	bool print_base64 = false;
 	std::vector<std::string> disable_sources;
 	std::vector<std::string> enable_sources;
 	std::string gvisor_generate_config_with_socket;
@@ -67,7 +65,6 @@ public:
 	std::string pidfilename;
 	// Rules list as passed by the user, via cmdline option '-r'
 	std::list<std::string> rules_filenames;
-	uint64_t snaplen = 0;
 	bool print_support = false;
 	bool unbuffered_outputs = false;
 	std::vector<std::string> validate_rules_filenames;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

0.40.0 deprecated 3 CLI flags: https://falco.org/blog/falco-0-40-0/#deprecations
Drop them for 0.41.0

Refs #3497 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
cleanup(userspace/falco)!: drop deprecated in 0.40.0 CLI flags.
```
