### PR TITLE
feat: capture events filesize limits

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -461,11 +461,29 @@ engine:
 # 2. `all_rules`: Captures events when any enabled rule is triggered.
 #
 # When a capture starts, Falco records events from the moment the triggering rule
-# fires until the deadline is reached. The deadline is determined by the rule's
-# `capture_duration` if specified, otherwise the `default_duration` is used.
-# If additional rules trigger during an active capture, the deadline is extended
-# accordingly. Once the deadline expires, the capture stops and data is written
-# to a file. Subsequent captures create new files with unique names.
+# fires until a stop condition is reached. Two stop conditions are available:
+#
+# - Time (per-rule, soft): determined by the rule's `capture_duration` if
+#   specified, otherwise `default_duration` is used. If additional rules trigger
+#   during an active capture, the deadline is extended accordingly (the longest
+#   deadline wins). For this reason, the time limit has "at least" semantics:
+#   the capture is guaranteed to last at least that long, but can last longer if
+#   other rules keep matching.
+#
+# - File size (global, hard): `max_file_size_mb` applies to any capture,
+#   regardless of which rule triggered it. Unlike the time limit, it cannot be
+#   overridden or extended by rules: if a capture reaches this size, it stops.
+#   N.B. The size check uses the dumper's compressed on-disk counter, which is
+#   updated in chunks as zlib flushes its internal buffers. The effective file
+#   size is therefore approximate and may overshoot the configured value by up
+#   to one flush window. For this reason, avoid very small values (under a few
+#   MB), which may be inaccurate, and consider tuning with a healthy margin.
+#
+# The first stop condition met wins (OR semantics). Once a stop condition is
+# met, the capture stops and data is written to a file. Subsequent captures
+# create new files with unique names. When a capture stops because of
+# `max_file_size_mb`, Falco emits an internal INFO message so the truncation
+# is visible in the configured outputs.
 #
 # Captured data is stored in files with a `.scap` extension, which can be
 # analyzed later using:
@@ -483,7 +501,8 @@ engine:
 # Use `capture.mode` to choose between `rules` and `all_rules` modes.
 #
 # Set `capture.default_duration` to define the default capture duration
-# in milliseconds.
+# in milliseconds. Optionally, set `capture.max_file_size_mb` to enforce a
+# hard upper bound on the capture file size in MB (applies to any capture).
 #
 # --- [Suggestions]
 #
@@ -512,6 +531,10 @@ capture:
   mode: rules
   # -- Default capture duration in milliseconds if not specified in the rule.
   default_duration: 5000
+  # -- Global hard cap on capture file size in MB (0 = unlimited).
+  # This limit applies to any capture and cannot be overridden or extended by rules.
+  # The check is approximate (see the section above): prefer values of at least a few MB.
+  # max_file_size_mb: 100
 
 #################
 # Falco plugins #

--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -1571,3 +1571,137 @@ TEST_F(test_falco_engine, deprecated_evt_dir_via_macro_folded_scalar_condition_s
 	}
 	FAIL() << "no LOAD_DEPRECATED_ITEM warning found: " << m_load_result_string;
 }
