### PR TITLE
chore(scripts): add script updating libs/drivers cmake module versions

### DIFF
--- a/scripts/update-deps-version
+++ b/scripts/update-deps-version
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2026 The Falco Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+# Update the version and recompute the SHA256 checksum in the cmake module for falcosecurity/libs or the driver.
+#
+# Usage:
+#   ./update-deps-version driver <version>
+#   ./update-deps-version libs   <version>
+#
+# <version> can be a commit hash, tag, or branch name.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+usage() {
+	echo "Usage: $(basename "$0") {driver|libs} <version>" >&2
+	exit 1
+}
+
+# Stream a URL directly into sha256sum and print the hash.
+sha256_of_url() {
+	local url="$1"
+	echo "Computing SHA256 for ${url} ..." >&2
+	if command -v curl &>/dev/null; then
+		curl -fsSL --retry 3 "${url}" | sha256sum | awk '{print $1}'
+	elif command -v wget &>/dev/null; then
+		wget -q --tries=3 -O - "${url}" | sha256sum | awk '{print $1}'
+	else
+		echo "Error: neither curl nor wget found" >&2
+		exit 1
+	fi
+}
+
+[[ $# -ne 2 ]] && usage
+SUBCMD="$1"
+VERSION="$2"
+
+case "${SUBCMD}" in
+driver)
+	CMAKE_FILE="${REPO_ROOT}/cmake/modules/driver.cmake"
+	REPO="$(grep -oP 'set\(DRIVER_REPO\s+"\K[^"]+' "${CMAKE_FILE}")"
+	VERSION_VAR="DRIVER_VERSION"
+	CHECKSUM_VAR="DRIVER_CHECKSUM"
+	;;
+libs)
+	CMAKE_FILE="${REPO_ROOT}/cmake/modules/falcosecurity-libs.cmake"
+	REPO="$(grep -oP 'set\(FALCOSECURITY_LIBS_REPO\s+"\K[^"]+' "${CMAKE_FILE}")"
+	VERSION_VAR="FALCOSECURITY_LIBS_VERSION"
+	CHECKSUM_VAR="FALCOSECURITY_LIBS_CHECKSUM"
+	;;
+*)
+	usage
+	;;
+esac
+
+echo "Repo: ${REPO}, Version: ${VERSION}"
+
+SHA256="$(sha256_of_url "https://github.com/${REPO}/archive/${VERSION}.tar.gz")"
+echo "  SHA256: ${SHA256}"
+
+# note: in the following `sed` expressions, `-z` is required in order for `[[:space:]]+` to span across newlines.
+
+# Update the version string in the cmake file, skipping the "0.0.0-local" one by temporarily swapping it with a
+# placeholder and restoring it at the end (note: this is required because `sed` has no negative lookahead`).
+sed -z -i -E \
+	-e 's/"0\.0\.0-local"/PLACEHOLDER/g' \
+	-e "s/(set\(${VERSION_VAR}[[:space:]]+\")[^\"]+(\")/\\1${VERSION}\\2/" \
+	-e 's/PLACEHOLDER/"0.0.0-local"/g' \
+	"${CMAKE_FILE}"
+
+# Update the SHA256 checksum string in the cmake file.
+sed -z -i -E "s/(set\(${CHECKSUM_VAR}[[:space:]]+\"SHA256=)[a-fA-F0-9]+(\")/\\1${SHA256}\\2/" "${CMAKE_FILE}"
+
+echo "Updated ${CMAKE_FILE}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area tests

> /area proposals

> /area CI

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds a utility script under `scripts` called `update-deps-version`. Each time you want to set libs version in `cmake/modules/falcosecurity-libs.cmake`, or the driver version in `cmake/modules/driver.cmake`, you could just issue
```bash
./scripts/update-deps-version libs <version>
./scripts/update-deps-version driver <version>
```
and it will set the versions and, most importantly, the correct checksums.

The following is an example of the output:
```bash
$ ./scripts/update-deps-version libs 957e96b7a0c07229a624f9f263786e0144dbf2db
Repo: falcosecurity/libs, Version: 957e96b7a0c07229a624f9f263786e0144dbf2db
Computing SHA256 for https://github.com/falcosecurity/libs/archive/957e96b7a0c07229a624f9f263786e0144dbf2db.tar.gz ...
  SHA256: 86285520d2ea9d3e84c84370e68b6547173bd161662f0ff314180e20bb4d151f
Updated /home/leonardo.digiovanna/projects/falco/cmake/modules/falcosecurity-libs.cmake
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.44.0

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
