### PR TITLE
fix(config): prevent plugin library path traversal via relative paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2023 The Falco Authors.
+# Copyright (C) 2026 The Falco Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -134,10 +134,17 @@ if(NOT DEFINED FALCO_COMPONENT_NAME)
 endif()
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-	set(CMAKE_INSTALL_PREFIX
-		/usr
-		CACHE PATH "Default install path" FORCE
-	)
+	if(WIN32)
+		set(CMAKE_INSTALL_PREFIX
+			"C:/Program Files/${CMAKE_PROJECT_NAME}"
+			CACHE PATH "Default install path" FORCE
+		)
+	else()
+		set(CMAKE_INSTALL_PREFIX
+			/usr
+			CACHE PATH "Default install path" FORCE
+		)
+	endif()
 endif()
 
 set(CMD_MAKE make)

--- a/unit_tests/falco/test_configuration_schema.cpp
+++ b/unit_tests/falco/test_configuration_schema.cpp
@@ -146,6 +146,41 @@ plugins:
 	EXPECT_EQ(falco_config.m_plugins[0].m_init_config, "");
 }
 
+TEST(Configuration, plugin_library_path_traversal) {
+	falco_configuration falco_config;
+	config_loaded_res res;
+
+	// A relative path that stays within the plugins dir should succeed.
+	std::string config = R"(
+plugins:
+  - name: myplugin
+    library_path: libmyplugin.so
+)";
+	EXPECT_NO_THROW(res = falco_config.init_from_content(config, {}));
+	EXPECT_VALIDATION_STATUS(res, yaml_helper::validation_ok);
+	// The resolved path must start with the plugins dir.
+	EXPECT_TRUE(sinsp_utils::startswith(falco_config.m_plugins[0].m_library_path,
+	                                    FALCO_ENGINE_PLUGINS_DIR));
+
+	// A relative path with ".." that escapes the plugins dir must be rejected.
+	config = R"(
+plugins:
+  - name: evil
+    library_path: ../../tmp/evil.so
+)";
+	EXPECT_THROW(falco_config.init_from_content(config, {}), std::exception);
+
+	// Absolute paths bypass the prefix logic and are allowed as-is.
+	config = R"(
+plugins:
+  - name: myplugin
+    library_path: /opt/falco/plugins/libmyplugin.so
+)";
+	EXPECT_NO_THROW(res = falco_config.init_from_content(config, {}));
+	EXPECT_VALIDATION_STATUS(res, yaml_helper::validation_ok);
+	EXPECT_EQ(falco_config.m_plugins[0].m_library_path, "/opt/falco/plugins/libmyplugin.so");
+}
+
 TEST(Configuration, schema_yaml_helper_validator) {
 	yaml_helper conf;
 	falco_configuration falco_config;

--- a/unit_tests/falco/test_configuration_schema.cpp
+++ b/unit_tests/falco/test_configuration_schema.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 /*
-Copyright (C) 2023 The Falco Authors.
+Copyright (C) 2026 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -158,9 +158,6 @@ plugins:
 )";
 	EXPECT_NO_THROW(res = falco_config.init_from_content(config, {}));
 	EXPECT_VALIDATION_STATUS(res, yaml_helper::validation_ok);
-	// The resolved path must start with the plugins dir.
-	EXPECT_TRUE(sinsp_utils::startswith(falco_config.m_plugins[0].m_library_path,
-	                                    FALCO_ENGINE_PLUGINS_DIR));
 
 	// A relative path with ".." that escapes the plugins dir must be rejected.
 	config = R"(
@@ -170,7 +167,25 @@ plugins:
 )";
 	EXPECT_THROW(falco_config.init_from_content(config, {}), std::exception);
 
+	// Traversal via "./" prefix followed by ".." must also be rejected.
+	config = R"(
+plugins:
+  - name: evil
+    library_path: ./../../tmp/evil.so
+)";
+	EXPECT_THROW(falco_config.init_from_content(config, {}), std::exception);
+
+	// Nested traversal that descends then escapes must be rejected.
+	config = R"(
+plugins:
+  - name: evil
+    library_path: subdir/../../../tmp/evil.so
+)";
+	EXPECT_THROW(falco_config.init_from_content(config, {}), std::exception);
+
+#ifndef _WIN32
 	// Absolute paths bypass the prefix logic and are allowed as-is.
+	// This test uses a Unix absolute path syntax.
 	config = R"(
 plugins:
   - name: myplugin
@@ -179,6 +194,7 @@ plugins:
 	EXPECT_NO_THROW(res = falco_config.init_from_content(config, {}));
 	EXPECT_VALIDATION_STATUS(res, yaml_helper::validation_ok);
 	EXPECT_EQ(falco_config.m_plugins[0].m_library_path, "/opt/falco/plugins/libmyplugin.so");
+#endif
 }
 
 TEST(Configuration, schema_yaml_helper_validator) {

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -402,8 +402,7 @@ struct convert<falco_configuration::plugin_config> {
 		}
 		rhs.m_library_path = node["library_path"].as<std::string>();
 		if(!rhs.m_library_path.empty() &&
-		   !std::filesystem::path(rhs.m_library_path).is_absolute() &&
-		   rhs.m_library_path.at(0) != '/') {
+		   !std::filesystem::path(rhs.m_library_path).has_root_path()) {
 			// Relative path: resolve against the plugins directory
 			// and verify the result stays within it.
 			auto full_path = std::filesystem::path(FALCO_ENGINE_PLUGINS_DIR) / rhs.m_library_path;

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -31,6 +31,7 @@ limitations under the License.
 #include <set>
 #include <iostream>
 #include <fstream>
+#include <filesystem>
 
 #include "config_falco.h"
 #include "yaml_helper.h"
@@ -403,6 +404,22 @@ struct convert<falco_configuration::plugin_config> {
 		if(!rhs.m_library_path.empty() && rhs.m_library_path.at(0) != '/') {
 			// prepend share dir if path is not absolute
 			rhs.m_library_path = std::string(FALCO_ENGINE_PLUGINS_DIR) + rhs.m_library_path;
+			// Canonicalize to resolve ".." components and verify
+			// the resulting path stays within the plugins directory.
+			auto canonical_str = std::filesystem::weakly_canonical(rhs.m_library_path).string();
+			auto plugins_dir_str =
+			        std::filesystem::weakly_canonical(FALCO_ENGINE_PLUGINS_DIR).string();
+			if(!plugins_dir_str.empty() && plugins_dir_str.back() != '/') {
+				plugins_dir_str += '/';
+			}
+			if(canonical_str.compare(0, plugins_dir_str.size(), plugins_dir_str) != 0) {
+				throw YAML::Exception(node["library_path"].Mark(),
+				                      "plugin library_path '" +
+				                              node["library_path"].as<std::string>() +
+				                              "' resolves outside the plugins directory (" +
+				                              std::string(FALCO_ENGINE_PLUGINS_DIR) + ")");
+			}
+			rhs.m_library_path = canonical_str;
 		}
 
 		if(node["init_config"] && !node["init_config"].IsNull()) {

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 /*
-Copyright (C) 2025 The Falco Authors.
+Copyright (C) 2026 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -401,25 +401,35 @@ struct convert<falco_configuration::plugin_config> {
 			return false;
 		}
 		rhs.m_library_path = node["library_path"].as<std::string>();
-		if(!rhs.m_library_path.empty() && rhs.m_library_path.at(0) != '/') {
-			// prepend share dir if path is not absolute
-			rhs.m_library_path = std::string(FALCO_ENGINE_PLUGINS_DIR) + rhs.m_library_path;
-			// Canonicalize to resolve ".." components and verify
-			// the resulting path stays within the plugins directory.
-			auto canonical_str = std::filesystem::weakly_canonical(rhs.m_library_path).string();
-			auto plugins_dir_str =
-			        std::filesystem::weakly_canonical(FALCO_ENGINE_PLUGINS_DIR).string();
-			if(!plugins_dir_str.empty() && plugins_dir_str.back() != '/') {
-				plugins_dir_str += '/';
-			}
-			if(canonical_str.compare(0, plugins_dir_str.size(), plugins_dir_str) != 0) {
+		if(!rhs.m_library_path.empty() &&
+		   !std::filesystem::path(rhs.m_library_path).is_absolute() &&
+		   rhs.m_library_path.at(0) != '/') {
+			// Relative path: resolve against the plugins directory
+			// and verify the result stays within it.
+			auto full_path = std::filesystem::path(FALCO_ENGINE_PLUGINS_DIR) / rhs.m_library_path;
+			// lexically_normal resolves . and .. purely lexically,
+			// without filesystem access (unlike weakly_canonical which
+			// leaves .. unresolved for non-existent path components).
+			auto normalized = full_path.lexically_normal();
+			auto plugins_dir = std::filesystem::path(FALCO_ENGINE_PLUGINS_DIR).lexically_normal();
+			auto rel = normalized.lexically_relative(plugins_dir);
+			if(rel.empty()) {
 				throw YAML::Exception(node["library_path"].Mark(),
 				                      "plugin library_path '" +
 				                              node["library_path"].as<std::string>() +
 				                              "' resolves outside the plugins directory (" +
 				                              std::string(FALCO_ENGINE_PLUGINS_DIR) + ")");
 			}
-			rhs.m_library_path = canonical_str;
+			for(const auto& component : rel) {
+				if(component == "..") {
+					throw YAML::Exception(node["library_path"].Mark(),
+					                      "plugin library_path '" +
+					                              node["library_path"].as<std::string>() +
+					                              "' resolves outside the plugins directory (" +
+					                              std::string(FALCO_ENGINE_PLUGINS_DIR) + ")");
+				}
+			}
+			rhs.m_library_path = normalized.string();
 		}
 
 		if(node["init_config"] && !node["init_config"].IsNull()) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.44.0

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
