### PR TITLE
fix(docker): Restrict falco-webui service to local access only

### DIFF
--- a/docker/docker-compose/docker-compose.yaml
+++ b/docker/docker-compose/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
     container_name: falco-webui
     image: falcosecurity/falcosidekick-ui:2.2.0
     ports:
-      - 2802:2802
+      - 127.0.0.1:2802:2802
     depends_on:
       - redis
     command: ['-r', 'redis:6379', '-d']


### PR DESCRIPTION
Change the port binding of the falco-webui service from public access to local access only (127.0.0.1) to enhance security.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:  
Restricts the falco-webui service port binding from public access to local access only (127.0.0.1) to enhance security. This ensures the web UI is only accessible from the host machine, reducing the attack surface.  


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix(docker): Restrict falco-webui service to local access only  
```
