### PR TITLE
new(falco): add json_container support and http_output authorization support

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -577,6 +577,18 @@ priority: debug
 # programs to process and consume the data. By default, this option is disabled.
 json_output: false
 
+# [Incubating] `json_container`
+#
+# When json_output is enabled, Falco will output alert messages and events as JSON. If
+# the json_container is also specified (optional), the event will be placed in that parent 
+# schema as defined in `falco_formats::format_json_container`
+# Supported json containers:
+# * `splunk_hec`: a container allowing direct posting to a Splunk HEC endpoint
+# * `slack_webhook`: a container allowing direct posting to a Slack webhook endpoint
+# * `generic_event_encoded`: a container that double encodes the json object as example container
+# * "" or omitted from config: the JSON object without any container is emmitted (default behaviour) 
+json_container: ""
+
 # [Stable] `json_include_output_property`
 #
 # When using JSON output in Falco, you have the option to include the "output"
@@ -782,6 +794,8 @@ http_output:
   keep_alive: false
   # Maximum consecutive timeouts of libcurl to ignore
   max_consecutive_timeouts: 5
+  # if provided, adds the value to the Authorization header in the POST
+  authorization: ""
 
 # [Stable] `program_output`
 #

--- a/userspace/engine/formats.h
+++ b/userspace/engine/formats.h
@@ -28,6 +28,7 @@ public:
 	              bool json_include_tags_property,
 	              bool json_include_message_property,
 	              bool json_include_output_fields_property,
+	              const std::string &json_container,
 	              bool time_format_iso_8601);
 	virtual ~falco_formats();
 
@@ -47,6 +48,7 @@ public:
 	std::map<std::string, std::string> get_field_values(sinsp_evt *evt,
 	                                                    const std::string &source,
 	                                                    const std::string &format) const;
+	std::string format_json_container(nlohmann::json &json, time_t evttime) const;
 
 protected:
 	std::shared_ptr<const falco_engine> m_falco_engine;
@@ -54,5 +56,6 @@ protected:
 	bool m_json_include_tags_property;
 	bool m_json_include_message_property;
 	bool m_json_include_output_fields_property;
+	const std::string m_json_container;
 	bool m_time_format_iso_8601;
 };