+
+// Capture field tests
+
+TEST_F(test_falco_engine, rule_capture_enabled) {
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = close
+  output: user=%user.name
+  priority: WARNING
+  capture: true
+)END";
+
+	std::string rule_name = "test_rule";
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+
+	auto rule_description = m_engine->describe_rule(&rule_name, {});
+	ASSERT_EQ(rule_description["rules"][0]["info"]["capture"].template get<bool>(), true);
+}
+
+TEST_F(test_falco_engine, rule_capture_disabled_by_default) {
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = close
+  output: user=%user.name
+  priority: INFO
+)END";
+
+	std::string rule_name = "test_rule";
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+
+	auto rule_description = m_engine->describe_rule(&rule_name, {});
+	ASSERT_EQ(rule_description["rules"][0]["info"]["capture"].template get<bool>(), false);
+	ASSERT_EQ(rule_description["rules"][0]["info"]["capture_duration"].template get<uint32_t>(),
+	          0u);
+}
+
+TEST_F(test_falco_engine, rule_capture_duration) {
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = close
+  output: user=%user.name
+  priority: WARNING
+  capture: true
+  capture_duration: 10000
+)END";
+
+	std::string rule_name = "test_rule";
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+
+	auto rule_description = m_engine->describe_rule(&rule_name, {});
+	ASSERT_EQ(rule_description["rules"][0]["info"]["capture_duration"].template get<uint32_t>(),
+	          10000u);
+}
+
+TEST_F(test_falco_engine, rule_override_capture_replace) {
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = close
+  output: user=%user.name
+  priority: WARNING
+  capture: true
+
+- rule: test_rule
+  capture: false
+  override:
+    capture: replace
+)END";
+
+	std::string rule_name = "test_rule";
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+
+	auto rule_description = m_engine->describe_rule(&rule_name, {});
+	ASSERT_EQ(rule_description["rules"][0]["info"]["capture"].template get<bool>(), false);
+}
+
+TEST_F(test_falco_engine, rule_override_capture_duration_replace) {
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = close
+  output: user=%user.name
+  priority: WARNING
+  capture: true
+  capture_duration: 5000
+
+- rule: test_rule
+  capture_duration: 15000
+  override:
+    capture_duration: replace
+)END";
+
+	std::string rule_name = "test_rule";
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+
+	auto rule_description = m_engine->describe_rule(&rule_name, {});
+	ASSERT_EQ(rule_description["rules"][0]["info"]["capture_duration"].template get<uint32_t>(),
+	          15000u);
+}
+
+TEST_F(test_falco_engine, rule_capture_duration_wrong_type) {
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = close
+  output: user=%user.name
+  priority: INFO
+  capture_duration: "not_a_number"
+)END";
+
+	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
+}
+
+TEST_F(test_falco_engine, rule_capture_wrong_type) {
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = close
+  output: user=%user.name
+  priority: INFO
+  capture: "yes"
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml"));
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_failed) << m_load_result->schema_validation();
+}

--- a/unit_tests/falco/test_capture.cpp
+++ b/unit_tests/falco/test_capture.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <falco/app/actions/helpers.h>
 #include <falco/configuration.h>
+#include <libsinsp/utils.h>
 #include <gtest/gtest.h>
 
 TEST(Capture, generate_scap_file_path_realistic_scenario) {
@@ -79,6 +80,7 @@ plugins:
 	EXPECT_EQ(config.m_capture_path_prefix, "/tmp/falco");
 	EXPECT_EQ(config.m_capture_mode, capture_mode_t::RULES);
 	EXPECT_EQ(config.m_capture_default_duration_ns, 5000 * 1000000LL);  // 5 seconds in ns
+	EXPECT_EQ(config.m_capture_max_file_size_mb, 0u);
 }
 
 TEST(Capture, capture_config_enabled_rules_mode) {
@@ -131,4 +133,93 @@ capture:
 
 	// Should throw an exception for invalid mode
 	EXPECT_THROW(res = config.init_from_content(config_content, {}), std::logic_error);
+}
+
+TEST(Capture, capture_config_with_max_file_size_mb) {
+	std::string config_content = R"(
+capture:
+  enabled: true
+  max_file_size_mb: 100
+)";
+
+	falco_configuration config;
+	config_loaded_res res;
+	ASSERT_NO_THROW(res = config.init_from_content(config_content, {}));
+
+	EXPECT_EQ(config.m_capture_max_file_size_mb, 100u);
+}
+
+TEST(Capture, capture_config_with_all_limits) {
+	std::string config_content = R"(
+capture:
+  enabled: true
+  default_duration: 15000
+  max_file_size_mb: 500
+)";
+
+	falco_configuration config;
+	config_loaded_res res;
+	ASSERT_NO_THROW(res = config.init_from_content(config_content, {}));
+
+	EXPECT_EQ(config.m_capture_default_duration_ns, 15000 * 1000000LL);
+	EXPECT_EQ(config.m_capture_max_file_size_mb, 500u);
+}
+
+TEST(Capture, capture_config_rejects_out_of_range_max_file_size_mb) {
+	// Exceeds the schema maximum (1 TB in MB)
+	std::string config_content = R"(
+capture:
+  enabled: true
+  max_file_size_mb: 99999999999
+)";
+
+	falco_configuration config;
+	config_loaded_res res;
+	ASSERT_NO_THROW(res = config.init_from_content(config_content, {}));
+	for(const auto& pair : res) {
+		EXPECT_TRUE(sinsp_utils::startswith(pair.second, yaml_helper::validation_failed))
+		        << pair.second;
+	}
+}
+
+TEST(Capture, check_capture_stop_no_stop) {
+	// Deadline in the future, no size cap
+	EXPECT_EQ(falco::app::actions::check_capture_stop(100, 200, 0, 0),
+	          falco::app::actions::capture_stop_reason::NONE);
+	// Deadline in the future, size under cap
+	EXPECT_EQ(falco::app::actions::check_capture_stop(100, 200, 1024, 1),
+	          falco::app::actions::capture_stop_reason::NONE);
+}
+
+TEST(Capture, check_capture_stop_time_deadline) {
+	// Exactly at deadline stops (>=)
+	EXPECT_EQ(falco::app::actions::check_capture_stop(200, 200, 0, 0),
+	          falco::app::actions::capture_stop_reason::TIME_DEADLINE);
+	// Past deadline
+	EXPECT_EQ(falco::app::actions::check_capture_stop(201, 200, 0, 0),
+	          falco::app::actions::capture_stop_reason::TIME_DEADLINE);
+}
+
+TEST(Capture, check_capture_stop_size_limit) {
+	// 1 MB cap, written exactly 1 MB -> stops
+	EXPECT_EQ(falco::app::actions::check_capture_stop(100, 200, 1024 * 1024, 1),
+	          falco::app::actions::capture_stop_reason::SIZE_LIMIT);
+	// 1 MB cap, written over
+	EXPECT_EQ(falco::app::actions::check_capture_stop(100, 200, 2 * 1024 * 1024, 1),
+	          falco::app::actions::capture_stop_reason::SIZE_LIMIT);
+	// 1 MB cap, written just under -> no stop
+	EXPECT_EQ(falco::app::actions::check_capture_stop(100, 200, 1024 * 1024 - 1, 1),
+	          falco::app::actions::capture_stop_reason::NONE);
+}
+
+TEST(Capture, check_capture_stop_zero_means_unlimited) {
+	// 0 MB cap means unlimited, even with huge written_bytes
+	EXPECT_EQ(falco::app::actions::check_capture_stop(100, 200, UINT64_MAX, 0),
+	          falco::app::actions::capture_stop_reason::NONE);
+}
+
+TEST(Capture, check_capture_stop_time_wins_when_both_tripped) {
+	// Both conditions met: time is reported first (matches check order)
+	EXPECT_EQ(falco::app::actions::check_capture_stop(200, 200, 10 * 1024 * 1024, 1),
+	          falco::app::actions::capture_stop_reason::TIME_DEADLINE);
 }

