### PR TITLE
fix: enforce const-correctness in indexed_vector

### DIFF
--- a/userspace/engine/indexed_vector.h
+++ b/userspace/engine/indexed_vector.h
@@ -87,9 +87,20 @@ public:
 	    \brief Returns a pointer to the element at the given numeric index,
 	    or nullptr if no element exists at the given index.
 	*/
-	virtual inline T* at(size_t id) const {
+	virtual inline const T* at(size_t id) const {
 		if(id < m_entries.size()) {
-			return (T* const)&m_entries[id];
+			return &m_entries[id];
+		}
+		return nullptr;
+	}
+
+	/*!
+	    \brief Returns a pointer to the element at the given numeric index,
+	    or nullptr if no element exists at the given index.
+	*/
+	virtual inline T* at(size_t id) {
+		if(id < m_entries.size()) {
+			return &m_entries[id];
 		}
 		return nullptr;
 	}
@@ -98,7 +109,19 @@ public:
 	    \brief Returns a pointer to the element at the given string index,
 	    or nullptr if no element exists at the given index.
 	*/
-	virtual inline T* at(const std::string& index) const {
+	virtual inline const T* at(const std::string& index) const {
+		auto it = m_index.find(index);
+		if(it != m_index.end()) {
+			return at(it->second);
+		}
+		return nullptr;
+	}
+
+	/*!
+	    \brief Returns a pointer to the element at the given string index,
+	    or nullptr if no element exists at the given index.
+	*/
+	virtual inline T* at(const std::string& index) {
 		auto it = m_index.find(index);
 		if(it != m_index.end()) {
 			return at(it->second);

--- a/userspace/engine/rule_loader_compiler.cpp
+++ b/userspace/engine/rule_loader_compiler.cpp
@@ -153,8 +153,8 @@ static void build_rule_exception_infos(
 	}
 }
 
-static inline rule_loader::list_info* list_info_from_name(const rule_loader::collector& c,
-                                                          const std::string& name) {
+static inline const rule_loader::list_info* list_info_from_name(const rule_loader::collector& c,
+                                                                const std::string& name) {
 	auto ret = c.lists().at(name);
 	if(!ret) {
 		throw falco_exception("can't find internal list info at name: " + name);
@@ -162,8 +162,8 @@ static inline rule_loader::list_info* list_info_from_name(const rule_loader::col
 	return ret;
 }
 
-static inline rule_loader::macro_info* macro_info_from_name(const rule_loader::collector& c,
-                                                            const std::string& name) {
+static inline const rule_loader::macro_info* macro_info_from_name(const rule_loader::collector& c,
+                                                                   const std::string& name) {
 	auto ret = c.macros().at(name);
 	if(!ret) {
 		throw falco_exception("can't find internal macro info at name: " + name);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Const `at()` methods were returning mutable pointers via const_cast, violating const-correctness.

Solution:
- Split `at()` methods into const/non-const overloads
- Const version returns `const T*`, non-const returns `T*`
- Updated callers to use const pointers where appropriate
- Removed unsafe const_cast

Changes:
- `indexed_vector.h`: Added const/non-const overloads for both `at()` methods
- `rule_loader_compiler.cpp`: Updated helper functions to return const pointers

Verified compilation and all call sites handle const-correctness properly.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```