### PR TITLE
fix(userspace/engine): backtrack in matches_wildcard

### DIFF
--- a/unit_tests/engine/test_falco_utils.cpp
+++ b/unit_tests/engine/test_falco_utils.cpp
@@ -101,4 +101,17 @@ TEST(FalcoUtils, matches_wildcard) {
 	ASSERT_FALSE(falco::utils::matches_wildcard("hello*world", "hello new world yes"));
 	ASSERT_FALSE(falco::utils::matches_wildcard("*hello*world", "come on hello this world yes"));
 	ASSERT_FALSE(falco::utils::matches_wildcard("*hello*world*", "come on hello this yes"));
+
+	// Backtracking: when a wildcard segment is followed by a literal that
+	// occurs more than once in `s`, matching the first occurrence is not
+	// always correct. The matcher must try later occurrences before giving up.
+	ASSERT_TRUE(falco::utils::matches_wildcard("*ab", "xabab"));
+	ASSERT_TRUE(falco::utils::matches_wildcard("*.yaml", "backup.yaml.yaml"));
+	ASSERT_TRUE(falco::utils::matches_wildcard("*foo*bar", "foofoobar"));
+	ASSERT_TRUE(falco::utils::matches_wildcard("*ab*ab", "ababab"));
+	ASSERT_TRUE(falco::utils::matches_wildcard("hello*world", "hello world hello world"));
+
+	// Backtracking must still respect a non-matching suffix.
+	ASSERT_FALSE(falco::utils::matches_wildcard("*ab", "xabcd"));
+	ASSERT_FALSE(falco::utils::matches_wildcard("*foo*bar", "foofoobaz"));
 }

