### PR TITLE
feat(userspace)!: improve invalid UTF-8 sequence handling

### DIFF
--- a/cmake/modules/driver.cmake
+++ b/cmake/modules/driver.cmake
@@ -35,9 +35,9 @@ else()
 	# FALCOSECURITY_LIBS_VERSION. In case you want to test against another driver version (or
 	# branch, or commit) just pass the variable - ie., `cmake -DDRIVER_VERSION=dev ..`
 	if(NOT DRIVER_VERSION)
-		set(DRIVER_VERSION "10.2.0+driver")
+		set(DRIVER_VERSION "6fbc055dd53eff5ce3ad79e96cb5b21252ad0090")
 		set(DRIVER_CHECKSUM
-			"SHA256=0e585f5fc2b76696ef2cb902f0901ea39a2f2df87e1f091f3348f968b9085f39"
+			"SHA256=5521a80af7ce1105ea23fc14351f7c486671aa7aa4fffda5b8e5f0c67a7a1a14"
 		)
 	endif()
 

--- a/cmake/modules/falcosecurity-libs.cmake
+++ b/cmake/modules/falcosecurity-libs.cmake
@@ -42,9 +42,9 @@ else()
 	# version (or branch, or commit) just pass the variable - ie., `cmake
 	# -DFALCOSECURITY_LIBS_VERSION=dev ..`
 	if(NOT FALCOSECURITY_LIBS_VERSION)
-		set(FALCOSECURITY_LIBS_VERSION "01b5cf7ffb294bc6605bc745b327e43f8cf55b40")
+		set(FALCOSECURITY_LIBS_VERSION "6fbc055dd53eff5ce3ad79e96cb5b21252ad0090")
 		set(FALCOSECURITY_LIBS_CHECKSUM
-			"SHA256=ad190a3bb3f0da29e7cf40e212930e955b2b364a556d16c134049ab3f7b4e7e9"
+			"SHA256=5521a80af7ce1105ea23fc14351f7c486671aa7aa4fffda5b8e5f0c67a7a1a14"
 		)
 	endif()
 

--- a/userspace/engine/falco_engine_version.h
+++ b/userspace/engine/falco_engine_version.h
@@ -20,7 +20,7 @@ limitations under the License.
 
 // The version of this Falco engine
 #define FALCO_ENGINE_VERSION_MAJOR 0
-#define FALCO_ENGINE_VERSION_MINOR 62
+#define FALCO_ENGINE_VERSION_MINOR 63
 #define FALCO_ENGINE_VERSION_PATCH 0
 
 #define FALCO_ENGINE_VERSION                                                               \
@@ -33,7 +33,6 @@ limitations under the License.
 //   echo $($FALCO --version | grep 'Engine:' | awk '{print $2}') $(echo $($FALCO --version | grep
 //   'Schema version:' | awk '{print $3}') $($FALCO --list --markdown | grep '^`' | sort) $($FALCO
 //   --list-events | sort) | sha256sum)
-// It represents the fields supported by this version of Falco,
-// the event types, and the underlying driverevent schema. It's used to
-// detetect changes in engine version in our CI jobs.
+// It represents the fields supported by this version of Falco, the event types, and the underlying
+// driver event schema. It's used to detect changes in engine version in our CI jobs.
 #define FALCO_ENGINE_CHECKSUM "ba6f1ac74018c623135c49f7da1cca6243c99a58d53f4dec983ddf3919304518"

--- a/userspace/engine/formats.cpp
+++ b/userspace/engine/formats.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 #include <nlohmann/json.hpp>
+#include <libsinsp/utils.h>
 
 #include "compat.h"
 #include "formats.h"
