### PR TITLE
fix(restart_handler): disable if there is no work

### DIFF
--- a/userspace/falco/app/restart_handler.cpp
+++ b/userspace/falco/app/restart_handler.cpp
@@ -38,7 +38,9 @@ limitations under the License.
 
 falco::app::restart_handler::~restart_handler() {
 	stop();
-	close(m_inotify_fd);
+	if(m_inotify_fd != -1) {
+		close(m_inotify_fd);
+	}
 	m_inotify_fd = -1;
 }
 
@@ -48,6 +50,12 @@ void falco::app::restart_handler::trigger() {
 
 bool falco::app::restart_handler::start(std::string& err) {
 #ifdef __linux__
+	if(m_watched_files.empty() && m_watched_dirs.empty()) {
+		falco_logger::log(falco_logger::level::DEBUG,
+		                  "Refusing to start restart handler due to nothing to watch\n");
+		return true;
+	}
+
 	m_inotify_fd = inotify_init();
 	if(m_inotify_fd < 0) {
 		err = "could not initialize inotify handler";

--- a/userspace/falco/app/restart_handler.h
+++ b/userspace/falco/app/restart_handler.h
@@ -61,7 +61,7 @@ public:
 private:
 	void watcher_loop() noexcept;
 
-	int m_inotify_fd;
+	int m_inotify_fd = -1;
 	std::thread m_watcher;
 	std::atomic<bool> m_stop;
 	std::atomic<bool> m_forced;


### PR DESCRIPTION
When there is no work to do, i.e. when all config watching is disabled, there is no need to keep the restart_handler running. Disable it in this case.

This is helpful to do on nodes where there is little to no headroom in terms of open inotify watches (as per the inotify/max_user_instances configuration), as can happen on nodes populated with other software that also watch the filesystem for changes. If Falco is run on such a node, it may fail to start due to functionality the app does not even intend on using.

This has one change in terms of behaviour, however: the dry-run restarts will no longer occur. As there is still never going to happen a real restart, I understand it as unlikely for there to be a proper need for dry-run restarts.

Fixes: #3639

/kind bug
/area engine

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**Does this PR introduce a user-facing change?**: YES

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
Dry-run restarts are disabled if Falco runs with config-watching disabled.
```