--- a/unit_tests/engine/test_falco_utils.cpp
+++ b/unit_tests/engine/test_falco_utils.cpp
@@ -111,6 +111,13 @@ TEST(FalcoUtils, matches_wildcard) {
 	ASSERT_TRUE(falco::utils::matches_wildcard("*ab*ab", "ababab"));
 	ASSERT_TRUE(falco::utils::matches_wildcard("hello*world", "hello world hello world"));
 
+	// Consecutive wildcards (`**`) collapse to a single `*` because the
+	// leading run of stars is consumed in one step by `find_first_not_of`,
+	// so backtracking behaves identically whether the pattern says `*` or `**`.
+	ASSERT_TRUE(falco::utils::matches_wildcard("**ab", "xabab"));
+	ASSERT_TRUE(falco::utils::matches_wildcard("**ab**ab", "ababab"));
+	ASSERT_FALSE(falco::utils::matches_wildcard("**ab", "xabcd"));
+
 	// Backtracking must still respect a non-matching suffix.
 	ASSERT_FALSE(falco::utils::matches_wildcard("*ab", "xabcd"));
 	ASSERT_FALSE(falco::utils::matches_wildcard("*foo*bar", "foofoobaz"));

--- a/userspace/engine/falco_engine_version.h
+++ b/userspace/engine/falco_engine_version.h
@@ -20,7 +20,7 @@ limitations under the License.
 
 // The version of this Falco engine
 #define FALCO_ENGINE_VERSION_MAJOR 0
-#define FALCO_ENGINE_VERSION_MINOR 62
+#define FALCO_ENGINE_VERSION_MINOR 63
 #define FALCO_ENGINE_VERSION_PATCH 0
 
 #define FALCO_ENGINE_VERSION                                                               \

--- a/userspace/engine/falco_engine_version.h
+++ b/userspace/engine/falco_engine_version.h
@@ -20,7 +20,7 @@ limitations under the License.
 
 // The version of this Falco engine
 #define FALCO_ENGINE_VERSION_MAJOR 0
-#define FALCO_ENGINE_VERSION_MINOR 63
+#define FALCO_ENGINE_VERSION_MINOR 64
 #define FALCO_ENGINE_VERSION_PATCH 0
 
 #define FALCO_ENGINE_VERSION                                                               \

--- a/userspace/engine/falco_utils.cpp
+++ b/userspace/engine/falco_utils.cpp
@@ -230,13 +230,23 @@ bool matches_wildcard(const std::string& pattern, const std::string& s) {
 
 		std::string next_pattern = pattern.substr(next_pattern_start);
 		std::string to_find = next_pattern.substr(0, next_pattern.find("*"));
-		std::string::size_type lit_pos = s.find(to_find);
-		if(lit_pos == std::string::npos) {
-			return false;
-		}
+		std::string remaining_pattern = next_pattern.substr(to_find.size());
 
-		return matches_wildcard(next_pattern.substr(to_find.size()),
-		                        s.substr(lit_pos + to_find.size()));
+		// The first occurrence of `to_find` in `s` is not always the right
+		// one. For instance, `*ab` against `xabab`: matching the `ab` at
+		// index 1 leaves `ab` unmatched against the empty remaining pattern.
+		// Try each occurrence and backtrack on failure.
+		std::string::size_type search_from = 0;
+		while(true) {
+			std::string::size_type lit_pos = s.find(to_find, search_from);
+			if(lit_pos == std::string::npos) {
+				return false;
+			}
+			if(matches_wildcard(remaining_pattern, s.substr(lit_pos + to_find.size()))) {
+				return true;
+			}
+			search_from = lit_pos + 1;
+		}
 	} else {
 		// wildcard at the end or in the middle "something*else*..."
 

--- a/userspace/engine/falco_utils.cpp
+++ b/userspace/engine/falco_utils.cpp
@@ -236,6 +236,11 @@ bool matches_wildcard(const std::string& pattern, const std::string& s) {
 		// one. For instance, `*ab` against `xabab`: matching the `ab` at
 		// index 1 leaves `ab` unmatched against the empty remaining pattern.
 		// Try each occurrence and backtrack on failure.
+		//
+		// Worst case this tries every occurrence of `to_find` in `s`, each
+		// paired with an O(|s|) substr/find, i.e. O(|s|^2) for a single `*`
+		// segment. This is fine for the short file/rule names this function
+		// is used on; do not turn this back into a single greedy `find`.
 		std::string::size_type search_from = 0;
 		while(true) {
 			std::string::size_type lit_pos = s.find(to_find, search_from);


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

`falco::utils::matches_wildcard` located the literal segment that follows a `*` using `std::string::find`, which returns the first occurrence. When that first occurrence left the remaining pattern unable to match the rest of the input, the function returned `false` even though a later occurrence would have produced a successful match.

A few concrete failing inputs (all of which should match but returned `false`):

| Pattern | Input | Old result | Expected |
|---|---|---|---|
| `*ab` | `xabab` | `false` | `true` |
| `*.yaml` | `backup.yaml.yaml` | `false` | `true` |
| `*ab*ab` | `ababab` | `false` | `true` |
| `hello*world` | `hello world hello world` | `false` | `true` |

Trace for `*ab` vs `xabab`: the matcher finds `ab` at index 1, recurses with the empty pattern against the remaining `ab`, and returns `false` because the empty pattern is not equal to `"ab"`. The second `ab` at index 3 (which would have matched against the empty remainder) is never tried.

The call sites that consume this helper are:

- [`userspace/falco/configuration.cpp`](https://github.com/falcosecurity/falco/blob/master/userspace/falco/configuration.cpp) — `*.yaml` / `*.yml` filtering when loading rule files from a directory. Filenames containing the literal more than once (e.g. `backup.yaml.yaml`) were silently skipped.
- [`userspace/engine/indexable_ruleset.h`](https://github.com/falcosecurity/falco/blob/master/userspace/engine/indexable_ruleset.h) — wildcard matching of rule names for `enable`/`disable`. Rules whose names contain the literal segment more than once would not be matched.

The fix replaces the single `find` with a loop that tries every occurrence of the literal segment and backtracks on failure. The other branch (literal prefix before the `*`) is unchanged since there is no ambiguity there.

All existing tests in `unit_tests/engine/test_falco_utils.cpp` continue to pass with the new implementation. New tests are added that cover the previously-broken inputs as well as a couple of negative cases to ensure backtracking still respects a non-matching suffix.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- The recursion depth is bounded by the number of `*` separators in the pattern, identical to the prior implementation. Worst-case work is `O(|s| * occurrences-of-literal)` per recursion level, which is the standard cost of greedy backtracking globbing on short inputs like file names and rule names.
- I do not have a maintainer-grade local toolchain (the project requires `clang-format 18.1.8` and a full libsinsp build to run `BUILD_FALCO_UNIT_TESTS`). The fix was matched to the surrounding style by hand and verified by extracting the function into a standalone harness; please let CI re-run the formatter and full unit-test suite.

**Does this PR introduce a user-facing change?**:

```release-note
fix(engine): correctly match wildcard patterns when the literal segment that follows a `*` appears more than once in the input (e.g. `*.yaml` against `backup.yaml.yaml`, or wildcard `enable`/`disable` of rule names whose names repeat a literal segment).
```
