### PR TITLE
feat(engine): support string comparator modifiers

### DIFF
--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -1705,3 +1705,481 @@ TEST_F(test_falco_engine, rule_capture_wrong_type) {
 	ASSERT_TRUE(load_rules(rules_content, "rules.yaml"));
 	ASSERT_VALIDATION_STATUS(yaml_helper::validation_failed) << m_load_result->schema_validation();
 }
+
+// ---------------------------------------------------------------------------
+// Tests for compound modifier operators in exception comps.
+//
+// libs 0.25.0 (falcosecurity/libs#2983) introduced oneof/anyof/allof as
+// modifiers for string operators in condition expressions, e.g.:
+//   proc.name startswith oneof (sshd, sudo)
+//
+// rule_loader_collector.cpp and rule_loader_compiler.cpp were patched to
+// accept the same compound forms in exception comps.
+//
+// Value format for compound comps uses the list-fields form:
+//   fields: [field]
+//   comps:  [startswith oneof]
+//   values: - [[val1, val2, val3]]   <- inner list is the RHS list for oneof
+// ---------------------------------------------------------------------------
+
+// ----- single-field exceptions with compound comps -----
+
+TEST_F(test_falco_engine, exceptions_modifier_op_startswith_oneof) {
+	// Verify: single-field exception with "startswith oneof" loads successfully
+	// and produces the correct compiled condition.
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [proc.name]
+      comps: [startswith oneof]
+      values:
+        - [[sshd, sudo, systemd]]
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+	ASSERT_EQ(get_compiled_rule_condition("test_rule"),
+	          "(evt.type = open and not proc.name startswith oneof (sshd, sudo, systemd))");
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_contains_allof) {
+	// Verify: "contains allof" in exception comps.
+	// For a single-value field, allof expands to a logical AND: the exception
+	// fires when proc.cmdline contains every listed token simultaneously.
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = execve
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [proc.cmdline]
+      comps: [contains allof]
+      values:
+        - [[curl, bash]]
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+	ASSERT_EQ(get_compiled_rule_condition("test_rule"),
+	          "(evt.type = execve and not proc.cmdline contains allof (curl, bash))");
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_endswith_anyof) {
+	// Verify: "endswith anyof" is accepted (anyof = at least one match).
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [fd.name]
+      comps: [endswith anyof]
+      values:
+        - [[.sh, .py, .pl]]
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+	ASSERT_EQ(get_compiled_rule_condition("test_rule"),
+	          "(evt.type = open and not fd.name endswith anyof (.sh, .py, .pl))");
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_glob_oneof) {
+	// Verify: "glob oneof" is accepted.
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [fd.name]
+      comps: [glob oneof]
+      values:
+        - [["/tmp/*.sh", "/tmp/*.py", "/dev/shm/*.sh"]]
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_icontains_oneof) {
+	// Verify: "icontains oneof" is accepted (case-insensitive substring match).
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = execve
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [proc.cmdline]
+      comps: [icontains oneof]
+      values:
+        - [[MONITOR, HEALTHCHECK, PROBE]]
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+}
+
+// ----- multi-field exceptions with compound comps -----
+
+TEST_F(test_falco_engine, exceptions_modifier_op_multi_field_mixed) {
+	// Verify: multi-field exception where the first comp is a compound operator
+	// and the second is a plain operator.
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [proc.name, fd.name]
+      comps: [startswith oneof, startswith]
+      values:
+        - [[sshd, sudo], /etc/]
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+	ASSERT_EQ(get_compiled_rule_condition("test_rule"),
+	          "(evt.type = open and not (proc.name startswith oneof (sshd, sudo) and "
+	          "fd.name startswith /etc/))");
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_multi_field_both_compound) {
+	// Verify: multi-field exception where both comps are compound operators.
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [proc.exepath, fd.name]
+      comps: [endswith anyof, glob oneof]
+      values:
+        - [[/dpkg, /rpm, /pip], ["/tmp/*.deb", "/tmp/*.rpm"]]
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+}
+
+// ----- rejection of invalid compound comps -----
+
+TEST_F(test_falco_engine, exceptions_modifier_op_invalid_base_operator) {
+	// Verify: a compound comp with an invalid base operator is rejected.
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [proc.name]
+      comps: [frobulate oneof]
+      values:
+        - [[bash]]
+)END";
+
+	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
+	ASSERT_TRUE(check_error_message("'frobulate oneof' is not a supported comparison operator"));
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_invalid_base_operator_scalar_field) {
+	// Verify: a compound comp with an invalid base operator is rejected when
+	// fields is a scalar string (single-value validation path, distinct from the
+	// list-fields path tested by exceptions_modifier_op_invalid_base_operator).
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: proc.name
+      comps: frobulate oneof
+      values:
+        - [bash]
+)END";
+
+	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
+	ASSERT_TRUE(check_error_message("comps must be one of"));
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_list_op_with_modifier) {
+	// Verify: list operators (in, pmatch, intersects) combined with a modifier
+	// are rejected — modifiers are only legal with string operators.
+	// "in oneof" would parse without throwing from str_to_cmpop_with_modifier
+	// but the filter grammar never allows a modifier after a list operator.
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [proc.name]
+      comps: [in oneof]
+      values:
+        - [[bash]]
+)END";
+
+	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
+	ASSERT_TRUE(check_error_message("'in oneof' is not a supported comparison operator"));
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_numeric_op_with_modifier) {
+	// Verify: numeric operators (<=, <, >=, >) combined with a modifier are
+	// rejected — modifiers are only legal with string operators.
+	// '>=' must be quoted in YAML flow sequences (bare '>' is an unknown token
+	// for yaml-cpp in flow context).
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [proc.pid]
+      comps: [">= oneof"]
+      values:
+        - [[1000]]
+)END";
+
+	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
+	ASSERT_TRUE(check_error_message("'>= oneof' is not a supported comparison operator"));
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_modifier_alone) {
+	// Verify: a bare modifier keyword without a base operator is rejected.
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [proc.name]
+      comps: [oneof]
+      values:
+        - [[bash]]
+)END";
+
+	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
+	ASSERT_TRUE(check_error_message("'oneof' is not a supported comparison operator"));
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_list_op_unchanged) {
+	// Regression: plain list operators (in, pmatch, intersects) in single-field
+	// exceptions must still work exactly as before.
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex_in
+      fields: proc.name
+      comps: in
+      values:
+        - cat
+        - grep
+    - name: ex_pmatch
+      fields: proc.exepath
+      comps: pmatch
+      values:
+        - /usr/bin/
+        - /usr/local/bin/
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_eq_oneof) {
+	// Verify: "= oneof" is accepted.  The equality operator is a single character;
+	// is_operator_with_modifier must split "= oneof" correctly into base "=" and
+	// modifier "oneof".
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = execve
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [proc.name]
+      comps: [= oneof]
+      values:
+        - [[nmap, masscan, nikto]]
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+	ASSERT_EQ(get_compiled_rule_condition("test_rule"),
+	          "(evt.type = execve and not proc.name = oneof (nmap, masscan, nikto))");
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_regex_oneof) {
+	// Verify: "regex oneof" is accepted with patterns that genuinely require
+	// regex (character classes, quantifiers).
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = execve
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [proc.name]
+      comps: [regex oneof]
+      values:
+        - [["research[0-9]+", "pentest-[0-9]{2,4}"]]
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_scalar_value_parenthesised) {
+	// Exercises the is_operator_for_list fix in rule_loader_compiler.cpp.
+	// When a single scalar value (not a nested list) is paired with a compound
+	// comp, the compiler must parenthesise it:
+	//   proc.name startswith oneof (sshd)    <- correct
+	//   proc.name startswith oneof sshd      <- invalid — no parens
+	// Without the fix, is_operator_for_list("startswith oneof") returned false
+	// and the value would be left unparenthesised, causing a parse error.
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [proc.name]
+      comps: [startswith oneof]
+      values:
+        - [sshd]
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+	ASSERT_EQ(get_compiled_rule_condition("test_rule"),
+	          "(evt.type = open and not proc.name startswith oneof (sshd))");
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_all_three_modifiers) {
+	// Verify: oneof, anyof, and allof all parse correctly for the same base
+	// operator in three separate exceptions on the same rule.
+	// For single-value fields the three modifiers produce distinct semantics
+	// (oneof=exactly-one, anyof=at-least-one, allof=logical-AND across RHS),
+	// but all three must be accepted by the validator and compiler.
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = execve
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex_oneof
+      fields: [proc.name]
+      comps: [startswith oneof]
+      values:
+        - [[ssh, su]]
+    - name: ex_anyof
+      fields: [proc.name]
+      comps: [startswith anyof]
+      values:
+        - [[ssh, su]]
+    - name: ex_allof
+      fields: [proc.cmdline]
+      comps: [contains allof]
+      values:
+        - [[curl, ci.internal]]
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+	ASSERT_EQ(get_compiled_rule_condition("test_rule"),
+	          "(evt.type = execve and not proc.name startswith oneof (ssh, su) and not "
+	          "proc.name startswith anyof (ssh, su) and not proc.cmdline contains allof "
+	          "(curl, ci.internal))");
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_comp_whitespace_normalized) {
+	// Comp strings with surrounding whitespace must be accepted: normalize_comp()
+	// in validate_exception_info strips them before the strict operator check,
+	// so the stored value is always canonical and the check itself stays exact.
+	// YAML quoted scalars are used below so the parser preserves the spaces.
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex_single
+      fields: [proc.name]
+      comps: ["  startswith oneof  "]
+      values:
+        - [[sshd, sudo]]
+    - name: ex_multi
+      fields: [proc.name, fd.name]
+      comps: ["  contains  ", "  startswith anyof  "]
+      values:
+        - [agent, [/etc/, /var/]]
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+	ASSERT_EQ(get_compiled_rule_condition("test_rule"),
+	          "(evt.type = open and not proc.name startswith oneof (sshd, sudo) and not "
+	          "(proc.name contains agent and fd.name startswith anyof (/etc/, /var/)))");
+}
+
+TEST_F(test_falco_engine, exceptions_modifier_op_str_op_multi_field_regression) {
+	// Regression: plain string operators in multi-field exceptions must still
+	// work after the is_operator_defined change (now uses && with
+	// is_operator_with_modifier instead of plain !is_operator_defined).
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule
+  condition: evt.type = open
+  output: command=%proc.cmdline
+  priority: INFO
+  exceptions:
+    - name: ex
+      fields: [proc.name, fd.name, proc.exepath]
+      comps: [contains, startswith, =]
+      values:
+        - [agent, /var/log/, /usr/bin/prometheus]
+)END";
+
+	ASSERT_TRUE(load_rules(rules_content, "rules.yaml")) << m_load_result_string;
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+	ASSERT_EQ(get_compiled_rule_condition("test_rule"),
+	          "(evt.type = open and not (proc.name contains agent and fd.name startswith "
+	          "/var/log/ and proc.exepath = /usr/bin/prometheus))");
+}

