### PR TITLE
chore(prometheus): deprecate enter events drop stats

### DIFF
--- a/userspace/falco/event_drops.cpp
+++ b/userspace/falco/event_drops.cpp
@@ -65,29 +65,16 @@ bool syscall_evt_drop_mgr::process_event(std::shared_ptr<sinsp> inspector, sinsp
 		delta.n_evts = stats.n_evts - m_last_stats.n_evts;
 		delta.n_drops = stats.n_drops - m_last_stats.n_drops;
 		delta.n_drops_buffer = stats.n_drops_buffer - m_last_stats.n_drops_buffer;
-		delta.n_drops_buffer_clone_fork_enter = stats.n_drops_buffer_clone_fork_enter -
-		                                        m_last_stats.n_drops_buffer_clone_fork_enter;
 		delta.n_drops_buffer_clone_fork_exit =
 		        stats.n_drops_buffer_clone_fork_exit - m_last_stats.n_drops_buffer_clone_fork_exit;
-		delta.n_drops_buffer_execve_enter =
-		        stats.n_drops_buffer_execve_enter - m_last_stats.n_drops_buffer_execve_enter;
 		delta.n_drops_buffer_execve_exit =
 		        stats.n_drops_buffer_execve_exit - m_last_stats.n_drops_buffer_execve_exit;
-		delta.n_drops_buffer_connect_enter =
-		        stats.n_drops_buffer_connect_enter - m_last_stats.n_drops_buffer_connect_enter;
 		delta.n_drops_buffer_connect_exit =
 		        stats.n_drops_buffer_connect_exit - m_last_stats.n_drops_buffer_connect_exit;
-		delta.n_drops_buffer_open_enter =
-		        stats.n_drops_buffer_open_enter - m_last_stats.n_drops_buffer_open_enter;
 		delta.n_drops_buffer_open_exit =
 		        stats.n_drops_buffer_open_exit - m_last_stats.n_drops_buffer_open_exit;
-		delta.n_drops_buffer_dir_file_enter =
-		        stats.n_drops_buffer_dir_file_enter - m_last_stats.n_drops_buffer_dir_file_enter;
 		delta.n_drops_buffer_dir_file_exit =
 		        stats.n_drops_buffer_dir_file_exit - m_last_stats.n_drops_buffer_dir_file_exit;
-		delta.n_drops_buffer_other_interest_enter =
-		        stats.n_drops_buffer_other_interest_enter -
-		        m_last_stats.n_drops_buffer_other_interest_enter;
 		delta.n_drops_buffer_other_interest_exit = stats.n_drops_buffer_other_interest_exit -
 		                                           m_last_stats.n_drops_buffer_other_interest_exit;
 		delta.n_drops_buffer_close_exit =
@@ -181,24 +168,14 @@ bool syscall_evt_drop_mgr::perform_actions(uint64_t now,
 			 * syscall category (typically `open` system call category is highest by orders of
 			 * magnitude).
 			 */
-			output_fields["n_drops_buffer_clone_fork_enter"] =
-			        std::to_string(delta.n_drops_buffer_clone_fork_enter);
 			output_fields["n_drops_buffer_clone_fork_exit"] =
 			        std::to_string(delta.n_drops_buffer_clone_fork_exit);
-			output_fields["n_drops_buffer_execve_enter"] =
-			        std::to_string(delta.n_drops_buffer_execve_enter);
 			output_fields["n_drops_buffer_execve_exit"] =
 			        std::to_string(delta.n_drops_buffer_execve_exit);
-			output_fields["n_drops_buffer_connect_enter"] =
-			        std::to_string(delta.n_drops_buffer_connect_enter);
 			output_fields["n_drops_buffer_connect_exit"] =
 			        std::to_string(delta.n_drops_buffer_connect_exit);
-			output_fields["n_drops_buffer_open_enter"] =
-			        std::to_string(delta.n_drops_buffer_open_enter);
 			output_fields["n_drops_buffer_open_exit"] =
 			        std::to_string(delta.n_drops_buffer_open_exit);
-			output_fields["n_drops_buffer_dir_file_enter"] =
-			        std::to_string(delta.n_drops_buffer_dir_file_enter);
 			output_fields["n_drops_buffer_dir_file_exit"] =
 			        std::to_string(delta.n_drops_buffer_dir_file_exit);
 			/* `n_drops_buffer_other_interest_*` Category consisting of other system calls of
@@ -206,8 +183,6 @@ bool syscall_evt_drop_mgr::perform_actions(uint64_t now,
 			 * for a custom category if needed - simply patch switch statement in kernel driver code
 			 * (`falcosecurity/libs` repo).
 			 */
-			output_fields["n_drops_buffer_other_interest_enter"] =
-			        std::to_string(delta.n_drops_buffer_other_interest_enter);
 			output_fields["n_drops_buffer_other_interest_exit"] =
 			        std::to_string(delta.n_drops_buffer_other_interest_exit);
 			output_fields["n_drops_buffer_close_exit"] =


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Enter events are no longer tracked by the Falco libs, this change deprecates the Prometheus metrics related to enter event drops.
See https://github.com/falcosecurity/libs/issues/2588

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
chore(prometheus): deprecate enter events drop stats
```
