### PR TITLE
cleanup(falco.yaml): drop `verbosity` from container plugin init config.

### DIFF
--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -35,9 +35,9 @@ else()
 	# FALCOSECURITY_LIBS_VERSION. In case you want to test against another driver version (or
 	# branch, or commit) just pass the variable - ie., `cmake -DDRIVER_VERSION=dev ..`
 	if(NOT DRIVER_VERSION)
-		set(DRIVER_VERSION "9ef8acd0b51ec76e0c81fd11b8252dd95ae7ce3a")
+		set(DRIVER_VERSION "eff27490e7d5259652047c9edc823049fe4fa876")
 		set(DRIVER_CHECKSUM
-			"SHA256=d5fe7d098ea58211d016514902e003f4ab8be4b10d89b254fbc86c9e659175da"
+			"SHA256=f2b7f7e7611c23b72aa2beb4550ba3fd219ebaa335e06534d89f3bc4f3f791f1"
 		)
 	endif()
 

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -42,9 +42,9 @@ else()
 	# version (or branch, or commit) just pass the variable - ie., `cmake
 	# -DFALCOSECURITY_LIBS_VERSION=dev ..`
 	if(NOT FALCOSECURITY_LIBS_VERSION)
-		set(FALCOSECURITY_LIBS_VERSION "9ef8acd0b51ec76e0c81fd11b8252dd95ae7ce3a")
+		set(FALCOSECURITY_LIBS_VERSION "eff27490e7d5259652047c9edc823049fe4fa876")
 		set(FALCOSECURITY_LIBS_CHECKSUM
-			"SHA256=d5fe7d098ea58211d016514902e003f4ab8be4b10d89b254fbc86c9e659175da"
+			"SHA256=f2b7f7e7611c23b72aa2beb4550ba3fd219ebaa335e06534d89f3bc4f3f791f1"
 		)
 	endif()
 

--- a/falco.yaml
+++ b/falco.yaml
@@ -905,8 +905,8 @@ log_level: info
 # library specifically, providing more granular control over the logging
 # behavior of the underlying components used by Falco. Only logs of a certain
 # severity level or higher will be emitted. Supported levels: "fatal",
-# "critical", "error", "warning", "notice", "info", "debug", "trace". It is not
-# recommended to use "debug" and "trace" for production use.
+# "critical", "error", "warning", "notice", "info", "debug", "trace".
+#  It is not recommended to use "debug" and "trace" for production use.
 libs_logger:
   enabled: true
   severity: info

--- a/falco.yaml
+++ b/falco.yaml
@@ -470,7 +470,6 @@ plugins:
     # For a summary of config option, see https://github.com/FedeDP/container_plugin?tab=readme-ov-file#configuration
     library_path: libcontainer.so
     init_config:
-      verbosity: warning
       label_max_len: 100
       with_size: false
 # We use default config values for engine key.

--- a/falco.yaml
+++ b/falco.yaml
@@ -906,10 +906,10 @@ log_level: info
 # behavior of the underlying components used by Falco. Only logs of a certain
 # severity level or higher will be emitted. Supported levels: "fatal",
 # "critical", "error", "warning", "notice", "info", "debug", "trace". It is not
-# recommended for production use.
+# recommended to use "debug" and "trace" for production use.
 libs_logger:
-  enabled: false
-  severity: debug
+  enabled: true
+  severity: info
 
 
 #################################################################################

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -213,8 +213,8 @@ void falco_configuration::init_logger() {
 	m_log_level = m_config.get_scalar<std::string>("log_level", "info");
 	falco_logger::set_level(m_log_level);
 	falco_logger::set_sinsp_logging(
-	        m_config.get_scalar<bool>("libs_logger.enabled", false),
-	        m_config.get_scalar<std::string>("libs_logger.severity", "debug"),
+	        m_config.get_scalar<bool>("libs_logger.enabled", true),
+	        m_config.get_scalar<std::string>("libs_logger.severity", "info"),
 	        "[libs]: ");
 	falco_logger::log_stderr = m_config.get_scalar<bool>("log_stderr", false);
 	falco_logger::log_syslog = m_config.get_scalar<bool>("log_syslog", true);


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Next plugin release will make use of libs logger instead of spdlog; this means we don't need a different verbosity flag, we will just use `libs_logger.severity`.

Also, this PR aims at enabling `libs_logger` by default, with `info` level. This way, plugins that use the provided logger will see their messages logged by default.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
chore(falco.yaml): enable libs_logger by default with info level
```
