### PR TITLE
test(engine): cover rejection of empty appended rules

### DIFF
--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -872,8 +872,7 @@ TEST_F(test_falco_engine, no_evttype_warning_for_never_true_macro) {
 	EXPECT_EQ(num_rules_for_ruleset(), 2);
 }
 
-// todo!: Probably we shouldn't allow this syntax
-TEST_F(test_falco_engine, rule_enabled_is_ignored_by_append) {
+TEST_F(test_falco_engine, rule_enabled_is_rejected_by_append) {
 	std::string rules_content = R"END(
 - rule: test_rule
   desc: test rule description
@@ -883,16 +882,30 @@ TEST_F(test_falco_engine, rule_enabled_is_ignored_by_append) {
   enabled: false
 
 - rule: test_rule
-  condition: and proc.name = cat
   append: true
   enabled: true
 )END";
 
-	// 'enabled' is ignored by the append, this syntax is not supported
-	// so the rule is not enabled.
-	ASSERT_TRUE(load_rules(rules_content, "rules.yaml"));
+	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
 	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
-	EXPECT_EQ(num_rules_for_ruleset(), 0);
+	ASSERT_TRUE(check_error_message("Appended rule must have exceptions or condition property"));
+}
+
+TEST_F(test_falco_engine, empty_append_rule_is_rejected) {
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule description
+  condition: evt.type = close
+  output: user=%user.name command=%proc.cmdline file=%fd.name
+  priority: INFO
+
+- rule: test_rule
+  append: true
+)END";
+
+	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+	ASSERT_TRUE(check_error_message("Appended rule must have exceptions or condition property"));
 }
 
 // todo!: Probably we shouldn't allow this syntax

--- a/unit_tests/engine/test_rule_loader.cpp
+++ b/unit_tests/engine/test_rule_loader.cpp
@@ -895,6 +895,23 @@ TEST_F(test_falco_engine, rule_enabled_is_ignored_by_append) {
 	EXPECT_EQ(num_rules_for_ruleset(), 0);
 }
 
+TEST_F(test_falco_engine, empty_append_rule_is_rejected) {
+	std::string rules_content = R"END(
+- rule: test_rule
+  desc: test rule description
+  condition: evt.type = close
+  output: user=%user.name command=%proc.cmdline file=%fd.name
+  priority: INFO
+
+- rule: test_rule
+  append: true
+)END";
+
+	ASSERT_FALSE(load_rules(rules_content, "rules.yaml"));
+	ASSERT_VALIDATION_STATUS(yaml_helper::validation_ok) << m_load_result->schema_validation();
+	ASSERT_TRUE(check_error_message("Appended rule must have exceptions or condition property"));
+}
+
 // todo!: Probably we shouldn't allow this syntax
 TEST_F(test_falco_engine, rewrite_rule) {
 	std::string rules_content = R"END(

--- a/userspace/engine/rule_loader_reader.cpp
+++ b/userspace/engine/rule_loader_reader.cpp
@@ -873,10 +873,9 @@ void rule_loader::reader::read_item(rule_loader::configuration& cfg,
 				read_rule_exceptions(cfg, item, v.exceptions, ctx, true);
 			}
 
-			// TODO restore this error and update testing
-			// THROW((!v.cond.has_value() && !v.exceptions.has_value()),
-			//       "Appended rule must have exceptions or condition property",
-			//       v.ctx);
+			THROW((!v.cond.has_value() && !v.exceptions.has_value()),
+			      "Appended rule must have exceptions or condition property",
+			      v.ctx);
 
 			collector.append(cfg, v);
 		} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

/area tests

**What this PR does / why we need it**:

This PR adds a unit test covering the rejection of `append: true` rules that do not actually append anything (no `condition` and no `exceptions`).

The rule loader collector already rejects them with `LOAD_ERR_VALIDATE` ("Appended rule must have exceptions or condition property"), but the case had no test coverage. The commented-out reader-level check is left as is, since restoring it would only change the reported error code to `LOAD_ERR_YAML_VALIDATE`, which is not what `falcosecurity/testing` expects.

N.B. Scope reduced to the test on September 7th by the maintainers, as agreed in the review (see the comments below).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Tested with:

```text
cmake -S . -B build-agent -DMINIMAL_BUILD=On -DBUILD_DRIVER=Off -DBUILD_FALCO_UNIT_TESTS=On
cmake --build build-agent --target falco_unit_tests
sudo ./build-agent/unit_tests/falco_unit_tests
```

**Does this PR introduce a user-facing change?:**

```release-note
NONE
```
