### PR TITLE
chart(falco): add serviceAccount.labels support

### DIFF
--- a/chart/falco/CHANGELOG.md
+++ b/chart/falco/CHANGELOG.md
@@ -8,6 +8,7 @@ numbering uses [semantic versioning](http://semver.org).
 * Do not render the `falcoctl-config-volume` pod volume when both falcoctl artifact install and follow containers are disabled
 * Fix Grafana dashboard priority level mappings to match Falco's numeric encoding (0=emergency … 7=debug)
 - Add `revisionHistoryLimit` support to the DaemonSet controller and honor an explicit zero for both DaemonSet and Deployment controllers
+* Add `serviceAccount.labels` to set custom labels on the ServiceAccount
 
 ## v9.0.0
 

--- a/chart/falco/README.md
+++ b/chart/falco/README.md
@@ -736,6 +736,7 @@ The following table lists the main configurable parameters of the falco chart v9
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.imagePullSecrets | list | `[]` | Secrets containing credentials when pulling from private/secure registries. |
+| serviceAccount.labels | object | `{}` | Labels to add to the service account. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | serviceMonitor | object | `{"create":false,"endpointPort":"metrics","interval":"15s","labels":{},"path":"/metrics","relabelings":[],"scheme":"http","scrapeTimeout":"10s","selector":{},"targetLabels":[],"tlsConfig":{}}` | serviceMonitor holds the configuration for the ServiceMonitor CRD. A ServiceMonitor is a custom resource definition (CRD) used to configure how Prometheus should discover and scrape metrics from the Falco service. |
 | serviceMonitor.create | bool | `false` | create specifies whether a ServiceMonitor CRD should be created for a prometheus operator. https://github.com/coreos/prometheus-operator Enable it only if the ServiceMonitor CRD is installed in your cluster. |

--- a/chart/falco/templates/serviceaccount.yaml
+++ b/chart/falco/templates/serviceaccount.yaml
@@ -11,6 +11,9 @@ metadata:
   namespace: {{ include "falco.namespace" . }}
   labels:
     {{- include "falco.labels" . | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/falco/tests/unit/falcoTemplates/serviceAccount_test.go
+++ b/chart/falco/tests/unit/falcoTemplates/serviceAccount_test.go
@@ -37,6 +37,17 @@ func TestServiceAccount(t *testing.T) {
 				require.Equal(t, sa.Name, "")
 			},
 		},
+		{
+			"customLabels",
+			map[string]string{
+				"serviceAccount.labels.app\\.kubernetes\\.io/part-of": "my-app",
+				"serviceAccount.labels.team":                           "platform",
+			},
+			func(t *testing.T, sa *corev1.ServiceAccount) {
+				require.Equal(t, "my-app", sa.Labels["app.kubernetes.io/part-of"])
+				require.Equal(t, "platform", sa.Labels["team"])
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/chart/falco/values.yaml
+++ b/chart/falco/values.yaml
@@ -33,6 +33,8 @@ serviceAccount:
   create: true
   # -- Annotations to add to the service account.
   annotations: {}
+  # -- Labels to add to the service account.
+  labels: {}
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## Any specific area of the project related to this PR?

/area chart

## What this PR does / Why we need it

Adds support for attaching arbitrary labels to the Falco `ServiceAccount` resource via a new `serviceAccount.labels` value. This mirrors the existing `serviceAccount.annotations` pattern that is already available.

**Motivation:** Users running in environments with admission webhooks (e.g. OPA/Kyverno policies) that require specific labels on every service account have no way to add those labels today.

## How can this be tested

Deploy the chart with:
```yaml
serviceAccount:
  labels:
    team: platform
    app.kubernetes.io/part-of: my-app
```
Verify the labels appear on the rendered `ServiceAccount` manifest.

Unit test added in `chart/falco/tests/unit/falcoTemplates/serviceAccount_test.go` (`customLabels` case).

## Special notes for your reviewer

The implementation follows the identical pattern used for `serviceAccount.annotations` and `serviceMonitor.labels` in the chart — `{{- with .Values.serviceAccount.labels }}{{- toYaml . | nindent 4 }}{{- end }}` appended after the standard `falco.labels` include.

Fixes #3785

```release-note
new(chart): add `serviceAccount.labels` to set custom labels on the ServiceAccount
```