### PR TITLE
ci(reusable_test_packages): produce core dumps when falco crashes

### DIFF
--- a/.github/workflows/reusable_test_packages.yaml
+++ b/.github/workflows/reusable_test_packages.yaml
@@ -28,11 +28,18 @@ jobs:
   test-packages:
     # See https://github.com/actions/runner/issues/409#issuecomment-1158849936
     runs-on: ${{ (inputs.arch == 'aarch64' && 'ubuntu-22.04-arm') || 'ubuntu-latest' }}
+    env:
+      ARTIFACT_SUFFIX: >-
+        ${{ format('{0}{1}-{2}{3}',
+        inputs.version,
+        inputs.static == true && '-static' || '',
+        inputs.arch,
+        inputs.sanitizers == true && '-sanitizers' || '') }}
     steps:
       - name: Download binary
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: falco-${{ inputs.version }}${{ inputs.static && '-static' || '' }}-${{ inputs.arch }}${{ inputs.sanitizers == true && '-sanitizers' || '' }}.tar.gz
+          name: falco-${{ env.ARTIFACT_SUFFIX }}.tar.gz
       
       - name: Install Falco package
         run: |
@@ -53,6 +60,11 @@ jobs:
           sudo apt update -y
           sudo apt install -y libasan5 libubsan1
           
+      - name: Enable core dumps
+        run: |
+          sudo sysctl -w kernel.core_pattern=/tmp/core.%e.%p
+          sudo prlimit --pid "$PPID" --core=unlimited:unlimited
+
       - name: Run tests
         env:
           LSAN_OPTIONS: "intercept_tls_get_addr=0"
@@ -65,4 +77,12 @@ jobs:
           static: ${{ inputs.static && 'true' || 'false' }}
           test-drivers: 'true'
           show-all: 'true'
-          report-name-suffix: ${{ inputs.static && '-static' || '' }}${{ inputs.sanitizers && '-sanitizers' || '' }}
+          report-name-suffix: ${{ env.ARTIFACT_SUFFIX }}
+
+      - name: Upload core dumps on failure
+        if: failure()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: testing-core-dumps-${{ env.ARTIFACT_SUFFIX }}
+          path: /tmp/core.*
+          if-no-files-found: ignore


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

/kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area tests

> /area proposals

/area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds support for producing core dumps when falco crashes during testing. Core dumps are uploaded as CI artifacts.
Moreover, it aligns the suffix of each artifact produced in `reusable_test_packages.yaml` by using a common env variable `ARTIFACT_SUFFIX`. This requires the change introduced in https://github.com/falcosecurity/testing/pull/88 to avoid having an architecture repetition in `falcosecurity/testing` report name suffix.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
