### PR TITLE
fix(metrics): Add null check for state.outputs in metrics collection

### DIFF
--- a/userspace/falco/falco_metrics.cpp
+++ b/userspace/falco/falco_metrics.cpp
@@ -150,13 +150,15 @@ std::string falco_metrics::falco_to_text_prometheus(
 	// # HELP falcosecurity_falco_outputs_queue_num_drops_total https://falco.org/docs/metrics/
 	// # TYPE falcosecurity_falco_outputs_queue_num_drops_total counter
 	// falcosecurity_falco_outputs_queue_num_drops_total 0
-	additional_wrapper_metrics.emplace_back(libs::metrics::libsinsp_metrics::new_metric(
-	        "outputs_queue_num_drops",
-	        METRICS_V2_MISC,
-	        METRIC_VALUE_TYPE_U64,
-	        METRIC_VALUE_UNIT_COUNT,
-	        METRIC_VALUE_METRIC_TYPE_MONOTONIC,
-	        state.outputs->get_outputs_queue_num_drops()));
+	if(state.outputs != nullptr) {
+		additional_wrapper_metrics.emplace_back(libs::metrics::libsinsp_metrics::new_metric(
+		        "outputs_queue_num_drops",
+		        METRICS_V2_MISC,
+		        METRIC_VALUE_TYPE_U64,
+		        METRIC_VALUE_UNIT_COUNT,
+		        METRIC_VALUE_METRIC_TYPE_MONOTONIC,
+		        state.outputs->get_outputs_queue_num_drops()));
+	}
 
 	// # HELP falcosecurity_falco_reload_timestamp_nanoseconds https://falco.org/docs/metrics/
 	// # TYPE falcosecurity_falco_reload_timestamp_nanoseconds gauge


### PR DESCRIPTION
This change adds a defensive null check before accessing state.outputs->get_outputs_queue_num_drops() to prevent segfaults if outputs is destroyed while metrics are being collected.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug



<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:
Adds a defensive null check before accessing `state.outputs->get_outputs_queue_num_drops()` in the Prometheus metrics collection code.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes 
Issue #3739 

**Special notes for your reviewer**:
This is a defensive measure that prevents accessing outputs when null.


**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
None
```
