### PR TITLE
test(engine): add unit tests for multi-value transformer AST visitors

### DIFF
--- a/unit_tests/engine/test_filter_details_resolver.cpp
+++ b/unit_tests/engine/test_filter_details_resolver.cpp
@@ -48,3 +48,101 @@ TEST(DetailsResolver, resolve_ast) {
 	ASSERT_EQ(details.lists.size(), 1);
 	ASSERT_NE(details.lists.find("known_procs"), details.lists.end());
 }
+
+// Tests for multi-value transformer support
+
+TEST(DetailsResolver, resolve_single_value_transformer) {
+	namespace ast = libsinsp::filter::ast;
+
+	// Build: tolower(proc.name) = nginx
+	auto filter = ast::binary_check_expr::create(
+	        ast::field_transformer_expr::create("tolower",
+	                                            ast::field_expr::create("proc.name", "")),
+	        "=",
+	        ast::value_expr::create("nginx"));
+
+	filter_details details;
+	filter_details_resolver resolver;
+	resolver.run(filter.get(), details);
+
+	ASSERT_EQ(details.fields.size(), 1);
+	ASSERT_NE(details.fields.find("proc.name"), details.fields.end());
+	ASSERT_EQ(details.transformers.size(), 1);
+	ASSERT_NE(details.transformers.find("tolower"), details.transformers.end());
+	ASSERT_EQ(details.operators.size(), 1);
+	ASSERT_NE(details.operators.find("="), details.operators.end());
+}
+
+TEST(DetailsResolver, resolve_multi_value_transformer) {
+	namespace ast = libsinsp::filter::ast;
+
+	// Build: concat(proc.name, proc.pname) = value
+	std::vector<std::unique_ptr<ast::expr>> args;
+	args.push_back(ast::field_expr::create("proc.name", ""));
+	args.push_back(ast::field_expr::create("proc.pname", ""));
+	auto filter =
+	        ast::binary_check_expr::create(ast::field_transformer_expr::create("concat", args),
+	                                       "=",
+	                                       ast::value_expr::create("value"));
+
+	filter_details details;
+	filter_details_resolver resolver;
+	resolver.run(filter.get(), details);
+
+	ASSERT_EQ(details.fields.size(), 2);
+	ASSERT_NE(details.fields.find("proc.name"), details.fields.end());
+	ASSERT_NE(details.fields.find("proc.pname"), details.fields.end());
+	ASSERT_EQ(details.transformers.size(), 1);
+	ASSERT_NE(details.transformers.find("concat"), details.transformers.end());
+}
+
+TEST(DetailsResolver, resolve_transformer_with_list) {
+	namespace ast = libsinsp::filter::ast;
+
+	// Build: join(",", (proc.name, proc.pid)) = value
+	std::vector<std::unique_ptr<ast::expr>> list_children;
+	list_children.push_back(ast::field_expr::create("proc.name", ""));
+	list_children.push_back(ast::field_expr::create("proc.pid", ""));
+
+	std::vector<std::unique_ptr<ast::expr>> transformer_args;
+	transformer_args.push_back(ast::value_expr::create(","));
+	transformer_args.push_back(ast::transformer_list_expr::create(list_children));
+
+	auto filter = ast::binary_check_expr::create(
+	        ast::field_transformer_expr::create("join", transformer_args),
+	        "=",
+	        ast::value_expr::create("value"));
+
+	filter_details details;
+	filter_details_resolver resolver;
+	resolver.run(filter.get(), details);
+
+	ASSERT_EQ(details.fields.size(), 2);
+	ASSERT_NE(details.fields.find("proc.name"), details.fields.end());
+	ASSERT_NE(details.fields.find("proc.pid"), details.fields.end());
+	ASSERT_EQ(details.transformers.size(), 1);
+	ASSERT_NE(details.transformers.find("join"), details.transformers.end());
+}
+
+TEST(DetailsResolver, resolve_nested_transformers) {
+	namespace ast = libsinsp::filter::ast;
+
+	// Build: toupper(tolower(proc.name)) = value
+	auto filter = ast::binary_check_expr::create(
+	        ast::field_transformer_expr::create(
+	                "toupper",
+	                ast::field_transformer_expr::create("tolower",
+	                                                    ast::field_expr::create("proc.name", ""))),
+	        "=",
+	        ast::value_expr::create("value"));
+
+	filter_details details;
+	filter_details_resolver resolver;
+	resolver.run(filter.get(), details);
+
+	ASSERT_EQ(details.fields.size(), 1);
+	ASSERT_NE(details.fields.find("proc.name"), details.fields.end());
+	ASSERT_EQ(details.transformers.size(), 2);
+	ASSERT_NE(details.transformers.find("toupper"), details.transformers.end());
+	ASSERT_NE(details.transformers.find("tolower"), details.transformers.end());
+}