--- a/userspace/falco/app/actions/helpers.h
+++ b/userspace/falco/app/actions/helpers.h
@@ -35,6 +35,33 @@ void check_for_ignored_events(falco::app::state& s);
 void format_plugin_info(std::shared_ptr<sinsp_plugin> p, std::ostream& os);
 void format_described_rules_as_text(const nlohmann::json& v, std::ostream& os);
 
+enum class capture_stop_reason {
+	NONE,
+	TIME_DEADLINE,
+	SIZE_LIMIT,
+};
+
+// Returns the reason why an active capture should stop, given the current
+// event timestamp, the dump deadline, and the number of bytes written so far.
+// Stop conditions combine with OR semantics (first met wins); time is checked
+// before size, so when both trip on the same event, TIME_DEADLINE is reported.
+// `max_file_size_mb == 0` means "unlimited".
+// Note: `written_bytes` is the dumper's on-disk counter (compressed, buffered
+// by zlib), so the check is approximate — the effective file size may overshoot
+// by up to one flush window.
+inline capture_stop_reason check_capture_stop(uint64_t evt_ts,
+                                              uint64_t dump_deadline_ts,
+                                              uint64_t written_bytes,
+                                              uint64_t max_file_size_mb) {
+	if(evt_ts >= dump_deadline_ts) {
+		return capture_stop_reason::TIME_DEADLINE;
+	}
+	if(max_file_size_mb > 0 && written_bytes >= max_file_size_mb * 1024 * 1024) {
+		return capture_stop_reason::SIZE_LIMIT;
+	}
+	return capture_stop_reason::NONE;
+}
+
 inline std::string generate_scap_file_path(const std::string& prefix,
                                            uint64_t timestamp,
                                            uint64_t evt_num) {

--- a/userspace/falco/app/actions/process_events.cpp
+++ b/userspace/falco/app/actions/process_events.cpp
@@ -149,6 +149,8 @@ static falco::app::run_result do_inspect(
 	auto dumper = std::make_unique<sinsp_dumper>();
 	uint64_t dump_started_ts = 0;
 	uint64_t dump_deadline_ts = 0;
+	// Global hard cap on capture file size (MB). 0 means unlimited.
+	const uint64_t dump_max_file_size_mb = s.config->m_capture_max_file_size_mb;
 
 	//
 	// Start capture
@@ -347,14 +349,39 @@ static falco::app::run_result do_inspect(
 		}
 
 		// Save events when a dump is in progress.
-		// If the deadline is reached, close the dump.
+		// If any stop condition is reached, close the dump.
+		// Stop conditions (first one met wins):
+		//   - per-rule time deadline (soft, extended by matching rules)
+		//   - global size cap (hard, applies to any capture)
 		if(dump_started_ts != 0) {
 			dumper->dump(ev);
-			if(ev->get_ts() > dump_deadline_ts) {
+			auto reason = check_capture_stop(ev->get_ts(),
+			                                 dump_deadline_ts,
+			                                 dumper->written_bytes(),
+			                                 dump_max_file_size_mb);
+			if(reason != capture_stop_reason::NONE) {
 				dumper->flush();
+				uint64_t written = dumper->written_bytes();
 				dumper->close();
 				dump_started_ts = 0;
 				dump_deadline_ts = 0;
+				if(reason == capture_stop_reason::SIZE_LIMIT) {
+					static std::string rule = "Falco internal: capture size limit reached";
+					std::string msg =
+					        rule + ". Configured limit: " + std::to_string(dump_max_file_size_mb) +
+					        " MB.";
+					nlohmann::json fields;
+					fields["max_file_size_mb"] = dump_max_file_size_mb;
+					fields["written_bytes"] = written;
+					auto now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+					                   std::chrono::system_clock::now().time_since_epoch())
+					                   .count();
+					s.outputs->handle_msg(now,
+					                      falco_common::PRIORITY_INFORMATIONAL,
+					                      msg,
+					                      rule,
+					                      fields);
+				}
 			}
 		}
 

--- a/userspace/falco/config_json_schema.h
+++ b/userspace/falco/config_json_schema.h
@@ -326,7 +326,13 @@ const char config_schema_string[] = LONG_STRING_CONST(
                     ]
                 },
                 "default_duration": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "max_file_size_mb": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 1048576
                 }
             },
             "title": "Capture"

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -100,7 +100,8 @@ falco_configuration::falco_configuration():
         m_capture_enabled(false),
         m_capture_path_prefix("/tmp/falco"),
         m_capture_mode(capture_mode_t::RULES),
