### PR TITLE
fix(ci): properly install rpm `systemd-rpm-macro` package on building packages pipeline

### DIFF
--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -59,7 +59,12 @@ jobs:
       # Always install deps before invoking checkout action, to properly perform a full clone.
       - name: Install build deps
         run: |
-          sudo apt update && sudo apt install -y --no-install-recommends ca-certificates cmake curl wget build-essential git pkg-config autoconf automake libtool m4 rpm
+          sudo apt update && sudo apt install -y --no-install-recommends ca-certificates cmake curl wget build-essential git pkg-config autoconf automake libtool m4 rpm alien
+
+      - name: Install systemd rpm macros
+        run: |
+          wget https://rpmfind.net/linux/fedora/linux/development/rawhide/Everything/x86_64/os/Packages/s/systemd-rpm-macros-257.4-3.fc43.noarch.rpm
+          sudo alien -d -i systemd-rpm-macros-257.4-3.fc43.noarch.rpm
 
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area CI

**What this PR does / why we need it**:

We need it because rpm pre/post install/remove scripts are evaluated at rpm package building time.
Bug introduced when porting the CI to zig: https://github.com/falcosecurity/falco/pull/3307

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #3503 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(ci): properly install rpm systemd-rpm-macro package on building packages pipeline
```