--- a/unit_tests/engine/test_filter_macro_resolver.cpp
+++ b/unit_tests/engine/test_filter_macro_resolver.cpp
@@ -304,3 +304,82 @@ TEST(MacroResolver, should_clone_macro_AST) {
 	macro->left = filter_ast::field_expr::create("another.field", "");
 	ASSERT_FALSE(filter->is_equal(macro.get()));
 }
+
+// Tests for multi-value transformer support
+
+TEST(MacroResolver, should_not_resolve_macro_inside_field_transformer) {
+	namespace ast = libsinsp::filter::ast;
+
+	// Build: tolower(some.field) = value AND test_macro
+	// The transformer wraps a field, not a macro -- no resolution inside it.
+	ast::pos_info macro_pos(1, 0, 10);
+
+	std::shared_ptr<ast::expr> macro =
+	        ast::unary_check_expr::create(ast::field_expr::create("resolved.field", ""), "exists");
+
+	std::vector<std::unique_ptr<ast::expr>> filter_and;
+	filter_and.push_back(ast::binary_check_expr::create(
+	        ast::field_transformer_expr::create("tolower",
+	                                            ast::field_expr::create("some.field", "")),
+	        "=",
+	        ast::value_expr::create("value")));
+	filter_and.push_back(ast::identifier_expr::create(MACRO_NAME, macro_pos));
+	std::shared_ptr<ast::expr> filter = ast::and_expr::create(filter_and);
+
+	filter_macro_resolver resolver;
+	resolver.set_macro(MACRO_NAME, macro);
+
+	ASSERT_TRUE(resolver.run(filter));
+	ASSERT_EQ(resolver.get_resolved_macros().size(), 1);
+	ASSERT_STREQ(resolver.get_resolved_macros().begin()->first.c_str(), MACRO_NAME);
+	ASSERT_TRUE(resolver.get_unknown_macros().empty());
+}
+
+TEST(MacroResolver, should_not_resolve_macro_inside_multi_value_transformer) {
+	namespace ast = libsinsp::filter::ast;
+
+	// Build: join(",", field1, field2) = value
+	// Multi-value transformer with 3 args -- no macro resolution inside.
+	std::vector<std::unique_ptr<ast::expr>> args;
+	args.push_back(ast::value_expr::create(","));
+	args.push_back(ast::field_expr::create("proc.name", ""));
+	args.push_back(ast::field_expr::create("proc.pname", ""));
+
+	std::shared_ptr<ast::expr> filter =
+	        ast::binary_check_expr::create(ast::field_transformer_expr::create("join", args),
+	                                       "=",
+	                                       ast::value_expr::create("value"));
+
+	filter_macro_resolver resolver;
+	resolver.set_macro(MACRO_NAME, ast::field_expr::create("x", ""));
+
+	ASSERT_FALSE(resolver.run(filter));
+	ASSERT_TRUE(resolver.get_resolved_macros().empty());
+	ASSERT_TRUE(resolver.get_unknown_macros().empty());
+}
+
+TEST(MacroResolver, should_not_resolve_macro_inside_transformer_list) {
+	namespace ast = libsinsp::filter::ast;
+
+	// Build: join(",", (field1, field2)) = value
+	// transformer_list_expr wraps multiple fields -- no macro resolution inside.
+	std::vector<std::unique_ptr<ast::expr>> list_children;
+	list_children.push_back(ast::field_expr::create("proc.name", ""));
+	list_children.push_back(ast::field_expr::create("proc.pname", ""));
+
+	std::vector<std::unique_ptr<ast::expr>> transformer_args;
+	transformer_args.push_back(ast::value_expr::create(","));
+	transformer_args.push_back(ast::transformer_list_expr::create(list_children));
+
+	std::shared_ptr<ast::expr> filter = ast::binary_check_expr::create(
+	        ast::field_transformer_expr::create("join", transformer_args),
+	        "=",
+	        ast::value_expr::create("value"));
+
+	filter_macro_resolver resolver;
+	resolver.set_macro(MACRO_NAME, ast::field_expr::create("x", ""));
+
+	ASSERT_FALSE(resolver.run(filter));
+	ASSERT_TRUE(resolver.get_resolved_macros().empty());
+	ASSERT_TRUE(resolver.get_unknown_macros().empty());
+}

