### PR TITLE
fix(chart): correct inverted priority level mappings in Grafana dashboard

### DIFF
--- a/chart/falco/CHANGELOG.md
+++ b/chart/falco/CHANGELOG.md
@@ -5,6 +5,8 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## Unreleased
 
+* Fix Grafana dashboard priority level mappings to match Falco's numeric encoding (0=emergency … 7=debug)
+
 ## v9.0.0
 
 * Drop gRPC output and server support

--- a/chart/falco/dashboards/falco-dashboard.json
+++ b/chart/falco/dashboards/falco-dashboard.json
@@ -319,28 +319,28 @@
           "id": "renameByRegex",
           "options": {
             "regex": "0",
-            "renamePattern": "default"
+            "renamePattern": "emergency"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "1",
-            "renamePattern": "debug"
+            "renamePattern": "alert"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "2",
-            "renamePattern": "informational"
+            "renamePattern": "critical"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "3",
-            "renamePattern": "notice"
+            "renamePattern": "error"
           }
         },
         {
@@ -354,28 +354,21 @@
           "id": "renameByRegex",
           "options": {
             "regex": "5",
-            "renamePattern": "error"
+            "renamePattern": "notice"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "6",
-            "renamePattern": "critical"
+            "renamePattern": "informational"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "7",
-            "renamePattern": "alert"
-          }
-        },
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "8",
-            "renamePattern": "emergency"
+            "renamePattern": "debug"
           }
         }
       ],
@@ -494,28 +487,28 @@
           "id": "renameByRegex",
           "options": {
             "regex": "0",
-            "renamePattern": "default"
+            "renamePattern": "emergency"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "1",
-            "renamePattern": "debug"
+            "renamePattern": "alert"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "2",
-            "renamePattern": "informational"
+            "renamePattern": "critical"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "3",
-            "renamePattern": "notice"
+            "renamePattern": "error"
           }
         },
         {
@@ -529,28 +522,21 @@
           "id": "renameByRegex",
           "options": {
             "regex": "5",
-            "renamePattern": "error"
+            "renamePattern": "notice"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "6",
-            "renamePattern": "critical"
+            "renamePattern": "informational"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "7",
-            "renamePattern": "alert"
-          }
-        },
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "8",
-            "renamePattern": "emergency"
+            "renamePattern": "debug"
           }
         }
       ],
@@ -668,28 +654,28 @@
           "id": "renameByRegex",
           "options": {
             "regex": "0",
-            "renamePattern": "default"
+            "renamePattern": "emergency"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "1",
-            "renamePattern": "debug"
+            "renamePattern": "alert"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "2",
-            "renamePattern": "informational"
+            "renamePattern": "critical"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "3",
-            "renamePattern": "notice"
+            "renamePattern": "error"
           }
         },
         {
@@ -703,28 +689,21 @@
           "id": "renameByRegex",
           "options": {
             "regex": "5",
-            "renamePattern": "error"
+            "renamePattern": "notice"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "6",
-            "renamePattern": "critical"
+            "renamePattern": "informational"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "7",
-            "renamePattern": "alert"
-          }
-        },
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "8",
-            "renamePattern": "emergency"
+            "renamePattern": "debug"
           }
         }
       ],
@@ -843,28 +822,28 @@
           "id": "renameByRegex",
           "options": {
             "regex": "0",
-            "renamePattern": "default"
+            "renamePattern": "emergency"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "1",
-            "renamePattern": "debug"
+            "renamePattern": "alert"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "2",
-            "renamePattern": "informational"
+            "renamePattern": "critical"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "3",
-            "renamePattern": "notice"
+            "renamePattern": "error"
           }
         },
         {
@@ -878,28 +857,21 @@
           "id": "renameByRegex",
           "options": {
             "regex": "5",
-            "renamePattern": "error"
+            "renamePattern": "notice"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "6",
-            "renamePattern": "critical"
+            "renamePattern": "informational"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
             "regex": "7",
-            "renamePattern": "alert"
-          }
-        },
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "8",
-            "renamePattern": "emergency"
+            "renamePattern": "debug"
           }
         }
       ],


### PR DESCRIPTION
## Summary

The Grafana dashboard's `renameByRegex` transforms had Falco's numeric priority levels exactly backwards.

Falco encodes priorities as (see `userspace/engine/falco_common.h`):
| Number | Level |
|--------|-------|
| 0 | Emergency |
| 1 | Alert |
| 2 | Critical |
| 3 | Error |
| 4 | Warning |
| 5 | Notice |
| 6 | Informational |
| 7 | Debug |

The dashboard was mapping them in reverse order (0→"default", 1→"debug", …, 7→"alert", 8→"emergency"), which caused the wrong severity labels to appear on all pie-chart and time-series panels.

This PR fixes all four occurrences of the mapping block to match Falco's actual numeric encoding, and removes the spurious `"8"→"emergency"` entry (Falco has no priority 8).

Fixes #3926

## Test plan

- [ ] Deploy Falco with Prometheus metrics and Grafana, trigger alerts at known severity levels (e.g. Warning=4, Notice=5), confirm the dashboard panels label them correctly

```release-note
fix(chart): correct the inverted priority level mappings in the Grafana dashboard, so severity labels match Falco's numeric priorities (0=emergency ... 7=debug)
```