### PR TITLE
fix(userspace/falco): when collecting metrics for stats_writer, create a `libs_metrics_collector` for each source

### DIFF
--- a/userspace/falco/app/actions/process_events.cpp
+++ b/userspace/falco/app/actions/process_events.cpp
@@ -235,12 +235,6 @@ static falco::app::run_result do_inspect(
 			}
 
 			// for capture mode, the source name can change at every event
-			// TODO: This may currently cause issues for multiple event sources. We are deferring
-			// the fix to Falco 0.42.0.
-			// For multiple event sources, it generates `n` metrics logs per source at a time, as
-			// expected, with the engine_name correctly reflected. However, the order may interfere,
-			// as the correct inspector for the syscalls event source seems to never get passed,
-			// resulting in most metrics being missing.
 			stats_collector.collect(inspector,
 			                        inspector->event_sources()[source_engine_idx],
 			                        num_evts);

--- a/userspace/falco/stats_writer.h
+++ b/userspace/falco/stats_writer.h
@@ -79,7 +79,8 @@ public:
 		   fields.
 		*/
 		void get_metrics_output_fields_additional(nlohmann::json& output_fields,
-		                                          double stats_snapshot_time_delta_sec);
+		                                          double stats_snapshot_time_delta_sec,
+		                                          const std::string& src);
 
 		std::shared_ptr<stats_writer> m_writer;
 		// Init m_last_tick w/ invalid value to enable metrics logging immediately after
@@ -153,7 +154,9 @@ private:
 	tbb::concurrent_bounded_queue<stats_writer::msg> m_queue;
 #endif
 #if defined(__linux__) and !defined(MINIMAL_BUILD) and !defined(__EMSCRIPTEN__)
-	std::unique_ptr<libs::metrics::libs_metrics_collector> m_libs_metrics_collector;
+	// Per source map of libs metrics collectors
+	std::unordered_map<std::string, std::unique_ptr<libs::metrics::libs_metrics_collector>>
+	        m_libs_metrics_collectors;
 	std::unique_ptr<libs::metrics::output_rule_metrics_converter> m_output_rule_metrics_converter;
 #endif
 	std::shared_ptr<falco_outputs> m_outputs;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

In case multiple sources are enabled, each source has its own `libs_metrics_collector` with correct flags, so that it can retrieve all metrics.

**Which issue(s) this PR fixes**:

Fixes #3583

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(userspace/falco): when collecting metrics for stats_writer, create a `libs_metrics_collector` for each source
```