-        m_capture_default_duration_ns(5000 * 1000000LL) {
+        m_capture_default_duration_ns(5000 * 1000000LL),
+        m_capture_max_file_size_mb(0) {
 	m_config_schema = nlohmann::json::parse(config_schema_string);
 }
 
@@ -621,6 +622,7 @@ void falco_configuration::load_yaml(const std::string &config_name) {
 	// Convert to nanoseconds
 	m_capture_default_duration_ns =
 	        m_config.get_scalar<uint32_t>("capture.default_duration", 5000) * 1000000LL;
+	m_capture_max_file_size_mb = m_config.get_scalar<uint64_t>("capture.max_file_size_mb", 0);
 
 	m_plugins_hostinfo = m_config.get_scalar<bool>("plugins_hostinfo", true);
 

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -199,6 +199,7 @@ public:
 	std::string m_capture_path_prefix;
 	capture_mode_t m_capture_mode = capture_mode_t::RULES;
 	uint64_t m_capture_default_duration_ns;
+	uint64_t m_capture_max_file_size_mb;
 
 	// Falco engine
 	engine_kind_t m_engine_mode = engine_kind_t::KMOD;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

/area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This adds capture_events and `capture_filesize` (kB) as new stop conditions for capture files, both as per-rule fields and as global config defaults (`default_events`, `default_filesize`). When multiple conditions are configured alongside the existing capture_duration, the first one that is met stops the capture (OR semantics).

Also fixes:
 - pre-existing gaps in the rule Override JSON schema 
 - and adds comprehensive unit tests for all capture-related fields.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #3764

**Special notes for your reviewer**:

/milestone 0.44.0

cc @geraldcombs 

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
new(config,rules): add `capture_events` and `capture_filesize` stop conditions for capture files
```