--- a/unit_tests/engine/test_filter_warning_resolver.cpp
+++ b/unit_tests/engine/test_filter_warning_resolver.cpp
@@ -45,3 +45,80 @@ TEST(WarningResolver, warnings_in_filtering_conditions) {
 	ASSERT_TRUE(warns("proc.name=test and evt.dir = <"));
 	ASSERT_TRUE(warns("evt.dir = < and proc.name=test"));
 }
+
+// Helper for programmatically-built ASTs (multi-value transformers can't be parsed yet)
+static bool warns_ast(libsinsp::filter::ast::expr& ast) {
+	rule_loader::context ctx("test");
+	rule_loader::result res("test");
+	filter_warning_resolver().run(ctx, res, ast);
+	return res.has_warnings();
+}
+
+TEST(WarningResolver, warnings_with_transformer_wrapping_unsafe_field) {
+	namespace ast = libsinsp::filter::ast;
+
+	// tolower(ka.field) = <NA> -- unsafe field inside transformer, should warn
+	auto filter = ast::binary_check_expr::create(
+	        ast::field_transformer_expr::create("tolower", ast::field_expr::create("ka.field", "")),
+	        "=",
+	        ast::value_expr::create("<NA>"));
+	ASSERT_TRUE(warns_ast(*filter));
+
+	// tolower(safe.field) = <NA> -- safe field inside transformer, should NOT warn
+	auto filter2 = ast::binary_check_expr::create(
+	        ast::field_transformer_expr::create("tolower",
+	                                            ast::field_expr::create("safe.field", "")),
+	        "=",
+	        ast::value_expr::create("<NA>"));
+	ASSERT_FALSE(warns_ast(*filter2));
+}
+
+TEST(WarningResolver, warnings_with_multi_value_transformer) {
+	namespace ast = libsinsp::filter::ast;
+
+	// concat(ka.field, other.field) = <NA> -- has unsafe field, but the warning
+	// resolver traverses through the transformer's values via base_expr_visitor
+	// defaults. The field_expr visit for ka.field sets m_last_node_is_unsafe_field,
+	// but since binary_check_expr only checks the direct left child (the transformer),
+	// the unsafe field detection depends on traversal order.
+	// The base_expr_visitor default for field_transformer_expr iterates e->values,
+	// which will visit field_expr nodes. The last field_expr visited determines
+	// m_last_node_is_unsafe_field state.
+	std::vector<std::unique_ptr<ast::expr>> args;
+	args.push_back(ast::field_expr::create("safe.field", ""));
+	args.push_back(ast::field_expr::create("ka.field", ""));
+	auto filter =
+	        ast::binary_check_expr::create(ast::field_transformer_expr::create("concat", args),
+	                                       "=",
+	                                       ast::value_expr::create("<NA>"));
+	// The base_expr_visitor will traverse into the transformer's values,
+	// and the last field_expr visited (ka.field) will set the unsafe flag.
+	// However, the warning resolver only overrides binary_check_expr to
+	// check the left side, and the base default will visit the transformer's
+	// children. Since field_expr for ka.field sets m_last_node_is_unsafe_field,
+	// this should trigger the warning.
+	ASSERT_TRUE(warns_ast(*filter));
+}
+
+TEST(WarningResolver, no_crash_with_transformer_list) {
+	namespace ast = libsinsp::filter::ast;
+
+	// join(",", (ka.field, safe.field)) = <NA>
+	std::vector<std::unique_ptr<ast::expr>> list_children;
+	list_children.push_back(ast::field_expr::create("ka.field", ""));
+	list_children.push_back(ast::field_expr::create("safe.field", ""));
+
+	std::vector<std::unique_ptr<ast::expr>> transformer_args;
+	transformer_args.push_back(ast::value_expr::create(","));
+	transformer_args.push_back(ast::transformer_list_expr::create(list_children));
+
+	auto filter = ast::binary_check_expr::create(
+	        ast::field_transformer_expr::create("join", transformer_args),
+	        "=",
+	        ast::value_expr::create("<NA>"));
+
+	// Should not crash -- the base_expr_visitor default for transformer_list_expr
+	// is a no-op, so ka.field inside it won't be visited for warning detection.
+	// This is acceptable behavior for now.
+	ASSERT_NO_FATAL_FAILURE(warns_ast(*filter));
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

/area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
