### PR TITLE
update(metrics): improve restart/hot_reload conditions inspection

### DIFF
--- a/userspace/falco/app/actions/load_config.cpp
+++ b/userspace/falco/app/actions/load_config.cpp
@@ -66,6 +66,10 @@ falco::app::run_result falco::app::actions::load_config(const falco::app::state&
 		}
 	}
 
+	s.config->m_falco_restart_ts = (int64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+	                                       std::chrono::system_clock::now().time_since_epoch())
+	                                       .count();
+
 	s.config->m_buffered_outputs = !s.options.unbuffered_outputs;
 
 	return apply_deprecated_options(s);

--- a/userspace/falco/app/actions/load_config.cpp
+++ b/userspace/falco/app/actions/load_config.cpp
@@ -66,9 +66,9 @@ falco::app::run_result falco::app::actions::load_config(const falco::app::state&
 		}
 	}
 
-	s.config->m_falco_restart_ts = (int64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
-	                                       std::chrono::system_clock::now().time_since_epoch())
-	                                       .count();
+	s.config->m_falco_reload_ts = (int64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+	                                      std::chrono::system_clock::now().time_since_epoch())
+	                                      .count();
 
 	s.config->m_buffered_outputs = !s.options.unbuffered_outputs;
 

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -161,7 +161,7 @@ public:
 
 	bool m_watch_config_files;
 	bool m_buffered_outputs;
-	int64_t m_falco_restart_ts;
+	int64_t m_falco_reload_ts;
 	size_t m_outputs_queue_capacity;
 	bool m_time_format_iso_8601;
 	bool m_buffer_format_base64;

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -161,7 +161,6 @@ public:
 
 	bool m_watch_config_files;
 	bool m_buffered_outputs;
-	int64_t m_falco_reload_ts;
 	size_t m_outputs_queue_capacity;
 	bool m_time_format_iso_8601;
 	bool m_buffer_format_base64;
@@ -215,7 +214,15 @@ public:
 	gvisor_config m_gvisor = {};
 
 	yaml_helper m_config;
+
+	//
+	// Runtime-Generated values (not user-configurable)
+	//
+
+	// JSON schema generated from a hardcoded string
 	nlohmann::json m_config_schema;
+	// Timestamp of most recent configuration reload
+	int64_t m_falco_reload_ts;
 
 private:
 	void merge_config_files(const std::string& config_name, config_loaded_res& res);

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -222,7 +222,7 @@ public:
 	// JSON schema generated from a hardcoded string
 	nlohmann::json m_config_schema;
 	// Timestamp of most recent configuration reload
-	int64_t m_falco_reload_ts;
+	int64_t m_falco_reload_ts{0};
 
 private:
 	void merge_config_files(const std::string& config_name, config_loaded_res& res);

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -161,6 +161,7 @@ public:
 
 	bool m_watch_config_files;
 	bool m_buffered_outputs;
+	int64_t m_falco_restart_ts;
 	size_t m_outputs_queue_capacity;
 	bool m_time_format_iso_8601;
 	bool m_buffer_format_base64;

