### PR TITLE
feat(metrics): add num_evts counter to Prometheus output

### DIFF
--- a/userspace/falco/app/actions/process_events.cpp
+++ b/userspace/falco/app/actions/process_events.cpp
@@ -386,6 +386,9 @@ static falco::app::run_result do_inspect(
 		}
 
 		num_evts++;
+		if(!is_capture_mode) {
+			s.source_infos.at(source)->num_evts.store(num_evts, std::memory_order_relaxed);
+		}
 	}
 
 	return run_result::ok();

--- a/userspace/falco/app/state.h
+++ b/userspace/falco/app/state.h
@@ -58,6 +58,9 @@ struct state {
 		// source is a plugin one, the assigned inspector must have that
 		// plugin registered in its plugin manager
 		std::shared_ptr<sinsp> inspector;
+		// Userspace event counter for this source. Written by the event loop
+		// and read by the Prometheus metrics endpoint without locking.
+		std::atomic<uint64_t> num_evts{0};
 	};
 
 	state():

--- a/userspace/falco/falco_metrics.cpp
+++ b/userspace/falco/falco_metrics.cpp
@@ -444,6 +444,24 @@ std::string falco_metrics::sources_to_text_prometheus(
 			}
 		}
 
+		// falcosecurity_falco_num_evts_total{evt_source="<source>"} — userspace event counter.
+		// Emitted once per source. Only available in live mode; zero in capture mode.
+		{
+			auto num_evts_metric = libs::metrics::libsinsp_metrics::new_metric(
+			        "num_evts",
+			        METRICS_V2_MISC,
+			        METRIC_VALUE_TYPE_U64,
+			        METRIC_VALUE_UNIT_COUNT,
+			        METRIC_VALUE_METRIC_TYPE_MONOTONIC,
+			        source_info->num_evts.load(std::memory_order_relaxed));
+			prometheus_metrics_converter.convert_metric_to_unit_convention(num_evts_metric);
+			prometheus_text += prometheus_metrics_converter.convert_metric_to_text_prometheus(
+			        num_evts_metric,
+			        "falcosecurity",
+			        "falco",
+			        {{"evt_source", source}});
+		}
+
 		// Source wrapper metrics Part B: Agnostic, performed only once.
 		if(agent_info_written && machine_info_written) {
 			continue;


### PR DESCRIPTION
## What

Adds `falcosecurity_falco_num_evts_total` to the Prometheus metrics endpoint, closing the gap noted in #3584.

The metric tracks userspace-processed events per event source:

```
# HELP falcosecurity_falco_num_evts_total https://falco.org/docs/metrics/
# TYPE falcosecurity_falco_num_evts_total counter
falcosecurity_falco_num_evts_total{evt_source="syscall"} 48271
```

## Why

`falco.num_evts` is already present in all other metrics sinks (file, stdout, rule output via `stats_writer`) but was missing from the Prometheus endpoint because `falco_metrics::to_text_prometheus` only has access to `state` and the counter was never stored there.

## How

Three minimal changes:

1. **`userspace/falco/app/state.h`** — add `std::atomic<uint64_t> num_evts{0}` to `state::source_info`. One counter per source, lock-free.

2. **`userspace/falco/app/actions/process_events.cpp`** — after each `num_evts++` in the event loop, store the updated value into `state::source_info` with `memory_order_relaxed`. Guarded by `!is_capture_mode` since capture mode has no named source in `source_infos`.

3. **`userspace/falco/falco_metrics.cpp`** — emit the metric in `sources_to_text_prometheus()` for each source, using an `evt_source` label to match the label convention already used by `scap_engine_name_info` and `n_evts_cpu` in the same function. Placed before the `agent_info_written && machine_info_written` continue-shortcut so it fires for every source.

## Notes

- **Capture mode:** counter is zero in capture mode. Metric is still emitted so dashboards do not error.
- **Thread safety:** `memory_order_relaxed` is sufficient — Prometheus scrape only needs an eventually consistent snapshot.
- **Flag:** `METRICS_V2_MISC` matches `outputs_queue_num_drops`, `reload_ts`, and other always-on wrapper metrics.

## Testing

Built locally. The metric appears in `/metrics` with:

```yaml
metrics:
  enabled: true
  output_rule: true
```

Closes #3584

```release-note
Add falcosecurity_falco_num_evts_total counter to Prometheus metrics output, bringing it to parity with other metrics sinks (file, stdout, rule output) that already expose falco.num_evts.
```