### PR TITLE
feat(chart): add support for custom serviceAccount labels

### DIFF
--- a/chart/falco/templates/serviceaccount.yaml
+++ b/chart/falco/templates/serviceaccount.yaml
@@ -1,18 +1,22 @@
-
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
-{{- with .Values.serviceAccount.imagePullSecrets }}
-imagePullSecrets:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
 kind: ServiceAccount
 metadata:
   name: {{ include "falco.serviceAccountName" . }}
   namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+
 {{- end }}

--- a/chart/falco/values.yaml
+++ b/chart/falco/values.yaml
@@ -37,6 +37,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+  labels: {}
+
 rbac:
   # Create and use rbac resources when set to true. Needed to list and update configmaps in Falco's namespace.
   create: true


### PR DESCRIPTION
### Description
This PR adds support for injecting custom labels into the `ServiceAccount` template for the Falco chart. Currently, the chart allows custom annotations but lacks a way to pass user-defined labels directly to the ServiceAccount metadata.

### Changes
- Updated `chart/falco/values.yaml` to include an empty `serviceAccount.labels` map.
- Modified `chart/falco/templates/serviceaccount.yaml` to dynamically render these custom labels using Helm's standard `with` block and `toYaml` function.

### Testing
Locally linted and verified the template rendering using the Helm CLI:
- `helm lint chart/falco` passed with 0 errors.
- Verified output with `helm template test-falco chart/falco --set serviceAccount.labels.mycustomlabel=works-perfectly --show-only templates/serviceaccount.yaml`. Custom labels are successfully injected under the metadata section without broken indentations.