### PR TITLE
fix(userspace/falco): always serve forced restart requests

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -58,7 +58,7 @@ add_executable(
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	target_sources(
 		falco_unit_tests
-		PRIVATE falco/test_atomic_signal_handler.cpp
+		PRIVATE falco/test_atomic_signal_handler.cpp falco/test_restart_handler.cpp
 				falco/app/actions/test_configure_interesting_sets.cpp
 				falco/app/actions/test_configure_syscall_buffer_num.cpp
 	)

--- a/unit_tests/falco/test_restart_handler.cpp
+++ b/unit_tests/falco/test_restart_handler.cpp
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2026 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <falco/app/restart_handler.h>
+#include <falco/app/signals.h>
+
+#include <gtest/gtest.h>
+
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <thread>
+
+namespace {
+
+// deadlines sized for the watcher's 100ms cycle, with margin for slow CI
+constexpr const std::chrono::seconds s_deadline{5};
+constexpr const std::chrono::milliseconds s_poll{10};
+
+bool wait_restart_triggered(std::chrono::seconds deadline) {
+	auto end = std::chrono::steady_clock::now() + deadline;
+	while(std::chrono::steady_clock::now() < end) {
+		if(falco::app::g_restart_signal.triggered()) {
+			return true;
+		}
+		std::this_thread::sleep_for(s_poll);
+	}
+	return falco::app::g_restart_signal.triggered();
+}
+
+bool wait_check_count(const std::atomic<int>& count, int expected, std::chrono::seconds deadline) {
+	auto end = std::chrono::steady_clock::now() + deadline;
+	while(count.load() < expected && std::chrono::steady_clock::now() < end) {
+		std::this_thread::sleep_for(s_poll);
+	}
+	return count.load() >= expected;
+}
+
+// g_restart_signal is a process-wide global: reset it around each test
+class RestartHandlerTest : public testing::Test {
+protected:
+	void SetUp() override { falco::app::g_restart_signal.reset(); }
+	void TearDown() override { falco::app::g_restart_signal.reset(); }
+};
+
+}  // namespace
+
+// a forced restart (SIGHUP/trigger()) must be served even with nothing to
+// watch (watch_config_files=false)
+TEST_F(RestartHandlerTest, forced_trigger_with_nothing_to_watch) {
+	std::atomic<int> checks{0};
+	falco::app::restart_handler handler([&checks] {
+		checks.fetch_add(1);
+		return true;
+	});
+
+	std::string err;
+	ASSERT_TRUE(handler.start(err)) << err;
+
+	handler.trigger();
+	EXPECT_TRUE(wait_restart_triggered(s_deadline));
+	EXPECT_GE(checks.load(), 1);
+	handler.stop();
+}
+
+TEST_F(RestartHandlerTest, failed_check_does_not_restart_and_can_retry) {
+	std::atomic<int> checks{0};
+	falco::app::restart_handler handler([&checks] {
+		checks.fetch_add(1);
+		return false;
+	});
+
+	std::string err;
+	ASSERT_TRUE(handler.start(err)) << err;
+
+	// a failed dry-run check must not trigger a restart
+	handler.trigger();
+	EXPECT_TRUE(wait_check_count(checks, 1, s_deadline));
+	EXPECT_FALSE(falco::app::g_restart_signal.triggered());
+
+	// a new forced request must cause a new check
+	handler.trigger();
+	EXPECT_TRUE(wait_check_count(checks, 2, s_deadline));
+	EXPECT_FALSE(falco::app::g_restart_signal.triggered());
+	handler.stop();
+}
+
+TEST_F(RestartHandlerTest, stop_with_nothing_to_watch_joins_promptly) {
+	falco::app::restart_handler handler([] { return true; });
+	std::string err;
+	ASSERT_TRUE(handler.start(err)) << err;
+	// must not hang: the watcher wakes up at the next 100ms timeout
+	handler.stop();
+	EXPECT_FALSE(falco::app::g_restart_signal.triggered());
+}
+
+// guard for the watch=true path: an inotify event on a watched file must
+// still produce a dry-run check and a restart trigger
+TEST_F(RestartHandlerTest, watched_file_change_triggers_restart) {
+	// note: pid-unique name so that parallel or leftover runs can't collide
+	auto path = std::string(testing::TempDir()) + "falco_test_restart_handler_" +
+	            std::to_string(getpid()) + ".yaml";
+	{
+		std::ofstream f(path);
+		f << "a" << std::endl;
+	}
+
+	std::atomic<int> checks{0};
+	falco::app::restart_handler handler(
+	        [&checks] {
+		        checks.fetch_add(1);
+		        return true;
+	        },
+	        {path},
+	        {});
+
+	std::string err;
+	ASSERT_TRUE(handler.start(err)) << err;
+
+	// closing the file after writing fires IN_CLOSE_WRITE
+	{
+		std::ofstream f(path);
+		f << "b" << std::endl;
+	}
+
+	EXPECT_TRUE(wait_restart_triggered(s_deadline));
+	EXPECT_GE(checks.load(), 1);
+	handler.stop();
+	std::remove(path.c_str());
+}

--- a/userspace/falco/app/restart_handler.cpp
+++ b/userspace/falco/app/restart_handler.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 #include "logger.h"
 
 #include <string.h>
+#include <errno.h>
 #include <fcntl.h>
 #ifdef _WIN32
 #include <io.h>
@@ -29,6 +30,7 @@ limitations under the License.
 #ifdef __linux__
 #include <sys/inotify.h>
 #include <sys/select.h>
+#include <sys/eventfd.h>
 #endif
 
 #if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
@@ -38,48 +40,77 @@ limitations under the License.
 
 falco::app::restart_handler::~restart_handler() {
 	stop();
+	close_fds();
+}
+
+void falco::app::restart_handler::close_fds() {
 	if(m_inotify_fd != -1) {
 		close(m_inotify_fd);
+		m_inotify_fd = -1;
 	}
-	m_inotify_fd = -1;
+	if(m_event_fd != -1) {
+		close(m_event_fd);
+		m_event_fd = -1;
+	}
 }
 
 void falco::app::restart_handler::trigger() {
 	m_forced.store(true, std::memory_order_release);
+#ifdef __linux__
+	// eventfd write is async-signal-safe, so this is safe from the SIGHUP handler
+	if(m_event_fd != -1) {
+		uint64_t v = 1;
+		auto ret = write(m_event_fd, &v, sizeof(v));
+		(void)ret;
+	}
+#endif
 }
 
 bool falco::app::restart_handler::start(std::string& err) {
 #ifdef __linux__
-	if(m_watched_files.empty() && m_watched_dirs.empty()) {
-		falco_logger::log(falco_logger::level::DEBUG,
-		                  "Refusing to start restart handler due to nothing to watch\n");
-		return true;
+	// Create the inotify handler only when there is something to watch, so we don't consume an
+	// inotify instance; the watcher thread is always started, as it also serves forced restart
+	// requests (e.g. SIGHUP).
+	if(!m_watched_files.empty() || !m_watched_dirs.empty()) {
+		m_inotify_fd = inotify_init();
+		if(m_inotify_fd < 0) {
+			err = "could not initialize inotify handler";
+			close_fds();
+			return false;
+		}
+
+		for(const auto& f : m_watched_files) {
+			auto wd = inotify_add_watch(m_inotify_fd,
+			                            f.c_str(),
+			                            IN_CLOSE_WRITE | IN_MOVE_SELF | IN_DELETE_SELF);
+			if(wd < 0) {
+				err = "could not watch file: " + f;
+				close_fds();
+				return false;
+			}
+			falco_logger::log(falco_logger::level::DEBUG, "Watching file '" + f + "'\n");
+		}
+
+		for(const auto& f : m_watched_dirs) {
+			auto wd = inotify_add_watch(m_inotify_fd, f.c_str(), IN_CREATE | IN_DELETE | IN_MOVE);
+			if(wd < 0) {
+				err = "could not watch directory: " + f;
+				close_fds();
+				return false;
+			}
+			falco_logger::log(falco_logger::level::DEBUG, "Watching directory '" + f + "'\n");
+		}
+	} else {
+		falco_logger::log(
+		        falco_logger::level::DEBUG,
+		        "Nothing to watch, restart handler will only serve forced restart requests\n");
 	}
 
-	m_inotify_fd = inotify_init();
-	if(m_inotify_fd < 0) {
-		err = "could not initialize inotify handler";
+	m_event_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+	if(m_event_fd < 0) {
+		err = "could not initialize eventfd handler";
+		close_fds();
 		return false;
-	}
-
-	for(const auto& f : m_watched_files) {
-		auto wd = inotify_add_watch(m_inotify_fd,
-		                            f.c_str(),
-		                            IN_CLOSE_WRITE | IN_MOVE_SELF | IN_DELETE_SELF);
-		if(wd < 0) {
-			err = "could not watch file: " + f;
-			return false;
-		}
-		falco_logger::log(falco_logger::level::DEBUG, "Watching file '" + f + "'\n");
-	}
-
-	for(const auto& f : m_watched_dirs) {
-		auto wd = inotify_add_watch(m_inotify_fd, f.c_str(), IN_CREATE | IN_DELETE | IN_MOVE);
-		if(wd < 0) {
-			err = "could not watch directory: " + f;
-			return false;
-		}
-		falco_logger::log(falco_logger::level::DEBUG, "Watching directory '" + f + "'\n");
 	}
 
 	// launch the watcher thread
@@ -91,6 +122,12 @@ bool falco::app::restart_handler::start(std::string& err) {
 void falco::app::restart_handler::stop() {
 #ifdef __linux__
 	m_stop.store(true, std::memory_order_release);
+	// wake the watcher in case it is blocked in select() without a timeout
+	if(m_event_fd != -1) {
+		uint64_t v = 1;
+		auto ret = write(m_event_fd, &v, sizeof(v));
+		(void)ret;
+	}
 	if(m_watcher.joinable()) {
 		m_watcher.join();
 	}
@@ -99,7 +136,7 @@ void falco::app::restart_handler::stop() {
 
 void falco::app::restart_handler::watcher_loop() noexcept {
 #ifdef __linux__
-	if(fcntl(m_inotify_fd, F_SETOWN, gettid()) < 0) {
+	if(m_inotify_fd >= 0 && fcntl(m_inotify_fd, F_SETOWN, gettid()) < 0) {
 		// an error occurred, we can't recover
 		// todo(jasondellaluce): should we terminate the process?
 		falco_logger::log(falco_logger::level::ERR,
@@ -112,17 +149,25 @@ void falco::app::restart_handler::watcher_loop() noexcept {
 	bool should_restart = false;
 	struct timeval timeout;
 	uint8_t buf[(10 * (sizeof(struct inotify_event) + NAME_MAX + 1))];
+	int nfds = (m_inotify_fd > m_event_fd ? m_inotify_fd : m_event_fd) + 1;
 	while(!m_stop.load(std::memory_order_acquire)) {
-		// wait for inotify events with a certain timeout.
-		// Note, we'll run through select even before performing a dry-run,
-		// so that we can dismiss in case we have to debounce rapid
-		// subsequent events.
-		timeout.tv_sec = 0;
-		timeout.tv_usec = 100000;
 		FD_ZERO(&set);
-		FD_SET(m_inotify_fd, &set);
-		auto rv = select(m_inotify_fd + 1, &set, NULL, NULL, &timeout);
+		if(m_inotify_fd >= 0) {
+			FD_SET(m_inotify_fd, &set);
+		}
+		FD_SET(m_event_fd, &set);
+
+		struct timeval* to = NULL;
+		if(should_check || should_restart) {
+			timeout.tv_sec = 0;
+			timeout.tv_usec = 100000;
+			to = &timeout;
+		}
+		auto rv = select(nfds, &set, NULL, NULL, to);
 		if(rv < 0) {
+			if(errno == EINTR) {
+				continue;
+			}
 			// an error occurred, we can't recover
 			// todo(jasondellaluce): should we terminate the process?
 			falco_logger::log(falco_logger::level::ERR,
@@ -130,9 +175,14 @@ void falco::app::restart_handler::watcher_loop() noexcept {
 			return;
 		}
 
-		// check if there's been a forced restart request
-		bool forced = m_forced.load(std::memory_order_acquire);
-		m_forced.store(false, std::memory_order_release);
+		if(rv > 0 && FD_ISSET(m_event_fd, &set)) {
+			uint64_t v = 0;
+			auto n = read(m_event_fd, &v, sizeof(v));
+			(void)n;
+		}
+
+		bool forced = m_forced.exchange(false, std::memory_order_acq_rel);
+		bool inotify_ready = m_inotify_fd >= 0 && rv > 0 && FD_ISSET(m_inotify_fd, &set);
 
 		// no new watch event is received during the timeout
 		if(rv == 0 && !forced) {
@@ -170,9 +220,9 @@ void falco::app::restart_handler::watcher_loop() noexcept {
 		should_restart = false;
 		should_check = false;
 
-		// if there's date on the inotify fd, consume it
+		// if there's data on the inotify fd, consume it
 		// (even if there is a forced request too)
-		if(rv > 0) {
+		if(inotify_ready) {
 			// note: if available data is less than buffer size, this should
 			// return n > 0 but not filling the buffer. If available data is
 			// more than buffer size, we will loop back to select and behave
@@ -191,11 +241,8 @@ void falco::app::restart_handler::watcher_loop() noexcept {
 			// there's data in the inotify fd but the first read
 			// returned no bytes. Likely we'll get back here at the
 			// next select call.
-			else if(n == 0) {
-				// we still proceed in case the request was forced
-				if(!forced) {
-					continue;
-				}
+			else if(n == 0 && !forced) {
+				continue;
 			}
 		}
 

--- a/userspace/falco/app/restart_handler.h
+++ b/userspace/falco/app/restart_handler.h
@@ -47,6 +47,7 @@ public:
 	                         const watch_list_t& watch_files = {},
 	                         const watch_list_t& watch_dirs = {}):
 	        m_inotify_fd(-1),
+	        m_event_fd(-1),
 	        m_stop(false),
 	        m_forced(false),
 	        m_on_check(on_check),
@@ -60,8 +61,10 @@ public:
 
 private:
 	void watcher_loop() noexcept;
+	void close_fds();
 
 	int m_inotify_fd = -1;
+	int m_event_fd = -1;
 	std::thread m_watcher;
 	std::atomic<bool> m_stop;
 	std::atomic<bool> m_forced;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind release

> If this PR prepares a chart release, uncomment:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

> /area tests

> /area proposals

> /area automation

> /area chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

`restart_handler::start()` returns without spawning the watcher thread when there is nothing to watch (i.e. `watch_config_files: false`). The `SIGHUP` handler is still installed and `s.restarter` is still assigned, so a `SIGHUP`, or any programmatic `restarter->trigger()`, only sets the internal `m_forced` flag, which nothing then consumes. The requested hot restart is silently dropped, and `systemctl reload falco` (whose shipped units run `ExecReload=kill -1 $MAINPID`) reports success while doing nothing.

This behavior came in with #3640, which skipped the watcher thread to avoid consuming an inotify instance when config-files watching is disabled.

This PR keeps that saving — no inotify instance is created when there is nothing to watch — but always starts the watcher thread so forced restart requests are served again. The watcher blocks in `select()` on an eventfd (plus the inotify fd when present) and is woken immediately by `trigger()`, which writes the eventfd; the write is async-signal-safe, so it works from the SIGHUP handler and there is no idle polling. The 100ms timeout is now used only to debounce bursts once a restart is pending. It also retries `select()` on `EINTR` (a signal delivered to the watcher thread would otherwise shut it down) and consumes `m_forced` with an atomic exchange so a request racing the check is not lost.

Unit tests cover: forced restart with nothing to watch, a failed dry-run not triggering a restart (and allowing a retry), prompt teardown with nothing to watch, and the watched-file inotify path.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
fix: serve SIGHUP-triggered hot restart when `watch_config_files` is disabled
```
