### PR TITLE
fix(userspace/falco): avoid untrusted search path when loading the kernel module

### DIFF
--- a/userspace/falco/app/actions/helpers_inspector.cpp
+++ b/userspace/falco/app/actions/helpers_inspector.cpp
@@ -17,12 +17,15 @@ limitations under the License.
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/wait.h>
 #include <fcntl.h>
+
+#ifdef __linux__
+#include <sys/wait.h>
 #include <unistd.h>
 #include <cerrno>
 #include <cstring>
 #include <array>
+#endif
 
 #include <libsinsp/plugin_manager.h>
 #include <configuration.h>
@@ -32,6 +35,7 @@ limitations under the License.
 using namespace falco::app;
 using namespace falco::app::actions;
 
+#ifdef __linux__
 namespace {
 
 // Loads the Falco kernel module by invoking modprobe through a fixed,
@@ -40,6 +44,10 @@ namespace {
 // attacker-controllable in some deployment scenarios (CWE-426: Untrusted
 // Search Path). No shell is involved, and no user-controlled input is
 // interpolated into the call.
+//
+// POSIX-only (fork/waitpid/WIFEXITED aren't available on Windows), so
+// this is gated behind __linux__; non-Linux builds fall straight through
+// to open_kmod() at the call site, unchanged from prior behavior.
 bool falco_modprobe(const char* module_name) {
 	static constexpr std::array<const char*, 2> modprobe_paths = {
 	        "/usr/sbin/modprobe",
@@ -84,7 +92,16 @@ bool falco_modprobe(const char* module_name) {
 	}
 
 	int status = 0;
-	if(waitpid(pid, &status, 0) < 0) {
+	int wait_ret;
+	do {
+		// Retry on EINTR: a signal (e.g. the SIGALRM used by the metrics
+		// timer, installed without SA_RESTART) landing mid-wait would
+		// otherwise cause us to report a spurious failure even though the
+		// module loaded successfully.
+		wait_ret = waitpid(pid, &status, 0);
+	} while(wait_ret < 0 && errno == EINTR);
+
+	if(wait_ret < 0) {
 		falco_logger::log(falco_logger::level::ERR,
 		                  std::string("waitpid() failed while loading kernel module: ") +
 		                          strerror(errno) + "\n");
@@ -95,6 +112,7 @@ bool falco_modprobe(const char* module_name) {
 }
 
 }  // namespace
+#endif  // __linux__
 
 falco::app::run_result falco::app::actions::open_offline_inspector(falco::app::state& s) {
 	try {
@@ -191,9 +209,11 @@ falco::app::run_result falco::app::actions::open_live_inspector(falco::app::stat
 				falco_logger::log(
 				        falco_logger::level::INFO,
 				        "Trying to inject the Kernel module and opening the capture again...");
+#ifdef __linux__
 				if(!falco_modprobe(DRIVER_NAME)) {
 					falco_logger::log(falco_logger::level::ERR, "Unable to load the driver\n");
 				}
+#endif
 				inspector->open_kmod(s.syscall_buffer_bytes_size, s.selected_sc_set);
 			}
 		}

--- a/userspace/falco/app/actions/helpers_inspector.cpp
+++ b/userspace/falco/app/actions/helpers_inspector.cpp
@@ -17,7 +17,12 @@ limitations under the License.
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <fcntl.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstring>
+#include <array>
 
 #include <libsinsp/plugin_manager.h>
 #include <configuration.h>
@@ -26,6 +31,70 @@ limitations under the License.
 
 using namespace falco::app;
 using namespace falco::app::actions;
+
+namespace {
+
+// Loads the Falco kernel module by invoking modprobe through a fixed,
+// absolute path (instead of system("modprobe ...")). This avoids
+// resolving "modprobe" via the PATH environment variable, which is
+// attacker-controllable in some deployment scenarios (CWE-426: Untrusted
+// Search Path). No shell is involved, and no user-controlled input is
+// interpolated into the call.
+bool falco_modprobe(const char* module_name) {
+	static constexpr std::array<const char*, 2> modprobe_paths = {
+	        "/usr/sbin/modprobe",
+	        "/sbin/modprobe",
+	};
+
+	const char* modprobe_bin = nullptr;
+	for(const auto& path : modprobe_paths) {
+		if(access(path, X_OK) == 0) {
+			modprobe_bin = path;
+			break;
+		}
+	}
+
+	if(modprobe_bin == nullptr) {
+		falco_logger::log(falco_logger::level::ERR,
+		                  "Could not find modprobe binary in /usr/sbin or /sbin\n");
+		return false;
+	}
+
+	pid_t pid = fork();
+	if(pid < 0) {
+		falco_logger::log(falco_logger::level::ERR,
+		                  std::string("fork() failed while loading kernel module: ") +
+		                          strerror(errno) + "\n");
+		return false;
+	}
+
+	if(pid == 0) {
+		// Child process: redirect stdout/stderr to /dev/null (mirrors the
+		// original "> /dev/null 2> /dev/null" redirection), then exec the
+		// resolved absolute path directly. No shell is spawned.
+		int devnull = open("/dev/null", O_WRONLY);
+		if(devnull >= 0) {
+			dup2(devnull, STDOUT_FILENO);
+			dup2(devnull, STDERR_FILENO);
+			close(devnull);
+		}
+		execl(modprobe_bin, modprobe_bin, module_name, (char*)nullptr);
+		// execl only returns on failure.
+		_exit(127);
+	}
+
+	int status = 0;
+	if(waitpid(pid, &status, 0) < 0) {
+		falco_logger::log(falco_logger::level::ERR,
+		                  std::string("waitpid() failed while loading kernel module: ") +
+		                          strerror(errno) + "\n");
+		return false;
+	}
+
+	return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+}  // namespace
 
 falco::app::run_result falco::app::actions::open_offline_inspector(falco::app::state& s) {
 	try {
@@ -122,7 +191,7 @@ falco::app::run_result falco::app::actions::open_live_inspector(falco::app::stat
 				falco_logger::log(
 				        falco_logger::level::INFO,
 				        "Trying to inject the Kernel module and opening the capture again...");
-				if(system("modprobe " DRIVER_NAME " > /dev/null 2> /dev/null")) {
+				if(!falco_modprobe(DRIVER_NAME)) {
 					falco_logger::log(falco_logger::level::ERR, "Unable to load the driver\n");
 				}
 				inspector->open_kmod(s.syscall_buffer_bytes_size, s.selected_sc_set);

--- a/userspace/falco/app/actions/helpers_inspector.cpp
+++ b/userspace/falco/app/actions/helpers_inspector.cpp
@@ -206,10 +206,11 @@ falco::app::run_result falco::app::actions::open_live_inspector(falco::app::stat
 				inspector->open_kmod(s.syscall_buffer_bytes_size, s.selected_sc_set);
 			} catch(sinsp_exception& e) {
 				// Try to insert the Falco kernel module
+#ifdef __linux__
 				falco_logger::log(
 				        falco_logger::level::INFO,
 				        "Trying to inject the Kernel module and opening the capture again...");
-#ifdef __linux__
+
 				if(!falco_modprobe(DRIVER_NAME)) {
 					falco_logger::log(falco_logger::level::ERR, "Unable to load the driver\n");
 				}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area engine

**What this PR does / why we need it**:

`open_live_inspector()` falls back to `system("modprobe " DRIVER_NAME " ...")`
when the kmod engine's initial `open_kmod()` call throws (i.e. the kernel
module isn't already loaded). Since `system()` resolves the unqualified
`modprobe` binary via `/bin/sh -c` and the process's `PATH`, this is an
instance of CWE-426 (Untrusted Search Path): in deployments where an
attacker can influence the Falco process's `PATH` (or write to a directory
that precedes the legitimate modprobe location in it), an attacker-controlled
binary named `modprobe` would be executed with Falco's privileges.

This PR replaces the `system()` call with `fork()` + `execl()` against a
fixed set of absolute paths (`/usr/sbin/modprobe`, `/sbin/modprobe`),
eliminating the shell and the PATH dependency entirely. No functional
behavior change is intended — only the resolution mechanism.

Note: the maintained systemd flow (`falco-kmod-inject.service`) already
loads the module via an absolute path before Falco starts, so this fallback
is mainly reached in manual, non-systemd, or container invocations.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Reported and confirmed via the private security disclosure process
(cncf-falco-maintainers@lists.cncf.io); classified as low severity /
hardening (defense-in-depth), not tracked as a GHSA. Verified locally
that the fallback resolves only the fixed absolute paths regardless of
`PATH` contents.

**Does this PR introduce a user-facing change?**:

```release-note
fix(userspace/falco): use the absolute `modprobe` path instead of a `PATH` lookup when falling back to loading the kernel module (untrusted search path, CWE-426)
```
Signed-off-by:Eneshan Erdoğan Karaca 