--- a/userspace/engine/rule_loader_cmpop.h
+++ b/userspace/engine/rule_loader_cmpop.h
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2026 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <libsinsp/filter_compare.h>
+#include <libsinsp/sinsp_exception.h>
+
+// Returns true when a base cmpop can legally be combined with a list modifier.
+// Mirrors the s_binary_str_ops set in libs' filter/parser.cpp: only string
+// comparison operators support oneof/anyof/allof in the filter grammar.
+inline bool cmpop_supports_modifier(cmpop op) {
+	switch(op) {
+	case CO_EQ:
+	case CO_NE:
+	case CO_CONTAINS:
+	case CO_ICONTAINS:
+	case CO_BCONTAINS:
+	case CO_STARTSWITH:
+	case CO_BSTARTSWITH:
+	case CO_ENDSWITH:
+	case CO_GLOB:
+	case CO_IGLOB:
+	case CO_REGEX:
+		return true;
+	default:
+		return false;
+	}
+}
+
+// Returns true when `op` is a string operator legally combined with a list
+// modifier, e.g. "startswith oneof", "contains allof", "glob anyof".
+// Returns false for plain operators, unknown tokens, and illegal combinations
+// such as "in oneof" or ">= oneof".
+inline bool is_str_operator_with_modifier(const std::string& op) {
+	try {
+		auto cmp = str_to_cmpop_with_modifier(op);
+		return cmp.mod != CMPOP_MOD_NONE && cmpop_supports_modifier(cmp.op);
+	} catch(const sinsp_exception&) {
+		return false;
+	}
+}

