### PR TITLE
fix(chart): add revisionHistoryLimit support to DaemonSet controller

### DIFF
--- a/chart/falco/CHANGELOG.md
+++ b/chart/falco/CHANGELOG.md
@@ -5,6 +5,8 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## Unreleased
 
+* Add `revisionHistoryLimit` support to the DaemonSet controller, matching existing deployment behavior
+
 ## v9.0.0
 
 * Drop gRPC output and server support

--- a/chart/falco/CHANGELOG.md
+++ b/chart/falco/CHANGELOG.md
@@ -6,6 +6,7 @@ numbering uses [semantic versioning](http://semver.org).
 ## Unreleased
 
 * Fix Grafana dashboard priority level mappings to match Falco's numeric encoding (0=emergency … 7=debug)
+* Add `revisionHistoryLimit` support to the DaemonSet controller, matching existing deployment behavior
 
 ## v9.0.0
 

--- a/chart/falco/CHANGELOG.md
+++ b/chart/falco/CHANGELOG.md
@@ -6,7 +6,7 @@ numbering uses [semantic versioning](http://semver.org).
 ## Unreleased
 
 * Fix Grafana dashboard priority level mappings to match Falco's numeric encoding (0=emergency … 7=debug)
-* Add `revisionHistoryLimit` support to the DaemonSet controller, matching existing deployment behavior
+- Add `revisionHistoryLimit` support to the DaemonSet controller and honor an explicit zero for both DaemonSet and Deployment controllers
 
 ## v9.0.0
 

--- a/chart/falco/README.md
+++ b/chart/falco/README.md
@@ -507,6 +507,7 @@ The following table lists the main configurable parameters of the falco chart v9
 | collectors.kubernetes.pluginRef | string | `"ghcr.io/falcosecurity/plugins/plugin/k8smeta:0.4.1"` | pluginRef is the OCI reference for the k8smeta plugin. It could be a full reference such as: "ghcr.io/falcosecurity/plugins/plugin/k8smeta:0.4.1". Or just name + tag: k8smeta:0.4.1. |
 | containerSecurityContext | object | `{}` | Set securityContext for the Falco container.For more info see the "falco.securityContext" helper in "pod-template.tpl" |
 | controller.annotations | object | `{}` |  |
+| controller.daemonset.revisionHistoryLimit | int | `nil` | Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10) |
 | controller.daemonset.updateStrategy.type | string | `"RollingUpdate"` | Perform rolling updates by default in the DaemonSet agent ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/ |
 | controller.deployment.replicas | int | `1` | Number of replicas when installing Falco using a deployment. Change it if you really know what you are doing. For more info check the section on Plugins in the README.md file. |
 | controller.kind | string | `"daemonset"` |  |

--- a/chart/falco/README.md
+++ b/chart/falco/README.md
@@ -507,9 +507,10 @@ The following table lists the main configurable parameters of the falco chart v9
 | collectors.kubernetes.pluginRef | string | `"ghcr.io/falcosecurity/plugins/plugin/k8smeta:0.4.1"` | pluginRef is the OCI reference for the k8smeta plugin. It could be a full reference such as: "ghcr.io/falcosecurity/plugins/plugin/k8smeta:0.4.1". Or just name + tag: k8smeta:0.4.1. |
 | containerSecurityContext | object | `{}` | Set securityContext for the Falco container.For more info see the "falco.securityContext" helper in "pod-template.tpl" |
 | controller.annotations | object | `{}` |  |
-| controller.daemonset.revisionHistoryLimit | int | `nil` | Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10) |
+| controller.daemonset.revisionHistoryLimit | int | `nil` | Number of old revisions to retain for rollback. Set to 0 to retain no old revisions. If unset, Kubernetes defaults to 10. |
 | controller.daemonset.updateStrategy.type | string | `"RollingUpdate"` | Perform rolling updates by default in the DaemonSet agent ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/ |
 | controller.deployment.replicas | int | `1` | Number of replicas when installing Falco using a deployment. Change it if you really know what you are doing. For more info check the section on Plugins in the README.md file. |
+| controller.deployment.revisionHistoryLimit | int | `nil` | Number of old revisions to retain for rollback. Set to 0 to retain no old revisions. If unset, Kubernetes defaults to 10. |
 | controller.kind | string | `"daemonset"` |  |
 | controller.labels | object | `{}` | Extra labels to add to the daemonset or deployment |
 | customRules | object | `{}` | Third party rules enabled for Falco. More info on the dedicated section in README.md file. |

--- a/chart/falco/templates/daemonset.yaml
+++ b/chart/falco/templates/daemonset.yaml
@@ -17,6 +17,9 @@ spec:
   selector:
     matchLabels:
       {{- include "falco.selectorLabels" . | nindent 6 }}
+  {{- if .Values.controller.daemonset.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.controller.daemonset.revisionHistoryLimit }}
+  {{- end }}
   template:
     {{- include "falco.podTemplate" . | nindent 4 }}
   {{- with .Values.controller.daemonset.updateStrategy }}

--- a/chart/falco/templates/daemonset.yaml
+++ b/chart/falco/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
   selector:
     matchLabels:
       {{- include "falco.selectorLabels" . | nindent 6 }}
