### PR TITLE
fix(engine): add empty string guards in logger

### DIFF
--- a/userspace/engine/logger.cpp
+++ b/userspace/engine/logger.cpp
@@ -101,6 +101,10 @@ void falco_logger::log(falco_logger::level priority, const std::string&& msg) {
 		return;
 	}
 
+	if(msg.find_first_not_of('\n') == std::string::npos) {
+		return;
+	}
+
 	std::string copy = msg;
 
 #ifndef _WIN32


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

Guard the `copy.back()` calls in `falco_logger::log` (`userspace/engine/logger.cpp`) with empty-string checks. 
`std::string::back()` on an empty string is undefined behavior, but the syslog trailing-newline strip and the stderr trailing-newline append both call `.back()` without first checking the string is non-empty.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

`if(!copy.empty() && copy.back() == '\n')` on the syslog path and `if(copy.empty() || copy.back() != '\n')` on the stderr path.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```