--- a/userspace/falco/app/actions/init_outputs.cpp
+++ b/userspace/falco/app/actions/init_outputs.cpp
@@ -65,6 +65,7 @@ falco::app::run_result falco::app::actions::init_outputs(falco::app::state& s) {
 	                                            s.config->m_json_include_tags_property,
 	                                            s.config->m_json_include_message_property,
 	                                            s.config->m_json_include_output_fields_property,
+	                                            s.config->m_json_container,
 	                                            s.config->m_output_timeout,
 	                                            s.config->m_buffered_outputs,
 	                                            s.config->m_outputs_queue_capacity,

--- a/userspace/falco/config_json_schema.h
+++ b/userspace/falco/config_json_schema.h
@@ -115,6 +115,9 @@ const char config_schema_string[] = LONG_STRING_CONST(
                 "json_output": {
                     "type": "boolean"
                 },
+                "json_container": {
+                    "type": "string"
+                },
                 "json_include_output_property": {
                     "type": "boolean"
                 },
@@ -543,6 +546,9 @@ const char config_schema_string[] = LONG_STRING_CONST(
                 },
                 "max_consecutive_timeouts": {
                     "type": "integer"
+                },
+                "authorization": {
+                    "type": "string"
                 }
             },
             "minProperties": 1,

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -70,6 +70,7 @@ falco_configuration::falco_configuration():
         m_json_include_tags_property(true),
         m_json_include_message_property(false),
         m_json_include_output_fields_property(true),
+        m_json_container(""),
         m_rule_matching(falco_common::rule_matching::FIRST),
         m_watch_config_files(true),
         m_buffered_outputs(false),
@@ -347,6 +348,7 @@ void falco_configuration::load_yaml(const std::string &config_name) {
 	        m_config.get_scalar<bool>("json_include_message_property", false);
 	m_json_include_output_fields_property =
 	        m_config.get_scalar<bool>("json_include_output_fields_property", true);
+	m_json_container = m_config.get_scalar<std::string>("json_container", "");
 
 	m_outputs.clear();
 	falco::outputs::config file_output;
@@ -461,6 +463,9 @@ void falco_configuration::load_yaml(const std::string &config_name) {
 		        m_config.get_scalar<uint8_t>("http_output.max_consecutive_timeouts", 5);
 		http_output.options["max_consecutive_timeouts"] = std::to_string(max_consecutive_timeouts);
 
+		std::string authorization;
+		authorization = m_config.get_scalar<std::string>("http_output.authorization", "");
+		http_output.options["authorization"] = authorization;
 		m_outputs.push_back(http_output);
 	}
 

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -153,6 +153,8 @@ public:
 	bool m_json_include_tags_property;
 	bool m_json_include_message_property;
 	bool m_json_include_output_fields_property;
+	std::string m_json_container;
+
 	std::string m_log_level;
 	std::vector<falco::outputs::config> m_outputs;
 

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -46,6 +46,7 @@ falco_outputs::falco_outputs(std::shared_ptr<falco_engine> engine,
                              bool json_include_tags_property,
                              bool json_include_message_property,
                              bool json_include_output_fields_property,
+                             const std::string &json_container,
                              uint32_t timeout,
                              bool buffered,
                              size_t outputs_queue_capacity,
@@ -56,6 +57,7 @@ falco_outputs::falco_outputs(std::shared_ptr<falco_engine> engine,
                                                   json_include_tags_property,
                                                   json_include_message_property,
                                                   json_include_output_fields_property,
+                                                  json_container,
                                                   time_format_iso_8601)),
         m_buffered(buffered),
         m_json_output(json_output),
@@ -201,7 +203,7 @@ void falco_outputs::handle_msg(uint64_t ts,
 		jmsg["hostname"] = m_hostname;
 		jmsg["source"] = s_internal_source;
 
-		cmsg.msg = jmsg.dump();
+		cmsg.msg = m_formats->format_json_container(jmsg, evttime);
 	} else {
 		std::string timestr;
 		bool first = true;

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -47,6 +47,7 @@ public:
 	              bool json_include_tags_property,
 	              bool json_include_message_property,
 	              bool json_include_output_fields_property,
+	              const std::string &json_container,
 	              uint32_t timeout,
 	              bool buffered,
 	              size_t outputs_queue_capacity,

--- a/userspace/falco/outputs_http.cpp
+++ b/userspace/falco/outputs_http.cpp
@@ -52,6 +52,11 @@ bool falco::outputs::output_http::init(const config &oc,
 	} else {
 		m_http_headers = curl_slist_append(m_http_headers, "Content-Type: text/plain");
 	}
+	if(!m_oc.options["authorization"].empty()) {
+		m_http_headers =
+		        curl_slist_append(m_http_headers,
+		                          ("Authorization: " + m_oc.options["authorization"]).c_str());
+	}
 	res = curl_easy_setopt(m_curl, CURLOPT_HTTPHEADER, m_http_headers);
 
 	// if the URL is quoted the quotes should be removed to satisfy libcurl expected format


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This is a simple POC for https://github.com/falcosecurity/falco/issues/3561
It implements the concept of `json_containers` and also a simple authorization header addon to support the header-based Splunk HEC posts. PR is just for initial discussion and likely needs to be split up into two PRs/commits

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes https://github.com/falcosecurity/falco/issues/3561

**Special notes for your reviewer**:

This is a simple POC of a `json_container` feature to allow enclosing a json output in a parent container to allow for more inline use of the http_output (and other) outputs directly with popular formats (splunk_hec, slack webhooks, etc). In lieu of introducing an entire templating engine, this may be simple enough to provide value to users without introducing too much complexity.

**Does this PR introduce a user-facing change?**:
It introduces a new configuration variable which will need documentation. It is not breaking and is implemented in an additive fashion.
<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note

```
