### PR TITLE
fix(engine): show condition text in warning snippet for folded scalar conditions

### DIFF
--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -1541,3 +1541,33 @@ TEST_F(test_falco_engine, deprecated_evt_dir_folded_scalar_condition_snippet) {
 	}
 	FAIL() << "no warning snippet containing 'evt.dir': " << m_load_result_string;
 }
+
+TEST_F(test_falco_engine, deprecated_evt_dir_via_macro_folded_scalar_condition_snippet) {
+	std::string rules_content = R"END(
+- macro: spawned_process
+  condition: evt.type in (execve, execveat) and evt.dir = <
+
+- rule: test_rule
+  desc: test rule
+  condition: >
+    spawned_process and proc.name = bash
+  output: command=%proc.cmdline
+  priority: INFO
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml"));
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+	ASSERT_TRUE(has_warnings());
+	ASSERT_TRUE(check_warning_message("evt.dir")) << m_load_result_string;
+
+	for(const auto& warn : m_load_result_json["warnings"]) {
+		if(warn["code"] != "LOAD_DEPRECATED_ITEM") {
+			continue;
+		}
+		std::string snippet = warn["context"]["snippet"];
+		ASSERT_EQ(snippet.find("condition: >"), std::string::npos) << snippet;
+		ASSERT_NE(snippet.find("spawned_process"), std::string::npos) << snippet;
+		return;
+	}
+	FAIL() << "no LOAD_DEPRECATED_ITEM warning found: " << m_load_result_string;
+}

--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -1516,3 +1516,28 @@ TEST_F(test_falco_engine, no_deprecated_field_warning_in_output) {
 	ASSERT_FALSE(check_warning_message("evt.dir")) << m_load_result_string;
 	EXPECT_EQ(num_rules_for_ruleset(), 1);
 }
+
+TEST_F(test_falco_engine, deprecated_evt_dir_folded_scalar_condition_snippet) {
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: >
+    evt.type = close and evt.dir = <
+  output: user=%user.name
+  priority: INFO
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml"));
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+	ASSERT_TRUE(has_warnings());
+	ASSERT_TRUE(check_warning_message("evt.dir")) << m_load_result_string;
+
+	for(const auto& warn : m_load_result_json["warnings"]) {
+		std::string snippet = warn["context"]["snippet"];
+		if(snippet.find("evt.dir") != std::string::npos) {
+			ASSERT_EQ(snippet.find("condition: >"), std::string::npos) << snippet;
+			return;
+		}
+	}
+	FAIL() << "no warning snippet containing 'evt.dir': " << m_load_result_string;
+}

--- a/userspace/engine/rule_loader_compiler.cpp
+++ b/userspace/engine/rule_loader_compiler.cpp
@@ -374,7 +374,10 @@ bool rule_loader::compiler::compile_condition(const configuration& cfg,
 	               parent_ctx);
 
 	// check for warnings in the filtering condition
-	warn_resolver.run(cond_ctx, *cfg.res, *ast_out.get());
+	// use a condition expression context so the snippet shows the actual condition text
+	// (avoids showing just "condition: >" when YAML folded scalars are used)
+	libsinsp::filter::ast::pos_info pos(0, 0, 0);
+	warn_resolver.run(rule_loader::context(pos, condition, cond_ctx), *cfg.res, *ast_out.get());
 
 	// validate the rule's condition: we compile it into a sinsp filter
 	// on-the-fly and we throw an exception with details on failure


### PR DESCRIPTION
When a rule condition uses YAML folded scalar syntax (`condition: >`), the warning snippet was pointing at the `>` character, making it look like the YAML indicator itself was causing the deprecated field warning (e.g. `evt.dir`). The fix wraps the warning context with the actual condition text, consistent with how compile errors are already handled in the same code path. Added a regression test covering this case. Fixes #3857 

/kind bug
/area engine

```release-note
fix: show condition text in warning snippet for folded scalar conditions
```