### PR TITLE
feat: make libs internal auto thread purging intervals configurable

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -1416,6 +1416,27 @@ base_syscalls:
 # and the fields called `n_drops_full_threadtable` or `n_store_evts_drops` will inform you
 # if you should increase this value for optimal performance.
 #
+# `thread_table_auto_purging_interval_s`
+#
+# Sets the interval (in seconds) at which the automatic threads purging routine runs. The
+# automatic threads purging is essential for Falco to remove stale inactive/dead threads
+# from its internal threadtable. The presence of this kind of threads could be the
+# results of multiple conditions, process exit events dropping or event re-ordering being
+# the most probable ones.
+#
+# Reducing the interval can help in better memory management, but as a consequence, could
+# impact the CPU usage.
+#
+# `thread_table_auto_purging_thread_timeout_s`
+#
+# Sets the amount of time after which a thread which has seen no events can be purged
+# through the automatic threads purging routine. As the purging happens only every
+# `thread_table_auto_purging_interval_s`, the max time a thread may linger is actually
+# `thread_table_auto_purging_interval_s` + `thread_table_auto_purging_thread_timeout_s`
+#
+# Reducing the interval can help in better memory management, but as a consequence, could
+# impact the CPU usage.
+#
 # `snaplen`
 #
 # Set how many bytes are collected of each I/O buffer for 'syscall' events.
@@ -1423,4 +1444,6 @@ base_syscalls:
 #
 falco_libs:
   thread_table_size: 262144
+  thread_table_auto_purging_interval_s: 300
+  thread_table_auto_purging_thread_timeout_s: 300
   snaplen: 80

--- a/userspace/engine/falco_common.h
+++ b/userspace/engine/falco_common.h
@@ -29,6 +29,8 @@ limitations under the License.
 #define DEFAULT_OUTPUTS_QUEUE_CAPACITY_UNBOUNDED_MAX_LONG_VALUE std::ptrdiff_t(~size_t(0) / 2)
 
 #define DEFAULT_FALCO_LIBS_THREAD_TABLE_SIZE 262144
+#define DEFAULT_FALCO_LIBS_THREAD_TABLE_AUTO_PURGING_INTERVAL_S (5 * 60)        // 5 minutes.
+#define DEFAULT_FALCO_LIBS_THREAD_TABLE_AUTO_PURGING_THREAD_TIMEOUT_S (5 * 60)  // 5 minutes.
 
 //
 // Most falco_* classes can throw exceptions. Unless directly related

--- a/userspace/falco/app/actions/helpers_inspector.cpp
+++ b/userspace/falco/app/actions/helpers_inspector.cpp
@@ -50,6 +50,12 @@ falco::app::run_result falco::app::actions::open_live_inspector(falco::app::stat
 			        s.config->m_falco_libs_thread_table_size);
 		}
 
+		inspector->set_auto_threads_purging(true);
+		inspector->set_auto_threads_purging_interval_s(
+		        s.config->m_falco_libs_thread_table_auto_purging_interval_s);
+		inspector->set_thread_timeout_s(
+		        s.config->m_falco_libs_thread_table_auto_purging_thread_timeout_s);
+
 		if(source != falco_common::syscall_source) /* Plugin engine */
 		{
 			for(const auto& p : inspector->get_plugin_manager()->plugins()) {

--- a/userspace/falco/config_json_schema.h
+++ b/userspace/falco/config_json_schema.h
@@ -471,6 +471,12 @@ const char config_schema_string[] = LONG_STRING_CONST(
                 "thread_table_size": {
                     "type": "integer"
                 },
+                "thread_table_auto_purging_interval_s": {
+                    "type": "integer"
+                },
+                "thread_table_auto_purging_thread_timeout_s": {
+                    "type": "integer"
+                },
                 "snaplen": {
                     "type": "integer"
                 }

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -86,6 +86,10 @@ falco_configuration::falco_configuration():
         m_syscall_evt_simulate_drops(false),
         m_syscall_evt_timeout_max_consecutives(1000),
         m_falco_libs_thread_table_size(DEFAULT_FALCO_LIBS_THREAD_TABLE_SIZE),
+        m_falco_libs_thread_table_auto_purging_interval_s(
+                DEFAULT_FALCO_LIBS_THREAD_TABLE_AUTO_PURGING_INTERVAL_S),
+        m_falco_libs_thread_table_auto_purging_thread_timeout_s(
+                DEFAULT_FALCO_LIBS_THREAD_TABLE_AUTO_PURGING_THREAD_TIMEOUT_S),
         m_falco_libs_snaplen(0),
         m_base_syscalls_all(false),
         m_base_syscalls_repair(false),
@@ -594,6 +598,12 @@ void falco_configuration::load_yaml(const std::string &config_name) {
 	m_falco_libs_thread_table_size =
 	        m_config.get_scalar<std::uint32_t>("falco_libs.thread_table_size",
 	                                           DEFAULT_FALCO_LIBS_THREAD_TABLE_SIZE);
+	m_falco_libs_thread_table_auto_purging_interval_s = m_config.get_scalar<std::uint32_t>(
+	        "falco_libs.thread_table_auto_purging_interval_s",
+	        DEFAULT_FALCO_LIBS_THREAD_TABLE_AUTO_PURGING_INTERVAL_S);
+	m_falco_libs_thread_table_auto_purging_thread_timeout_s = m_config.get_scalar<std::uint32_t>(
+	        "falco_libs.thread_table_auto_purging_thread_timeout_s",
+	        DEFAULT_FALCO_LIBS_THREAD_TABLE_AUTO_PURGING_THREAD_TIMEOUT_S);
 
 	// if falco_libs.snaplen is not set we'll let libs configure it
 	m_falco_libs_snaplen = m_config.get_scalar<std::uint64_t>("falco_libs.snaplen", 0);

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -190,6 +190,8 @@ public:
 	uint32_t m_syscall_evt_timeout_max_consecutives;
 
 	uint32_t m_falco_libs_thread_table_size;
+	uint32_t m_falco_libs_thread_table_auto_purging_interval_s;
+	uint32_t m_falco_libs_thread_table_auto_purging_thread_timeout_s;
 	uint64_t m_falco_libs_snaplen;
 
 	// User supplied base_syscalls, overrides any Falco state engine enforcement.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR makes Falco's libs internal auto thread purging interval configurable and sets its default value to 5 minutes. This helps controlling the memory impact of process exit events dropping and events re-ordering.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
feat: add `falco_libs.thread_table_auto_purging_interval_s` configuration option
```