@@ -74,18 +75,15 @@ std::string falco_formats::format_event(sinsp_evt *evt,
 	std::string output = prefix + " " + message;
 
 	if(message_formatter->get_output_format() == sinsp_evt_formatter::OF_NORMAL) {
-		return output;
+		// Use JSON encoder to escape control characters and replace any invalid UTF-8 sequence with
+		// `U+FFFD`, making it consistent with JSON-encoded output.
+		const auto encoded_output =
+		        nlohmann::json(output).dump(-1,
+		                                    ' ',
+		                                    false,
+		                                    nlohmann::detail::error_handler_t::replace);
+		return encoded_output.substr(1, encoded_output.size() - 2);  // Remove double-quotes.
 	} else if(message_formatter->get_output_format() == sinsp_evt_formatter::OF_JSON) {
-		std::string json_fields_message;
-		std::string json_fields_prefix;
-
-		// Resolve message fields
-		if(m_json_include_output_fields_property) {
-			message_formatter->tostring(evt, json_fields_message);
-		}
-		// Resolve prefix (e.g. time) fields
-		prefix_formatter->tostring(evt, json_fields_prefix);
-
 		// For JSON output, the formatter returned a json-as-text
 		// object containing all the fields in the original format
 		// message as well as the event time in ns. Use this to build
@@ -124,9 +122,22 @@ std::string falco_formats::format_event(sinsp_evt *evt,
 		}
 
 		if(m_json_include_output_fields_property) {
-			event["output_fields"] = nlohmann::json::parse(json_fields_message);
+			std::string sanitized_str_storage;
 
-			auto prefix_fields = nlohmann::json::parse(json_fields_prefix);
+			// Resolve message fields.
+			std::string json_fields_message;
+			message_formatter->tostring(evt, json_fields_message);
+			const auto sanitized_message =
+			        utf8::sanitize(json_fields_message, sanitized_str_storage);
+			event["output_fields"] =
+			        nlohmann::json::parse(sanitized_message.cbegin(), sanitized_message.cend());
+
+			// Resolve prefix (e.g. time) fields.
+			std::string json_fields_prefix;
+			prefix_formatter->tostring(evt, json_fields_prefix);
+			const auto sanitized_prefix = utf8::sanitize(json_fields_prefix, sanitized_str_storage);
+			auto prefix_fields =
+			        nlohmann::json::parse(sanitized_prefix.cbegin(), sanitized_prefix.cend());
 			if(prefix_fields.is_object()) {
 				for(auto const &el : prefix_fields.items()) {
 					event["output_fields"][el.key()] = el.value();
@@ -150,7 +161,10 @@ std::string falco_formats::format_event(sinsp_evt *evt,
 					field_formatter->tostring_withformat(evt,
 					                                     json_field_map,
 					                                     sinsp_evt_formatter::OF_JSON);
-					auto json_obj = nlohmann::json::parse(json_field_map);
+					const auto sanitized_field =
+					        utf8::sanitize(json_field_map, sanitized_str_storage);
+					auto json_obj =
+					        nlohmann::json::parse(sanitized_field.cbegin(), sanitized_field.cend());
 					event["output_fields"][ef.first] = json_obj[ef.first];
 				} else {
 					event["output_fields"][ef.first] = format_string(evt, fformat, source);

--- a/userspace/falco/app/actions/load_rules_files.cpp
+++ b/userspace/falco/app/actions/load_rules_files.cpp
@@ -158,7 +158,8 @@ falco::app::run_result falco::app::actions::load_rules_files(falco::app::state& 
 		if(!s.config->m_json_output) {
 			format_described_rules_as_text(out, std::cout);
 		} else {
-			std::cout << out.dump() << std::endl;
+			auto dumped_out = out.dump(-1, ' ', false, nlohmann::detail::error_handler_t::replace);
+			std::cout << dumped_out << std::endl;
 		}
 
 		return run_result::exit();

--- a/userspace/falco/app/actions/validate_rules_files.cpp
+++ b/userspace/falco/app/actions/validate_rules_files.cpp
@@ -122,7 +122,8 @@ falco::app::run_result falco::app::actions::validate_rules_files(falco::app::sta
 		if(!describe_res.empty() && successful) {
 			res["falco_describe_results"] = std::move(describe_res);
 		}
-		std::cout << res.dump() << std::endl;
+		auto dumped_res = res.dump(-1, ' ', false, nlohmann::detail::error_handler_t::replace);
+		std::cout << dumped_res << std::endl;
 	} else {
 		std::cout << summary << std::endl;
 		if(!describe_res.empty() && successful) {

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -207,7 +207,7 @@ void falco_outputs::handle_msg(uint64_t ts,
 		jmsg["hostname"] = m_hostname;
 		jmsg["source"] = s_internal_source;
 
-		cmsg.msg = jmsg.dump();
+		cmsg.msg = jmsg.dump(-1, ' ', false, nlohmann::detail::error_handler_t::replace);
 	} else {
 		std::string timestr;
 		bool first = true;
@@ -223,7 +223,9 @@ void falco_outputs::handle_msg(uint64_t ts,
 			if(!pair.value().is_primitive()) {
 				throw falco_exception("falco_outputs: output fields must be key-value maps");
 			}
-			cmsg.msg += pair.key() + "=" + pair.value().dump();
+			cmsg.msg +=
+			        pair.key() + "=" +
+			        pair.value().dump(-1, ' ', false, nlohmann::detail::error_handler_t::replace);
 		}
 		cmsg.msg += ")";
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

/kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

> If this PR prepares a chart release, uncomment:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area engine

> /area tests

> /area proposals

> /area automation

> /area chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR syncs Falco with the changes introduced by libs in https://github.com/falcosecurity/libs/pull/3051 .

The PR moves to a more consistent model in which conditions are evaluated on raw/original field values instead of sanitized versions of them (that is, versions where both invalid UTF-8 sequences and non-printable UTF-8 sequences are replaced with the UTF-8 replacement character). This allows to improve the matching accuracy, since specific non-printable and invalid sequences can now be matched using traditional string operators.

An exception to the aforementioned matching model is given by how the `regex` operator now behaves. Each invalid UTF-8 sequence is now replaced by the replacement character before entering the regex engine: this is due to the fact that the current regex engine doesn't support matching on invalid bytes, and would return false on each field containing them, completely defeating the purpose of the `regex` operator. From the end user point of view, this means that invalid sequences can now be matched by directly trying to match the replacement character (e.g.: `foo regex "bar�baz" or `foo regex "bar.baz"`).

As a side note, independent from this initiative, take into account that the other string operators operate at byte level, so `foo glob "?"` matches a single (even invalid) byte, and will not match any multibyte character.

Single invalid bytes are now matchable leveraging the new `\xHH` escape sequence. As an example, a string containing an invalid `0xFF` byte can be matched by writing a condition like `foo contains "bar\xFFbaz"`. Notice that this escape sequence cannot be used in regular expressions provided to the `regex` operator. Moreover, there's a limitation on the specific `\x00` escape sequence, representing the NUL byte: this can only be used with byte buffer fields to match NUL bytes. Previously, the only way to match a NUL byte in a byte buffer field was using specialized operators like `bcontains` and `bstartswith`. The usage of any `\xHH` escape sequence in the RHS operands of `bcontains`/`bstartswith` operators is discouraged, as these latter ones already accept a sequence of hexadecimal digits as RHS, and a condition like `foo bcontains "\x0a\x0b"` is not the same as `foo bcontains "0a0b"`: the first fails to compile, as bytes `0x0a` and `0x0b` do not correspond to any valid hexadecimal digit in ASCII encoding, while the second correctly expresses the idea of matching against something containing the `0x0a 0x0b` byte sequence.

Raw bytes coming from filterchecks are now sanitized at the end of the alert creation pipeline, in `userspace/engine/formats.cpp`, instead of being sanitized in `falcosecurity/libs`. Plain text output is now encoded leveraging the same technique used for JSON output encoding: non-printable characters are escaped (e.g.: the new line character is escaped as a literal '\' followed by a literal 'n', the NUL character is escaped as "\^@") instead of being replaced by the UTF-8 replacement character, and invalid UTF-8 sequences are replaced by the replacement character.

The rule "validate" (`--validate`) and "describe" (`-L`) command outputs are now consistent with the aforementioned output model.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

/milestone 0.45.0

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
feat(userspace)!: evaluate rule conditions on raw field bytes (invalid and non-printable UTF-8 sequences are now matchable with string operators, single bytes with the new `\xHH` escape sequence), let `regex` operate on sanitized input, and escape non-printable characters / replace invalid UTF-8 sequences at output encoding time; `FALCO_ENGINE_VERSION` bumped from `0.62.0` to `0.63.0`; rules that matched the replacement character with non-regex operators must be reviewed
```
