### PR TITLE
fix(userspace/falco): fix outputs_http timeout

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -753,6 +753,8 @@ http_output:
   echo: false
   compress_uploads: false
   keep_alive: false
+  # Maximum consecutive timeouts of libcurl to ignore
+  max_consecutive_timeouts: 5
 
 # [Stable] `program_output`
 #

--- a/userspace/falco/config_json_schema.h
+++ b/userspace/falco/config_json_schema.h
@@ -518,7 +518,7 @@ const char config_schema_string[] = LONG_STRING_CONST(
                 "keep_alive": {
                     "type": "boolean"
                 },
-                "max_consecutive_timeouts:" {
+                "max_consecutive_timeouts": {
                     "type": "integer"
                 }
             },

--- a/userspace/falco/config_json_schema.h
+++ b/userspace/falco/config_json_schema.h
@@ -517,6 +517,9 @@ const char config_schema_string[] = LONG_STRING_CONST(
                 },
                 "keep_alive": {
                     "type": "boolean"
+                },
+                "max_consecutive_timeouts:" {
+                    "type": "integer"
                 }
             },
             "minProperties": 1,

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -450,6 +450,11 @@ void falco_configuration::load_yaml(const std::string &config_name) {
 		keep_alive = m_config.get_scalar<bool>("http_output.keep_alive", false);
 		http_output.options["keep_alive"] = keep_alive ? std::string("true") : std::string("false");
 
+		uint8_t max_consecutive_timeouts;
+		max_consecutive_timeouts =
+		        m_config.get_scalar<uint8_t>("http_output.max_consecutive_timeouts", 5);
+		http_output.options["max_consecutive_timeouts"] = std::to_string(max_consecutive_timeouts);
+
 		m_outputs.push_back(http_output);
 	}
 

--- a/userspace/falco/outputs_http.cpp
+++ b/userspace/falco/outputs_http.cpp
@@ -37,7 +37,7 @@ bool falco::outputs::output_http::init(const config &oc,
 	m_curl = nullptr;
 	m_http_headers = nullptr;
 	m_max_consecutive_timeouts =
-	        static_cast<uint8_t>(std::stoi(m_oc.options["max_consecutive_timeouts"]));
+	        static_cast<uint8_t>(std::stoi(m_oc.options["max_consecutive_timeouts"]) & 0xFF);
 	CURLcode res = CURLE_FAILED_INIT;
 
 	m_curl = curl_easy_init();
@@ -105,7 +105,7 @@ bool falco::outputs::output_http::init(const config &oc,
 
 void falco::outputs::output_http::output(const message *msg) {
 	CURLcode res = curl_easy_setopt(m_curl, CURLOPT_POSTFIELDS, msg->msg.c_str());
-	uint32_t curl_easy_platform_calls = 0;
+	uint8_t curl_easy_platform_calls = 0;
 
 	if(res == CURLE_OK) {
 		do {

--- a/userspace/falco/outputs_http.h
+++ b/userspace/falco/outputs_http.h
@@ -36,6 +36,7 @@ class output_http : public abstract_output {
 private:
 	CURL *m_curl;
 	struct curl_slist *m_http_headers;
+	uint8_t m_max_consecutive_timeouts;
 };
 
 }  // namespace outputs


### PR DESCRIPTION
libcurl timeout prevent to send alert through http keep trying to send the alert

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

this PR  ignore http_output libcurl timeout when network is not available, 
it allows to send the alert when network is back and to not lost it

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #3522

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
