### PR TITLE
Provide a default network policy in extra section for falco in falco chart

### DIFF
--- a/chart/falco/CHANGELOG.md
+++ b/chart/falco/CHANGELOG.md
@@ -5,6 +5,8 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## Unreleased
 
+* Add defaultNetworkPolicies feature to deploy a standard default networkPolicy (ingress allow kube-apiserver, egress allow core-dns resolution and falco-sidekick events forwarding)
+
 ## v9.0.0
 
 * Drop gRPC output and server support

--- a/chart/falco/README.gotmpl
+++ b/chart/falco/README.gotmpl
@@ -472,6 +472,21 @@ helm install falco falcosecurity/falco \
 
 Or instead of directly setting the files via `--set-file`, mounting an existing volume with the `certs.existingClientSecret` value.
 
+## Loading default networkPolicy
+
+Falco ships with a default networkPolicy. It is a good starting point before going further in hardening falco deployment.
+
+The default netwokPolicy, once activated, enables the following flows:
+* ingress flow from kube-apiserver on ports 8765 (Liveness, readyness and health probes) and 9765 (Webhook for k8saudit)
+* egress flow to core-dns PODs for kubernetes cluster internal resolution
+* egress flow to falcosidekick PODs if falcosidekick is enabled
+
+Additional flow such as on premise private registry, corporate proxy or even external syslog server are not covered by the default networkPolicy
+and should be configured aside of helm chart default netwokPolicy.
+
+Simply set  `defaultNetworkPolicy.enabled=true` to activate the default networkPolicy rendering.
+In addition, if `falcosidekick.enabled=true` is set, then default networkPolicy will embed the egress flow related to falcosidekick.
+
 ## Deploy Falcosidekick with Falco
 
 [`Falcosidekick`](https://github.com/falcosecurity/falcosidekick) can be installed with `Falco` by setting `--set falcosidekick.enabled=true`. This setting automatically configures all options of `Falco` for working with `Falcosidekick`.

--- a/chart/falco/README.md
+++ b/chart/falco/README.md
@@ -468,6 +468,21 @@ helm install falco falcosecurity/falco \
 
 Or instead of directly setting the files via `--set-file`, mounting an existing volume with the `certs.existingClientSecret` value.
 
+## Loading default networkPolicy
+
+Falco ships with a default networkPolicy. It is a good starting point before going further in hardening falco deployment.
+
+The default netwokPolicy, once activated, enables the following flows:
+* ingress flow from kube-apiserver on ports 8765 (Liveness, readyness and health probes) and 9765 (Webhook for k8saudit)
+* egress flow to core-dns PODs for kubernetes cluster internal resolution
+* egress flow to falcosidekick PODs if falcosidekick is enabled
+
+Additional flow such as on premise private registry, corporate proxy or even external syslog server are not covered by the default networkPolicy
+and should be configured aside of helm chart default netwokPolicy.
+
+Simply set  `defaultNetworkPolicy.enabled=true` to activate the default networkPolicy rendering.
+In addition, if `falcosidekick.enabled=true` is set, then default networkPolicy will embed the egress flow related to falcosidekick.
+
 ## Deploy Falcosidekick with Falco
 
 [`Falcosidekick`](https://github.com/falcosecurity/falcosidekick) can be installed with `Falco` by setting `--set falcosidekick.enabled=true`. This setting automatically configures all options of `Falco` for working with `Falcosidekick`.
@@ -512,6 +527,7 @@ The following table lists the main configurable parameters of the falco chart v9
 | controller.kind | string | `"daemonset"` |  |
 | controller.labels | object | `{}` | Extra labels to add to the daemonset or deployment |
 | customRules | object | `{}` | Third party rules enabled for Falco. More info on the dedicated section in README.md file. |
+| defaultNetworkPolicy | object | `{"enabled":false}` | Default networkPolicy that comes out of the box with falco if you don't have any specific needs. |
 | driver.enabled | bool | `true` | Set it to false if you want to deploy Falco without the drivers. Always set it to false when using Falco with plugins. |
 | driver.kind | string | `"auto"` | kind tells Falco which driver to use. Available options: kmod (kernel driver), modern_ebpf (modern eBPF probe). |
 | driver.kmod | object | `{"bufSizePreset":4,"dropFailedExit":false}` | kmod holds the configuration for the kernel module. |

--- a/chart/falco/templates/falco-network-policy.yaml
+++ b/chart/falco/templates/falco-network-policy.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.defaultNetworkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "falco.fullname" . }}-network-policy
+  namespace: {{ include "falco.namespace" . }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: falco
+      app.kubernetes.io/name: falco
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        # Liveness, readyness and health probes
+        - port: 8765
+          protocol: TCP
+        # Falco Webhook for k8saudit
+        - port: 9765
+          protocol: TCP
+  egress:
+    # Allow kube-dns resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+    {{- if .Values.falcosidekick.enabled -}}
+    # Outgoing Traffic to falco sidekick pods
+    - to:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/component: core
+            app.kubernetes.io/instance: falco
+            app.kubernetes.io/name: falcosidekick
+      ports:
+        # Falco to sidekick communication
+        - port: 2801
+          protocol: TCP
+        - port: 2810
+          protocol: TCP
+    {{- end -}}
+{{- end -}}

--- a/chart/falco/values.yaml
+++ b/chart/falco/values.yaml
@@ -508,6 +508,11 @@ customRules: {}
   # rules-traefik.yaml: |-
   #   [ rule body ]
 
+# -- Default networkPolicy that comes out of the box with falco if you don't have any specific needs.
+defaultNetworkPolicy:
+  # Disabled by default to avoid being categorized as BREAKING CHANGES
+  enabled: false
+
 ########################
 # Falco integrations   #
 ########################


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

> If this PR prepares a chart release, uncomment:

/kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area engine

> /area tests

> /area proposals

> /area automation

/area chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

By default no network policy is set by falco helm chart.

As falco is ran by default as a DaemonSet and requires the securityContext: privileged: true (equivalent to docker --privileged ), it can become a suitable and preferred target for an attacker to get in.

Provide an extra section to activate a default networkPolicy to deploy during helm install. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #3912 

**Special notes for your reviewer**:

Non regression tests Matrix done, and results:
| defaultNetworkPolicy.enabled | falcosidekick.enabled | networkPolicy rendered | ingress section content | egress section content |
| --------------------------------- | ----------------------- | -------------------------- | --------------------------- | ------------------------------- |
| false                                          | false                           | NO                                  | none                               | none                                |
| false                                          | true                            | NO                                  | none                               | none                                |
| true                                           | false                           | YES                                  | falco TCP port 8765, k8saudit TCP port  9765 |  core-dns/kube-dns UDP port 53                        |
| true                                           | true                            | YES                                  | falco TCP port  8765, k8saudit TCP port 9765 |  core-dns/kube-dns UDP port 53, falcosidekick TCP port 2801 and TCP port 2810 |

Detailed results in GIST link: https://gist.github.com/heitzflorian/f01f1919a6d7a01245a9eab535a0406d

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
NONE
```
