### PR TITLE
fix(userspace): Escape output controls

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(
 	engine/test_filter_details_resolver.cpp
 	engine/test_filter_macro_resolver.cpp
 	engine/test_filter_warning_resolver.cpp
+	engine/test_formats.cpp
 	engine/test_plugin_requirements.cpp
 	engine/test_rule_loader.cpp
 	engine/test_rulesets.cpp
@@ -51,6 +52,7 @@ add_executable(
 	falco/test_configuration_env_vars.cpp
 	falco/test_configuration_output_options.cpp
 	falco/test_configuration_schema.cpp
+	falco/test_outputs.cpp
 	falco/app/actions/test_select_event_sources.cpp
 	falco/app/actions/test_load_config.cpp
 )

--- a/unit_tests/engine/test_formats.cpp
+++ b/unit_tests/engine/test_formats.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <engine/formats.h>
+
+#include "../test_falco_engine.h"
+
+namespace {
+
+static void init_test_event(sinsp_evt &evt, sinsp &inspector, scap_evt &scap_evt) {
+	scap_evt.ts = 1000000000;
+	scap_evt.tid = 1;
+	scap_evt.len = sizeof(scap_evt);
+	scap_evt.type = PPME_GENERIC_E;
+	scap_evt.nparams = 0;
+	evt.init_from_raw(&inspector, &scap_evt, 0);
+}
+
+}  // namespace
+
+TEST(FalcoFormats, escape_text_output_controls) {
+	ASSERT_EQ(falco_formats::escape_text_output(""), "");
+	ASSERT_EQ(falco_formats::escape_text_output("\n"), "\\n");
+	ASSERT_EQ(falco_formats::escape_text_output("\r"), "\\r");
+	ASSERT_EQ(falco_formats::escape_text_output("\t"), "\\t");
+	ASSERT_EQ(falco_formats::escape_text_output(std::string(1, '\x1b')), "\\u001b");
+	ASSERT_EQ(falco_formats::escape_text_output(std::string("a\0b", 3)), "a\\u0000b");
+	ASSERT_EQ(falco_formats::escape_text_output(std::string(1, '\x7f')), "\\u007f");
+	ASSERT_EQ(falco_formats::escape_text_output(std::string(1, '\x1f')), "\\u001f");
+}
+
+TEST(FalcoFormats, escape_text_output_keeps_printable_bytes) {
+	ASSERT_EQ(falco_formats::escape_text_output(" "), " ");
+
+	const std::string utf8 = std::string("\xc3\xa9", 2);
+	ASSERT_EQ(falco_formats::escape_text_output(utf8), utf8);
+}
+
+TEST_F(test_falco_engine, format_event_escapes_normal_output) {
+	scap_evt raw_evt = {};
+	sinsp_evt evt;
+	init_test_event(evt, m_inspector, raw_evt);
+
+	falco_formats formats(m_engine, true, false, false, false, false);
+	std::set<std::string> tags;
+	extra_output_field_t extra_fields;
+	const std::string output = formats.format_event(&evt,
+	                                                "test rule",
+	                                                falco_common::syscall_source,
+	                                                "Warning",
+	                                                "line\nnext\tend",
+	                                                tags,
+	                                                "host",
+	                                                extra_fields);
+
+	ASSERT_NE(output.find(": Warning line\\nnext\\tend"), std::string::npos);
+	ASSERT_EQ(output.find("line\nnext"), std::string::npos);
+}
+
+TEST_F(test_falco_engine, format_event_json_output_is_not_double_escaped) {
+	m_formatter_factory->set_output_format(sinsp_evt_formatter::OF_JSON);
+
+	scap_evt raw_evt = {};
+	sinsp_evt evt;
+	init_test_event(evt, m_inspector, raw_evt);
+
+	falco_formats formats(m_engine, true, false, true, false, false);
+	std::set<std::string> tags;
+	extra_output_field_t extra_fields;
+	const std::string output = formats.format_event(&evt,
+	                                                "test rule",
+	                                                falco_common::syscall_source,
+	                                                "Warning",
+	                                                "line\nnext",
+	                                                tags,
+	                                                "host",
+	                                                extra_fields);
+
+	const auto event = nlohmann::json::parse(output);
+	ASSERT_EQ(event.at("message").get<std::string>(), "line\nnext");
+	ASSERT_NE(event.at("output").get<std::string>().find("line\nnext"), std::string::npos);
+	ASSERT_EQ(output.find(R"(line\\nnext)"), std::string::npos);
+}

--- a/unit_tests/falco/test_outputs.cpp
+++ b/unit_tests/falco/test_outputs.cpp
@@ -1,0 +1,50 @@
+#include <gtest/gtest.h>
+
+#include <falco/falco_outputs.h>
+
+#include <filesystem>
+#include <fstream>
+
+TEST(FalcoOutputs, handle_msg_escapes_plain_text_output) {
+	const auto output_path =
+	        std::filesystem::temp_directory_path() / "falco_outputs_handle_msg_escape.txt";
+	std::filesystem::remove(output_path);
+
+	falco::outputs::config output_config;
+	output_config.name = "file";
+	output_config.options["filename"] = output_path.string();
+	output_config.options["keep_alive"] = "false";
+
+	{
+		std::vector<falco::outputs::config> outputs = {output_config};
+		auto engine = std::make_shared<falco_engine>();
+		falco_outputs falco_outputs(engine,
+		                            outputs,
+		                            false,
+		                            true,
+		                            true,
+		                            true,
+		                            true,
+		                            1000,
+		                            false,
+		                            1024,
+		                            false,
+		                            "host");
+		nlohmann::json output_fields = nlohmann::json::object();
+		output_fields["detail"] = "value";
+
+		falco_outputs.handle_msg(1000000000,
+		                         falco_common::PRIORITY_WARNING,
+		                         "line\nnext\tend",
+		                         "test rule",
+		                         output_fields);
+	}
+
+	std::ifstream input(output_path);
+	std::string contents((std::istreambuf_iterator<char>(input)),
+	                     std::istreambuf_iterator<char>());
+	std::filesystem::remove(output_path);
+
+	ASSERT_NE(contents.find(": Warning line\\nnext\\tend ("), std::string::npos);
+	ASSERT_EQ(contents.find("line\nnext"), std::string::npos);
+}

--- a/userspace/engine/formats.cpp
+++ b/userspace/engine/formats.cpp
@@ -36,6 +36,38 @@ falco_formats::falco_formats(std::shared_ptr<const falco_engine> engine,
 
 falco_formats::~falco_formats() {}
 
+std::string falco_formats::escape_text_output(const std::string &output) {
+	static const char hex[] = "0123456789abcdef";
+
+	std::string escaped;
+	escaped.reserve(output.size());
+
+	for(unsigned char c : output) {
+		switch(c) {
+		case '\n':
+			escaped += "\\n";
+			break;
+		case '\r':
+			escaped += "\\r";
+			break;
+		case '\t':
+			escaped += "\\t";
+			break;
+		default:
+			if(c < 0x20 || c == 0x7f) {
+				escaped += "\\u00";
+				escaped += hex[c >> 4];
+				escaped += hex[c & 0x0f];
+			} else {
+				escaped += static_cast<char>(c);
+			}
+			break;
+		}
+	}
+
+	return escaped;
+}
+
 std::string falco_formats::format_event(sinsp_evt *evt,
                                         const std::string &rule,
                                         const std::string &source,
@@ -74,7 +106,7 @@ std::string falco_formats::format_event(sinsp_evt *evt,
 	std::string output = prefix + " " + message;
 
 	if(message_formatter->get_output_format() == sinsp_evt_formatter::OF_NORMAL) {
-		return output;
+		return escape_text_output(output);
 	} else if(message_formatter->get_output_format() == sinsp_evt_formatter::OF_JSON) {
 		std::string json_fields_message;
 		std::string json_fields_prefix;

--- a/userspace/engine/formats.h
+++ b/userspace/engine/formats.h
@@ -40,6 +40,8 @@ public:
 	                         const std::string &hostname,
 	                         const extra_output_field_t &extra_fields) const;
 
+	static std::string escape_text_output(const std::string &output);
+
 	std::string format_string(sinsp_evt *evt,
 	                          const std::string &format,
 	                          const std::string &source) const;

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -210,10 +210,11 @@ void falco_outputs::handle_msg(uint64_t ts,
 		cmsg.msg = jmsg.dump();
 	} else {
 		std::string timestr;
+		std::string escaped_msg = falco_formats::escape_text_output(msg);
 		bool first = true;
 
 		sinsp_utils::ts_to_string(ts, &timestr, false, true);
-		cmsg.msg = timestr + ": " + falco_common::format_priority(priority) + " " + msg + " (";
+		cmsg.msg = timestr + ": " + falco_common::format_priority(priority) + " " + escaped_msg + " (";
 		for(auto &pair : output_fields.items()) {
 			if(first) {
 				first = false;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Escapes control characters in plain text Falco output so event field values cannot inject forged lines or terminal control sequences.

* I kept JSON output on `nlohmann::json::dump()` so structured consumers do not get double-escaped values
* I handled internal plain text messages because they use the same output sinks
* I left the libs formatter path alone because Falco owns the text serialization boundary here

**Which issue(s) this PR fixes**:

Closes #3895

**Special notes for your reviewer**:

Assumption: downstream JSON consumers expect decoded `output_fields` values to stay unchanged.

Out of scope: `format_event()` still assumes a non-empty rule output format before indexing `message_format[0]`.

**Does this PR introduce a user-facing change?**:

```release-note
Plain text outputs now escape control characters in rendered alert text.