### PR TITLE
fix(userspace/falco): only enable prometheus metrics once all inspectors have been opened

### DIFF
--- a/userspace/falco/app/actions/process_events.cpp
+++ b/userspace/falco/app/actions/process_events.cpp
@@ -491,6 +491,9 @@ falco::app::run_result falco::app::actions::process_events(falco::app::state& s)
 				}
 
 				if(s.enabled_sources.size() == 1) {
+					// Since the inspector is now opened, we can enable prometheus metrics
+					s.webserver.enable_prometheus_metrics(s);
+
 					// optimization: with only one source we don't spawn additional threads
 					process_inspector_events(s,
 					                         src_info->inspector,
@@ -519,6 +522,10 @@ falco::app::run_result falco::app::actions::process_events(falco::app::state& s)
 				ctx.sync->finish();
 				break;
 			}
+		}
+		if(s.enabled_sources.size() > 1) {
+			// Since all inspectors are now opened, we can enable prometheus metrics
+			s.webserver.enable_prometheus_metrics(s);
 		}
 
 		// wait for event processing to terminate for all sources

--- a/userspace/falco/webserver.cpp
+++ b/userspace/falco/webserver.cpp
@@ -58,12 +58,6 @@ void falco_webserver::start(const falco::app::state &state,
 		              res.set_content(versions_json_str, "application/json");
 	              });
 
-	if(state.config->m_metrics_enabled && webserver_config.m_prometheus_metrics_enabled) {
-		m_server->Get("/metrics", [&state](const httplib::Request &, httplib::Response &res) {
-			res.set_content(falco_metrics::to_text_prometheus(state),
-			                falco_metrics::content_type_prometheus);
-		});
-	}
 	// run server in a separate thread
 	if(!m_server->is_valid()) {
 		m_server = nullptr;
@@ -104,5 +98,15 @@ void falco_webserver::stop() {
 		}
 		m_server = nullptr;
 		m_running = false;
+	}
+}
+
+void falco_webserver::enable_prometheus_metrics(const falco::app::state &state) {
+	if(state.config->m_metrics_enabled &&
+	   state.config->m_webserver_config.m_prometheus_metrics_enabled) {
+		m_server->Get("/metrics", [&state](const httplib::Request &, httplib::Response &res) {
+			res.set_content(falco_metrics::to_text_prometheus(state),
+			                falco_metrics::content_type_prometheus);
+		});
 	}
 }

--- a/userspace/falco/webserver.h
+++ b/userspace/falco/webserver.h
@@ -40,6 +40,7 @@ public:
 	virtual void start(const falco::app::state& state,
 	                   const falco_configuration::webserver_config& webserver_config);
 	virtual void stop();
+	virtual void enable_prometheus_metrics(const falco::app::state& state);
 
 private:
 	bool m_running = false;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

There is a certain slice of team where prometheus metrics are exposed but the inspectors for all the enabled sources are not opened yet.
In this scenario, if eg: grafana scrapes our metrics, it would trigger a Falco crash because metrics need the inspectors to be fully inited and opened.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #3571

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(userspace/falco): only enable prometheus metrics once all inspectors have been opened
```