--- a/userspace/engine/rule_loader_collector.cpp
+++ b/userspace/engine/rule_loader_collector.cpp
@@ -18,6 +18,8 @@ limitations under the License.
 #include <string>
 #include <libsinsp/version.h>
 
+#include "rule_loader_cmpop.h"
+
 #include "falco_engine.h"
 #include "rule_loader_collector.h"
 #include "rule_loading_messages.h"
@@ -34,6 +36,22 @@ limitations under the License.
 static inline bool is_operator_defined(const std::string& op) {
 	auto ops = libsinsp::filter::parser::supported_operators();
 	return find(ops.begin(), ops.end(), op) != ops.end();
+}
+
+// Strips leading and trailing ASCII whitespace from a comp string so that
+// validation and downstream assembly always see canonical operator tokens.
+static inline void normalize_comp(std::string& s) {
+	const char* ws = " \t\r\n";
+	const auto z = s.find_last_not_of(ws);
+	if(z == std::string::npos) {
+		s.clear();
+		return;
+	}
+	s.erase(z + 1);
+	const auto a = s.find_first_not_of(ws);
+	if(a != 0) {
+		s.erase(0, a);
+	}
 }
 
 template<typename T>
@@ -72,8 +90,9 @@ static void validate_exception_info(const falco_source* source,
 		THROW(ex.fields.items.size() != ex.comps.items.size(),
 		      "Fields and comps lists must have equal length",
 		      ex.ctx);
-		for(const auto& v : ex.comps.items) {
-			THROW(!is_operator_defined(v.item),
+		for(auto& v : ex.comps.items) {
+			normalize_comp(v.item);
+			THROW(!is_operator_defined(v.item) && !is_str_operator_with_modifier(v.item),
 			      std::string("'") + v.item + "' is not a supported comparison operator",
 			      ex.ctx);
 		}
@@ -90,8 +109,11 @@ static void validate_exception_info(const falco_source* source,
 			ex.comps.item = "in";
 		}
 		THROW(ex.comps.is_list, "Fields and comps must both be strings", ex.ctx);
-		THROW((ex.comps.item != "in" && ex.comps.item != "pmatch" && ex.comps.item != "intersects"),
-		      "When fields is a single value, comps must be one of (in, pmatch, intersects)",
+		normalize_comp(ex.comps.item);
+		THROW((ex.comps.item != "in" && ex.comps.item != "pmatch" &&
+		       ex.comps.item != "intersects" && !is_str_operator_with_modifier(ex.comps.item)),
+		      "When fields is a single value, comps must be one of "
+		      "(in, pmatch, intersects) or a modifier operator (e.g. startswith oneof)",
 		      ex.ctx);
 		if(source) {
 			THROW(!source->is_valid_lhs_field(ex.fields.item),

--- a/userspace/engine/rule_loader_compiler.cpp
+++ b/userspace/engine/rule_loader_compiler.cpp
@@ -20,6 +20,8 @@ limitations under the License.
 #include <set>
 #include <vector>
 
+#include "rule_loader_cmpop.h"
+
 #include "rule_loader_compiler.h"
 #include "filter_warning_resolver.h"
 
@@ -58,7 +60,12 @@ static void paren_item(std::string& e) {
 
 static inline bool is_operator_for_list(const std::string& op) {
 	auto ops = libsinsp::filter::parser::supported_operators(true);
-	return find(ops.begin(), ops.end(), op) != ops.end();
+	if(find(ops.begin(), ops.end(), op) != ops.end()) {
+		return true;
+	}
+	// Compound operators (e.g. "startswith oneof", "contains allof") take a
+	// parenthesised list as RHS, just like the built-in list operators.
+	return is_str_operator_with_modifier(op);
 }
 
 static bool is_format_valid(const falco_source& source, std::string fmt, std::string& err) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

/area tests

> /area proposals

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

We are missing the support for the new string comp modifiers. This adds it to the falco engine.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
feat(engine): support string comparator modifiers (oneof/allof/anyof)
```
