### PR TITLE
feat(engine): emit warning when a condition uses deprecated "evt.dir"

### DIFF
--- a/unit_tests/engine/test_filter_warning_resolver.cpp
+++ b/unit_tests/engine/test_filter_warning_resolver.cpp
@@ -20,10 +20,11 @@ limitations under the License.
 #include <engine/filter_warning_resolver.h>
 
 static bool warns(const std::string& condition) {
-	std::set<falco::load_result::warning_code> w;
 	auto ast = libsinsp::filter::parser(condition).parse();
-	filter_warning_resolver().run(ast.get(), w);
-	return !w.empty();
+	rule_loader::context ctx("test");
+	rule_loader::result res("test");
+	filter_warning_resolver().run(ctx, res, *ast.get());
+	return res.has_warnings();
 }
 
 TEST(WarningResolver, warnings_in_filtering_conditions) {

--- a/userspace/engine/falco_load_result.cpp
+++ b/userspace/engine/falco_load_result.cpp
@@ -73,11 +73,16 @@ static const std::string warning_codes[] = {"LOAD_UNKNOWN_SOURCE",
                                             "LOAD_EXCEPTION_NAME_NOT_UNIQUE",
                                             "LOAD_INVALID_MACRO_NAME",
                                             "LOAD_INVALID_LIST_NAME",
-                                            "LOAD_COMPILE_CONDITION",
-                                            "LOAD_DEPRECATED_DIR_FIELD"};
+                                            "LOAD_COMPILE_CONDITION"};
+
+// Compile-time check to ensure warning_codes array has the correct size
+static_assert(std::size(warning_codes) ==
+                      static_cast<int>(falco::load_result::warning_code::LOAD_COMPILE_CONDITION) +
+                              1,
+              "warning_codes array size must match the last warning_code enum value + 1");
 
 const std::string& falco::load_result::warning_code_str(warning_code wc) {
-	return warning_codes[wc];
+	return warning_codes[static_cast<int>(wc)];
 }
 
 static const std::string warning_strings[] = {"Unknown event source",
@@ -93,11 +98,16 @@ static const std::string warning_strings[] = {"Unknown event source",
                                               "Multiple exceptions defined with the same name",
                                               "Invalid macro name",
                                               "Invalid list name",
-                                              "Warning in rule condition",
-                                              "Deprecated evt.dir field usage"};
+                                              "Warning in rule condition"};
+
+// Compile-time check to ensure warning_strings array has the correct size
+static_assert(std::size(warning_strings) ==
+                      static_cast<int>(falco::load_result::warning_code::LOAD_COMPILE_CONDITION) +
+                              1,
+              "warning_strings array size must match the last warning_code enum value + 1");
 
 const std::string& falco::load_result::warning_str(warning_code wc) {
-	return warning_strings[wc];
+	return warning_strings[static_cast<int>(wc)];
 }
 
 static const std::string warning_descs[] = {
@@ -121,11 +131,48 @@ static const std::string warning_descs[] = {
         "A rule is defining multiple exceptions with the same name",
         "A macro is defined with an invalid name",
         "A list is defined with an invalid name",
-        "A rule condition or output have been parsed with a warning",
-        "A rule condition uses the deprecated 'evt.dir' field. Due to the drop of enter events, "
-        "'evt.dir = <' always evaluates to true, and 'evt.dir = >' always evaluates to false. The "
-        "rule expression can be simplified by removing the condition on 'evt.dir'."};
+        "A rule condition or output have been parsed with a warning"};
+
+// Compile-time check to ensure warning_descs array has the correct size
+static_assert(std::size(warning_descs) ==
+                      static_cast<int>(falco::load_result::warning_code::LOAD_COMPILE_CONDITION) +
+                              1,
+              "warning_descs array size must match the last warning_code enum value + 1");
 
 const std::string& falco::load_result::warning_desc(warning_code wc) {
-	return warning_descs[wc];
+	return warning_descs[static_cast<int>(wc)];
+}
+
+static const std::string deprecated_fields[] = {"evt.dir"};
+
+// Compile-time check to ensure deprecated_fields array has the correct size
+static_assert(
+        std::size(deprecated_fields) ==
+                static_cast<int>(falco::load_result::deprecated_field::DEPRECATED_FIELD_NOT_FOUND),
+        "deprecated_fields array size must match DEPRECATED_FIELD_NOT_FOUND enum value");
+
+const std::string& falco::load_result::deprecated_field_str(deprecated_field df) {
+	return deprecated_fields[static_cast<int>(df)];
+}
+
+static const std::string deprecated_field_descs[] = {
+        "due to the drop of enter events, 'evt.dir = <' always evaluates to true, and 'evt.dir = "
+        ">' always evaluates to false. The rule expression can be simplified by removing the "
+        "condition on 'evt.dir'"};
+
+// Compile-time check to ensure deprecated_field_descs array has the correct size
+static_assert(
+        std::size(deprecated_field_descs) ==
+                static_cast<int>(falco::load_result::deprecated_field::DEPRECATED_FIELD_NOT_FOUND),
+        "deprecated_field_descs array size must match DEPRECATED_FIELD_NOT_FOUND enum value");
+
+const std::string& falco::load_result::deprecated_field_desc(deprecated_field df) {
+	return deprecated_field_descs[static_cast<int>(df)];
+}
+
+falco::load_result::deprecated_field falco::load_result::deprecated_field_from_str(
+        const std::string& f) {
+	return falco::load_result::deprecated_field(
+	        std::find(std::begin(deprecated_fields), std::end(deprecated_fields), f) -
+	        std::begin(deprecated_fields));
 }

