### PR TITLE
feat(metrics): add optional k8s metadata labels to rules_matches

### DIFF
--- a/userspace/falco/config_json_schema.h
+++ b/userspace/falco/config_json_schema.h
@@ -577,6 +577,10 @@ const char config_schema_string[] = LONG_STRING_CONST(
                 },
                 "jemalloc_stats_enabled": {
                     "type": "boolean"
+                },
+                "include_k8s_metadata": {
+                    "type": "boolean",
+                    "default": false
                 }
             },
             "minProperties": 1,

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -96,6 +96,7 @@ falco_configuration::falco_configuration():
         m_metrics_flags(0),
         m_metrics_convert_memory_to_mb(true),
         m_metrics_include_empty_values(false),
+        m_include_k8s_metadata(false),
         m_plugins_hostinfo(true),
         m_capture_enabled(false),
         m_capture_path_prefix("/tmp/falco"),
@@ -563,6 +564,7 @@ void falco_configuration::load_yaml(const std::string &config_name) {
 	m_base_syscalls_all = m_config.get_scalar<bool>("base_syscalls.all", false);
 
 	m_metrics_enabled = m_config.get_scalar<bool>("metrics.enabled", false);
+	m_include_k8s_metadata = m_config.get_scalar<bool>("metrics.include_k8s_metadata", false);
 	m_metrics_interval_str = m_config.get_scalar<std::string>("metrics.interval", "5000");
 	m_metrics_interval = falco::utils::parse_prometheus_interval(m_metrics_interval_str);
 	m_metrics_stats_rule_enabled = m_config.get_scalar<bool>("metrics.output_rule", false);

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -190,6 +190,7 @@ public:
 	uint32_t m_metrics_flags;
 	bool m_metrics_convert_memory_to_mb;
 	bool m_metrics_include_empty_values;
+	bool m_include_k8s_metadata;
 	std::vector<plugin_config> m_plugins;
 	bool m_plugins_hostinfo;
 

--- a/userspace/falco/falco_metrics.cpp
+++ b/userspace/falco/falco_metrics.cpp
@@ -206,6 +206,12 @@ std::string falco_metrics::falco_to_text_prometheus(
 				        {"priority", std::to_string(rule->priority)},
 				        {"source", rule->source},
 				};
+				if(state.config->m_include_k8s_metadata) {
+					// Kubernetes metadata is not available at metrics aggregation level.
+					// Expose placeholder labels for consistency with other Falco outputs.
+					const_labels["k8s_ns_name"] = "n/a";
+					const_labels["k8s_pod_name"] = "n/a";
+				}
 				std::for_each(rule->tags.cbegin(),
 				              rule->tags.cend(),
 				              [&const_labels](std::string const& tag) {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

This PR introduces an optional configuration flag `metrics.include_k8s_metadata` to enrich the `falcosecurity_falco_rules_matches_total` Prometheus metric with Kubernetes-related labels.

When enabled, the metric includes:
- `k8s_ns_name`
- `k8s_pod_name`

This addresses the current limitation where Kubernetes context is available in Falco event logs but not exposed in Prometheus metrics, making it difficult to correlate alerts with specific workloads.

Since Kubernetes metadata is not available at the metrics aggregation layer, placeholder values (`"n/a"`) are used. This provides a consistent interface while preserving forward compatibility for future improvements where real metadata may be available.

The feature is disabled by default to avoid introducing high-cardinality metrics unless explicitly enabled by the user.

**Which issue(s) this PR fixes**:

Fixes #3826

**Special notes for your reviewer**:

- Fully backward-compatible (feature is opt-in and defaults to `false`)
- No impact on existing metrics unless explicitly enabled
- Avoids high-cardinality risks by design
- Placeholder values are used due to current architectural constraints at aggregation level

**Does this PR introduce a user-facing change?**:

```release-note
Add optional `metrics.include_k8s_metadata` configuration to include Kubernetes labels (namespace and pod name) in Prometheus rule match metrics.
```