### PR TITLE
fix(cmake): enable webserver deps on macOS (httplib include/link)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,6 @@ include(njson)
 include(yaml-cpp)
 
 if(NOT WIN32
-   AND NOT APPLE
    AND NOT MINIMAL_BUILD
    AND NOT EMSCRIPTEN
 )
@@ -184,7 +183,7 @@ if(NOT WIN32
 	# libcurl
 	include(curl)
 
-	# todo(jasondellaluce,rohith-raju): support webserver for non-linux builds too cpp-httlib
+	# cpp-httplib (health/metrics webserver; used on all non-Windows Unix, e.g. Linux and macOS)
 	include(cpp-httplib)
 endif()
 
@@ -203,10 +202,7 @@ if(USE_GPERFTOOLS)
 	include(gperftools)
 endif()
 if(NOT MINIMAL_BUILD)
-	if(NOT WIN32
-	   AND NOT APPLE
-	   AND NOT EMSCRIPTEN
-	)
+	if(NOT WIN32 AND NOT EMSCRIPTEN)
 		include(cares)
 	endif()
 endif()

--- a/userspace/falco/CMakeLists.txt
+++ b/userspace/falco/CMakeLists.txt
@@ -81,29 +81,27 @@ if(NOT WIN32)
 	target_sources(falco_application PRIVATE outputs_program.cpp outputs_syslog.cpp)
 endif()
 
-if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT MINIMAL_BUILD)
+if(NOT WIN32 AND NOT EMSCRIPTEN AND NOT MINIMAL_BUILD)
 	target_sources(falco_application PRIVATE outputs_http.cpp falco_metrics.cpp webserver.cpp)
 
-	list(APPEND FALCO_INCLUDE_DIRECTORIES FALCO_INCLUDE_DIRECTORIES "${OPENSSL_INCLUDE_DIR}"
-		 "${CARES_INCLUDE}"
-	)
+	list(APPEND FALCO_INCLUDE_DIRECTORIES "${OPENSSL_INCLUDE_DIR}" "${CARES_INCLUDE}")
 
 	if(TARGET c-ares)
 		list(APPEND FALCO_DEPENDENCIES c-ares)
 	endif()
 
-	if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND USE_BUNDLED_CURL)
+	if(USE_BUNDLED_CURL)
 		list(APPEND FALCO_DEPENDENCIES curl)
 	endif()
 
 	list(APPEND FALCO_LIBRARIES httplib::httplib "${CURL_LIBRARIES}" "${CARES_LIB}")
+
+	target_compile_definitions(falco_application PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)
 endif()
 
 if(EMSCRIPTEN)
 	target_compile_options(falco_application PRIVATE "-sDISABLE_EXCEPTION_CATCHING=0")
 endif()
-
-target_compile_definitions(falco_application PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)
 
 add_dependencies(falco_application ${FALCO_DEPENDENCIES})
 

--- a/userspace/falco/CMakeLists.txt
+++ b/userspace/falco/CMakeLists.txt
@@ -81,7 +81,10 @@ if(NOT WIN32)
 	target_sources(falco_application PRIVATE outputs_program.cpp outputs_syslog.cpp)
 endif()
 
-if(NOT WIN32 AND NOT EMSCRIPTEN AND NOT MINIMAL_BUILD)
+if(NOT WIN32
+   AND NOT EMSCRIPTEN
+   AND NOT MINIMAL_BUILD
+)
 	target_sources(falco_application PRIVATE outputs_http.cpp falco_metrics.cpp webserver.cpp)
 
 	list(APPEND FALCO_INCLUDE_DIRECTORIES "${OPENSSL_INCLUDE_DIR}" "${CARES_INCLUDE}")

--- a/userspace/falco/CMakeLists.txt
+++ b/userspace/falco/CMakeLists.txt
@@ -94,7 +94,14 @@ if(NOT WIN32 AND NOT EMSCRIPTEN AND NOT MINIMAL_BUILD)
 		list(APPEND FALCO_DEPENDENCIES curl)
 	endif()
 
-	list(APPEND FALCO_LIBRARIES httplib::httplib "${CURL_LIBRARIES}" "${CARES_LIB}")
+	if(USE_BUNDLED_OPENSSL)
+		list(APPEND FALCO_DEPENDENCIES openssl)
+	endif()
+
+	# libcurl (static) and cpp-httplib SSL pull in OpenSSL; falco_engine only links it on Linux.
+	list(APPEND FALCO_LIBRARIES httplib::httplib "${CURL_LIBRARIES}" "${OPENSSL_LIBRARIES}"
+		 "${CARES_LIB}"
+	)
 
 	target_compile_definitions(falco_application PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)
 endif()


### PR DESCRIPTION
Root CMake skipped openssl/curl/cpp-httplib and c-ares on APPLE while state.h still included webserver.h on all non-Windows Unix builds, causing missing httplib.h on Darwin. Align userspace/falco targets with those conditions, fix FALCO_INCLUDE_DIRECTORIES typo, and gate CPPHTTPLIB_OPENSSL_SUPPORT with the webserver block.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #3831

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(cmake): enable webserver deps (httplib) on macOS
```