--- a/userspace/falco/falco_metrics.cpp
+++ b/userspace/falco/falco_metrics.cpp
@@ -144,12 +144,12 @@ std::string falco_metrics::to_text(const falco::app::state& state) {
 		std::vector<metrics_v2> additional_wrapper_metrics;
 
 		additional_wrapper_metrics.emplace_back(libs::metrics::libsinsp_metrics::new_metric(
-		        "restart_ts",
+		        "reload_ts",
 		        METRICS_V2_MISC,
 		        METRIC_VALUE_TYPE_S64,
 		        METRIC_VALUE_UNIT_TIME_TIMESTAMP_NS,
 		        METRIC_VALUE_METRIC_TYPE_NON_MONOTONIC_CURRENT,
-		        state.config->m_falco_restart_ts));
+		        state.config->m_falco_reload_ts));
 
 		if(agent_info) {
 			additional_wrapper_metrics.emplace_back(libs::metrics::libsinsp_metrics::new_metric(

--- a/userspace/falco/falco_metrics.cpp
+++ b/userspace/falco/falco_metrics.cpp
@@ -143,6 +143,14 @@ std::string falco_metrics::to_text(const falco::app::state& state) {
 		}
 		std::vector<metrics_v2> additional_wrapper_metrics;
 
+		additional_wrapper_metrics.emplace_back(libs::metrics::libsinsp_metrics::new_metric(
+		        "restart_ts",
+		        METRICS_V2_MISC,
+		        METRIC_VALUE_TYPE_S64,
+		        METRIC_VALUE_UNIT_TIME_TIMESTAMP_NS,
+		        METRIC_VALUE_METRIC_TYPE_NON_MONOTONIC_CURRENT,
+		        state.config->m_falco_restart_ts));
+
 		if(agent_info) {
 			additional_wrapper_metrics.emplace_back(libs::metrics::libsinsp_metrics::new_metric(
 			        "start_ts",

--- a/userspace/falco/stats_writer.cpp
+++ b/userspace/falco/stats_writer.cpp
@@ -354,6 +354,7 @@ void stats_writer::collector::get_metrics_output_fields_wrapper(
 	/* Wrapper fields useful for statistical analyses and attributions. Always enabled. */
 	output_fields["evt.time"] =
 	        now; /* Some ETLs may prefer a consistent timestamp within output_fields. */
+	output_fields["falco.restart_ts"] = m_writer->m_config->m_falco_restart_ts;
 	output_fields["falco.version"] = FALCO_VERSION;
 	if(agent_info) {
 		output_fields["falco.start_ts"] = agent_info->start_ts_epoch;

--- a/userspace/falco/stats_writer.cpp
+++ b/userspace/falco/stats_writer.cpp
@@ -354,7 +354,7 @@ void stats_writer::collector::get_metrics_output_fields_wrapper(
 	/* Wrapper fields useful for statistical analyses and attributions. Always enabled. */
 	output_fields["evt.time"] =
 	        now; /* Some ETLs may prefer a consistent timestamp within output_fields. */
-	output_fields["falco.restart_ts"] = m_writer->m_config->m_falco_restart_ts;
+	output_fields["falco.reload_ts"] = m_writer->m_config->m_falco_reload_ts;
 	output_fields["falco.version"] = FALCO_VERSION;
 	if(agent_info) {
 		output_fields["falco.start_ts"] = agent_info->start_ts_epoch;

--- a/userspace/falco/stats_writer.cpp
+++ b/userspace/falco/stats_writer.cpp
@@ -246,7 +246,7 @@ void stats_writer::worker() noexcept {
 
 		// this helps waiting for the first tick
 		tick = stats_writer::get_ticker();
-		if(first_tick != tick) {
+		if(m_first_run || first_tick != tick) {
 			if(last_tick != tick) {
 				m_total_samples++;
 			}
@@ -274,6 +274,7 @@ void stats_writer::worker() noexcept {
 				                  "stats_writer (worker): " + std::string(e.what()) + "\n");
 			}
 		}
+		m_first_run = false;
 	}
 }
 
@@ -638,7 +639,7 @@ void stats_writer::collector::collect(const std::shared_ptr<sinsp>& inspector,
 #endif
 		/* Collect stats / metrics once per ticker period. */
 		auto tick = stats_writer::get_ticker();
-		if(tick != m_last_tick) {
+		if(m_first_run || tick != m_last_tick) {
 			m_last_tick = tick;
 			auto now = std::chrono::duration_cast<std::chrono::nanoseconds>(
 			                   std::chrono::system_clock::now().time_since_epoch())
@@ -659,7 +660,10 @@ void stats_writer::collector::collect(const std::shared_ptr<sinsp>& inspector,
 			                                  num_evts,
 			                                  now,
 			                                  stats_snapshot_time_delta_sec);
-			get_metrics_output_fields_additional(output_fields, stats_snapshot_time_delta_sec);
+			if(!m_first_run) {
+				get_metrics_output_fields_additional(output_fields, stats_snapshot_time_delta_sec);
+			}
+			m_first_run = false;
 
 			/* Send message in the queue */
 			stats_writer::msg msg;

--- a/userspace/falco/stats_writer.h
+++ b/userspace/falco/stats_writer.h
@@ -82,8 +82,9 @@ public:
 		                                          double stats_snapshot_time_delta_sec);
 
 		std::shared_ptr<stats_writer> m_writer;
-		bool m_first_run = true;
-		stats_writer::ticker_t m_last_tick = 0;
+		// Init m_last_tick w/ invalid value to enable metrics logging immediately after
+		// startup/reload
+		stats_writer::ticker_t m_last_tick = -1;
 		uint64_t m_last_now = 0;
 		uint64_t m_last_n_evts = 0;
 		uint64_t m_last_n_drops = 0;
@@ -145,7 +146,6 @@ private:
 	inline void push(const stats_writer::msg& m);
 
 	bool m_initialized = false;
-	bool m_first_run = true;
 	uint64_t m_total_samples = 0;
 	std::thread m_worker;
 	std::ofstream m_file_output;

--- a/userspace/falco/stats_writer.h
+++ b/userspace/falco/stats_writer.h
@@ -84,7 +84,7 @@ public:
 		std::shared_ptr<stats_writer> m_writer;
 		// Init m_last_tick w/ invalid value to enable metrics logging immediately after
 		// startup/reload
-		stats_writer::ticker_t m_last_tick = -1;
+		stats_writer::ticker_t m_last_tick = std::numeric_limits<ticker_t>::max();
 		uint64_t m_last_now = 0;
 		uint64_t m_last_n_evts = 0;
 		uint64_t m_last_n_drops = 0;

--- a/userspace/falco/stats_writer.h
+++ b/userspace/falco/stats_writer.h
@@ -82,6 +82,7 @@ public:
 		                                          double stats_snapshot_time_delta_sec);
 
 		std::shared_ptr<stats_writer> m_writer;
+		bool m_first_run = true;
 		stats_writer::ticker_t m_last_tick = 0;
 		uint64_t m_last_now = 0;
 		uint64_t m_last_n_evts = 0;
@@ -144,6 +145,7 @@ private:
 	inline void push(const stats_writer::msg& m);
 
 	bool m_initialized = false;
+	bool m_first_run = true;
 	uint64_t m_total_samples = 0;
 	std::thread m_worker;
 	std::ofstream m_file_output;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Proposing the following minor improvements:
- Introduce an immediate initial metrics msg (output_rule or output_file) upon start/restart/hot_reload -> this may be useful to directly inspect deployment convergence and eliminates the need to wait until the first two ticks happened
- Introduce a restart ts metric for all metrics output channels (including prometheus) -> this may be useful to statistically inspect potential issues wrt falco crashing and restarting and/or whether the hot config reload was successful and similar conditions


**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
update(metrics): improve restart/hot_reload conditions inspection
```
