### PR TITLE
update(userspace/engine): relax validation for `values` in `exceptions`

### DIFF
--- a/userspace/engine/rule_json_schema.h
+++ b/userspace/engine/rule_json_schema.h
@@ -119,8 +119,7 @@ const char rule_schema_string[] = LONG_STRING_CONST(
                 "values": {}
             },
             "required": [
-                "name",
-                "values"
+                "name"
             ],
             "title": "Exception"
         },


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Not really a bug, still.
Defining `exceptions` with empty `values` is a legitimate use case since the values can be added to another rules file. Even when values are not populated elsewhere, Falco can work without issues; that's the reason why the `values` field is not required. With this change, we avoid emitting useless validation warnings in situations where exceptions are just defined but not actually used because values are not being provided.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.41.0

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
update: empty `values` in `exceptions` won't emit a warning anymore
```