-  {{- if .Values.controller.daemonset.revisionHistoryLimit }}
+  {{- if ne .Values.controller.daemonset.revisionHistoryLimit nil }}
   revisionHistoryLimit: {{ .Values.controller.daemonset.revisionHistoryLimit }}
   {{- end }}
   template:

--- a/chart/falco/templates/deployment.yaml
+++ b/chart/falco/templates/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.controller.deployment.replicas }}
-  {{- if .Values.controller.deployment.revisionHistoryLimit }}
+  {{- if ne .Values.controller.deployment.revisionHistoryLimit nil }}
   revisionHistoryLimit: {{ .Values.controller.deployment.revisionHistoryLimit }}
   {{- end }}
   selector:

--- a/chart/falco/tests/unit/falcoTemplates/revisionHistoryLimit_test.go
+++ b/chart/falco/tests/unit/falcoTemplates/revisionHistoryLimit_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package falcoTemplates
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/falcosecurity/falco/chart/falco/tests/unit"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestRevisionHistoryLimit(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs(unit.ChartPath)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name       string
+		value      string
+		configured bool
+		expected   int32
+	}{
+		{name: "unset"},
+		{name: "null", value: "null"},
+		{name: "zero", value: "0", configured: true, expected: 0},
+		{name: "positive", value: "3", configured: true, expected: 3},
+	}
+
+	for _, kind := range []string{"daemonset", "deployment"} {
+		for _, testCase := range testCases {
+			t.Run(kind+"/"+testCase.name, func(t *testing.T) {
+				t.Parallel()
+
+				values := map[string]string{"controller.kind": kind}
+				if testCase.value != "" {
+					values["controller."+kind+".revisionHistoryLimit"] = testCase.value
+				}
+				options := &helm.Options{SetValues: values}
+				output := helm.RenderTemplate(t, options, helmChartPath, unit.ReleaseName, []string{"templates/" + kind + ".yaml"})
+
+				var revisionHistoryLimit *int32
+				if kind == "daemonset" {
+					var ds appsv1.DaemonSet
+					helm.UnmarshalK8SYaml(t, output, &ds)
+					revisionHistoryLimit = ds.Spec.RevisionHistoryLimit
+				} else {
+					var deployment appsv1.Deployment
+					helm.UnmarshalK8SYaml(t, output, &deployment)
+					revisionHistoryLimit = deployment.Spec.RevisionHistoryLimit
+				}
+
+				if testCase.configured {
+					require.NotNil(t, revisionHistoryLimit)
+					require.Equal(t, testCase.expected, *revisionHistoryLimit)
+				} else {
+					require.Nil(t, revisionHistoryLimit)
+					require.NotContains(t, output, "revisionHistoryLimit:")
+				}
+			})
+		}
+	}
+}

--- a/chart/falco/values.yaml
+++ b/chart/falco/values.yaml
@@ -157,6 +157,8 @@ controller:
   # -- Extra labels to add to the daemonset or deployment
   labels: {}
   daemonset:
+    # -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+    # revisionHistoryLimit: 1
     updateStrategy:
       # You can also customize maxUnavailable or minReadySeconds if you
       # need it

--- a/chart/falco/values.yaml
+++ b/chart/falco/values.yaml
@@ -157,8 +157,8 @@ controller:
   # -- Extra labels to add to the daemonset or deployment
   labels: {}
   daemonset:
-    # -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
-    # revisionHistoryLimit: 1
+    # -- (int) Number of old revisions to retain for rollback. Set to 0 to retain no old revisions. If unset, Kubernetes defaults to 10.
+    revisionHistoryLimit: null
     updateStrategy:
       # You can also customize maxUnavailable or minReadySeconds if you
       # need it
@@ -169,8 +169,8 @@ controller:
     # -- Number of replicas when installing Falco using a deployment. Change it if you really know what you are doing.
     # For more info check the section on Plugins in the README.md file.
     replicas: 1
-    # -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
-    # revisionHistoryLimit: 1
+    # -- (int) Number of old revisions to retain for rollback. Set to 0 to retain no old revisions. If unset, Kubernetes defaults to 10.
+    revisionHistoryLimit: null
 
 # -- Network services configuration (scenario requirement)
 # Add here your services to be deployed together with Falco.


### PR DESCRIPTION
## Summary

Allow DaemonSet users to configure `controller.daemonset.revisionHistoryLimit`.

- Honor an explicit `0` for both DaemonSet and Deployment controllers.
- Omit the field when unset or `null`, allowing Kubernetes to apply its default.
- Document both optional values and regenerate the chart README.

Fixes #3925

## Test plan

- [x] Regression tests cover unset, `null`, `0`, and a positive value for both controllers. The two zero cases failed before the fix.
- [x] All chart unit tests pass with `go test ./unit/... -count=1`.
- [x] `helm lint` passes for both controller kinds.
- [x] `make chart-docs-check` passes with `helm-docs` v1.11.0.
- [x] `git diff --check` passes.

```release-note
fix(chart): support DaemonSet revision history limits and honor an explicit zero for both DaemonSet and Deployment controllers.
```