--- a/userspace/engine/falco_load_result.h
+++ b/userspace/engine/falco_load_result.h
@@ -46,7 +46,9 @@ public:
 	// impact.
 	static const std::string& error_desc(error_code ec);
 
-	enum warning_code {
+	virtual ~load_result() = default;
+
+	enum class warning_code {
 		LOAD_UNKNOWN_SOURCE = 0,
 		LOAD_UNSAFE_NA_CHECK,
 		LOAD_NO_EVTTYPE,
@@ -60,11 +62,8 @@ public:
 		LOAD_EXCEPTION_NAME_NOT_UNIQUE,
 		LOAD_INVALID_MACRO_NAME,
 		LOAD_INVALID_LIST_NAME,
-		LOAD_COMPILE_CONDITION,
-		LOAD_DEPRECATED_DIR_FIELD
+		LOAD_COMPILE_CONDITION
 	};
-
-	virtual ~load_result() = default;
 
 	// The warning code as a string
 	static const std::string& warning_code_str(warning_code ec);
@@ -75,6 +74,19 @@ public:
 	// A longer description of what the warning represents and the
 	// impact.
 	static const std::string& warning_desc(warning_code ec);
+
+	enum class deprecated_field { DEPRECATED_FIELD_EVT_DIR, DEPRECATED_FIELD_NOT_FOUND };
+
+	// The deprecated field as a string
+	static const std::string& deprecated_field_str(deprecated_field df);
+
+	// A longer description of what the deprecated field represents and the
+	// impact.
+	static const std::string& deprecated_field_desc(deprecated_field df);
+
+	// Return the deprecated field from a field string name, or DEPRECATED_FIELD_NOT_FOUND if the
+	// field is not deprecated
+	static deprecated_field deprecated_field_from_str(const std::string& f);
 
 	// If true, the rules were loaded successfully and can be used
 	// against events. If false, there were one or more

--- a/userspace/engine/rule_loader_collector.cpp
+++ b/userspace/engine/rule_loader_collector.cpp
@@ -188,7 +188,7 @@ void rule_loader::collector::define(configuration& cfg, rule_info& info) {
 	const auto* source = cfg.sources.at(info.source);
 	if(!source) {
 		info.unknown_source = true;
-		cfg.res->add_warning(falco::load_result::LOAD_UNKNOWN_SOURCE,
+		cfg.res->add_warning(falco::load_result::warning_code::LOAD_UNKNOWN_SOURCE,
 		                     "Unknown source " + info.source + ", skipping",
 		                     info.ctx);
 	}

--- a/userspace/engine/rule_loader_reader.cpp
+++ b/userspace/engine/rule_loader_reader.cpp
@@ -359,7 +359,7 @@ static void read_rule_exceptions(rule_loader::configuration& cfg,
 		for(const auto& exception : exceptions) {
 			if(v_ex.name == exception.name) {
 				cfg.res->add_warning(
-				        falco::load_result::LOAD_EXCEPTION_NAME_NOT_UNIQUE,
+				        falco::load_result::warning_code::LOAD_EXCEPTION_NAME_NOT_UNIQUE,
 				        "Multiple definitions of exception '" + v_ex.name + "' in the same rule",
 				        ex_ctx);
 			}
@@ -385,7 +385,7 @@ static void read_rule_exceptions(rule_loader::configuration& cfg,
 				v_ex.values.push_back(v_ex_val);
 			}
 		} else if(append) {
-			cfg.res->add_warning(falco::load_result::LOAD_APPEND_NO_VALUES,
+			cfg.res->add_warning(falco::load_result::warning_code::LOAD_APPEND_NO_VALUES,
 			                     "Overriding/appending exception with no values",
 			                     ex_ctx);
 		}
@@ -524,7 +524,7 @@ void rule_loader::reader::read_item(rule_loader::configuration& cfg,
 
 		bool invalid_name = !re2::RE2::FullMatch(name, s_rgx_barestr);
 		if(invalid_name) {
-			cfg.res->add_warning(falco::load_result::LOAD_INVALID_LIST_NAME,
+			cfg.res->add_warning(falco::load_result::warning_code::LOAD_INVALID_LIST_NAME,
 			                     "List has an invalid name. List names should match a regular "
 			                     "expression: " RGX_BARESTR,
 			                     ctx);
@@ -538,7 +538,9 @@ void rule_loader::reader::read_item(rule_loader::configuration& cfg,
 
 		decode_optional_val(item, "append", append, ctx);
 		if(append) {
-			cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_APPEND, ctx);
+			cfg.res->add_warning(falco::load_result::warning_code::LOAD_DEPRECATED_ITEM,
+			                     WARNING_APPEND,
+			                     ctx);
 		}
 
 		std::set<std::string> override_append, override_replace;
@@ -567,7 +569,7 @@ void rule_loader::reader::read_item(rule_loader::configuration& cfg,
 
 		bool invalid_name = !re2::RE2::FullMatch(name, s_rgx_identifier);
 		if(invalid_name) {
-			cfg.res->add_warning(falco::load_result::LOAD_INVALID_MACRO_NAME,
+			cfg.res->add_warning(falco::load_result::warning_code::LOAD_INVALID_MACRO_NAME,
 			                     "Macro has an invalid name. Macro names should match a regular "
 			                     "expression: " RGX_IDENTIFIER,
 			                     ctx);
@@ -587,7 +589,9 @@ void rule_loader::reader::read_item(rule_loader::configuration& cfg,
 
 		decode_optional_val(item, "append", append, ctx);
 		if(append) {
-			cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_APPEND, ctx);
+			cfg.res->add_warning(falco::load_result::warning_code::LOAD_DEPRECATED_ITEM,
+			                     WARNING_APPEND,
+			                     ctx);
 		}
 
 		std::set<std::string> override_append, override_replace;
@@ -621,7 +625,9 @@ void rule_loader::reader::read_item(rule_loader::configuration& cfg,
 		bool has_append_flag = false;
 		decode_optional_val(item, "append", has_append_flag, ctx);
 		if(has_append_flag) {
-			cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM, WARNING_APPEND, ctx);
+			cfg.res->add_warning(falco::load_result::warning_code::LOAD_DEPRECATED_ITEM,
+			                     WARNING_APPEND,
+			                     ctx);
 		}
 
 		std::set<std::string> override_append, override_replace;
@@ -849,7 +855,7 @@ void rule_loader::reader::read_item(rule_loader::configuration& cfg,
 			if(!item["condition"].IsDefined() && !item["output"].IsDefined() &&
 			   !item["desc"].IsDefined() && !item["priority"].IsDefined()) {
 				decode_val(item, "enabled", v.enabled, ctx);
-				cfg.res->add_warning(falco::load_result::LOAD_DEPRECATED_ITEM,
+				cfg.res->add_warning(falco::load_result::warning_code::LOAD_DEPRECATED_ITEM,
 				                     WARNING_ENABLED,
 				                     ctx);
 				collector.enable(cfg, v);
@@ -894,7 +900,9 @@ void rule_loader::reader::read_item(rule_loader::configuration& cfg,
 		}
 	} else {
 		rule_loader::context ctx(item, rule_loader::context::RULES_CONTENT_ITEM, "", parent);
-		cfg.res->add_warning(falco::load_result::LOAD_UNKNOWN_ITEM, "Unknown top level item", ctx);
+		cfg.res->add_warning(falco::load_result::warning_code::LOAD_UNKNOWN_ITEM,
+		                     "Unknown top level item",
+		                     ctx);
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Emit a warning when a rule with a condition using "evt.dir" field is encountered.
The direction have been deprecated in the scope of enter event suppression initiative.

ref: https://github.com/falcosecurity/libs/issues/2588

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Example output:
```
Wed Oct 08 08:50:51 2025: rules/falco-deprecated_rules.yaml: Ok, with warnings
4 Warnings:
In rules content: (rules/falco-deprecated_rules.yaml:0:0)
    rule 'Disallowed SSH Connection': (rules/falco-deprecated_rules.yaml:82:2)
    rule condition: (rules/falco-deprecated_rules.yaml:88:13)
------
  condition: >
             ^
------
LOAD_DEPRECATED_ITEM (Used deprecated item: field 'evt.dir' is deprecated): due to the drop of enter events, 'evt.dir = <' always evaluates to true, and 'evt.dir = >' always evaluates to false. The rule expression can be simplified by removing the condition on 'evt.dir'
In rules content: (rules/falco-deprecated_rules.yaml:0:0)
    rule 'Unexpected outbound connection destination': (rules/falco-deprecated_rules.yaml:115:2)
    rule condition: (rules/falco-deprecated_rules.yaml:121:13)
------
  condition: >
             ^
------
LOAD_DEPRECATED_ITEM (Used deprecated item: field 'evt.dir' is deprecated): due to the drop of enter events, 'evt.dir = <' always evaluates to true, and 'evt.dir = >' always evaluates to false. The rule expression can be simplified by removing the condition on 'evt.dir'
In rules content: (rules/falco-deprecated_rules.yaml:0:0)
    rule 'Outbound or Inbound Traffic not to Authorized Server Process and Port': (rules/falco-deprecated_rules.yaml:155:2)
    rule condition: (rules/falco-deprecated_rules.yaml:163:13)
------
  condition: >
             ^
------
LOAD_DEPRECATED_ITEM (Used deprecated item: field 'evt.dir' is deprecated): due to the drop of enter events, 'evt.dir = <' always evaluates to true, and 'evt.dir = >' always evaluates to false. The rule expression can be simplified by removing the condition on 'evt.dir'
In rules content: (rules/falco-deprecated_rules.yaml:0:0)
    rule 'Outbound Connection to C2 Servers': (rules/falco-deprecated_rules.yaml:180:2)
    rule condition: (rules/falco-deprecated_rules.yaml:187:13)
------
  condition: >
             ^
------
LOAD_DEPRECATED_ITEM (Used deprecated item: field 'evt.dir' is deprecated): due to the drop of enter events, 'evt.dir = <' always evaluates to true, and 'evt.dir = >' always evaluates to false. The rule expression can be simplified by removing the condition on 'evt.dir'
```

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
feat(engine): emit warning when a rule containing a condition on the deprecated `evt.dir` field is encountered
```
