### PR TITLE
feat(userspace/falco): clarify rules validation errors

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(
 	falco/test_configuration_schema.cpp
 	falco/app/actions/test_select_event_sources.cpp
 	falco/app/actions/test_load_config.cpp
+	falco/app/actions/test_validate_rules_files.cpp
 )
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(
 	falco/app/actions/test_select_event_sources.cpp
 	falco/app/actions/test_load_config.cpp
 	falco/app/actions/test_pidfile.cpp
+	falco/app/actions/test_validate_rules_files.cpp
 )
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/unit_tests/falco/app/actions/test_validate_rules_files.cpp
+++ b/unit_tests/falco/app/actions/test_validate_rules_files.cpp
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2026 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "app_action_helpers.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace {
+const std::string s_hint =
+        "--validate accepts Falco rules files only. To validate a Falco configuration file "
+        "and its configured rules, use --dry-run.";
+
+class stdout_capture {
+public:
+	stdout_capture(): m_original(std::cout.rdbuf(m_stream.rdbuf())) {}
+	~stdout_capture() { std::cout.rdbuf(m_original); }
+
+	std::string str() const { return m_stream.str(); }
+
+private:
+	std::ostringstream m_stream;
+	std::streambuf* m_original;
+};
+
+falco::app::run_result validate_content(const std::string& filename,
+                                        const std::string& content,
+                                        bool json_output,
+                                        std::string& output) {
+	{
+		std::ofstream file(filename);
+		if(!file.is_open()) {
+			return falco::app::run_result::fatal("Could not create test file " + filename);
+		}
+		file << content;
+	}
+
+	falco::app::state s = {};
+	s.options.validate_rules_filenames = {filename};
+	s.config->m_json_output = json_output;
+
+	falco::app::run_result result;
+	{
+		stdout_capture capture;
+		result = falco::app::actions::validate_rules_files(s);
+		output = capture.str();
+	}
+	EXPECT_EQ(std::remove(filename.c_str()), 0);
+	return result;
+}
+}  // namespace
+
+TEST(ActionValidateRulesFiles, suggests_dry_run_for_config_file) {
+	std::string output;
+	auto result = validate_content("falco_config_for_rules_validation.yaml",
+	                               "rules_files:\n  - /etc/falco/falco_rules.yaml\n",
+	                               false,
+	                               output);
+	EXPECT_FALSE(result.success);
+	EXPECT_FALSE(result.proceed);
+	EXPECT_NE(result.errstr.find(s_hint), std::string::npos);
+	EXPECT_NE(output.find(s_hint), std::string::npos);
+}
+
+TEST(ActionValidateRulesFiles, preserves_json_output_for_config_file) {
+	std::string output;
+	auto result = validate_content("falco_config_for_json_rules_validation.yaml",
+	                               "rules_files:\n  - /etc/falco/falco_rules.yaml\n",
+	                               true,
+	                               output);
+	auto json_output = nlohmann::json::parse(output, nullptr, false);
+	EXPECT_FALSE(result.success);
+	EXPECT_NE(result.errstr.find(s_hint), std::string::npos);
+	EXPECT_TRUE(json_output.is_object());
+	EXPECT_TRUE(json_output.contains("falco_load_results"));
+	EXPECT_EQ(output.find(s_hint), std::string::npos);
+}
+
+TEST(ActionValidateRulesFiles, omits_config_hint_for_rules_sequence) {
+	std::string output;
+	auto result = validate_content("invalid_rules_for_validation.yaml",
+	                               "- rule: missing required fields\n",
+	                               false,
+	                               output);
+	EXPECT_FALSE(result.success);
+	EXPECT_EQ(result.errstr.find(s_hint), std::string::npos);
+	EXPECT_EQ(output.find(s_hint), std::string::npos);
+}

--- a/unit_tests/falco/app/actions/test_validate_rules_files.cpp
+++ b/unit_tests/falco/app/actions/test_validate_rules_files.cpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2026 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "app_action_helpers.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace {
+const std::string s_hint =
+        "--validate expects a rules file, that is a YAML list of rule, macro, and list items.";
+
+std::string dry_run_command(const std::string& filename) {
+	return "falco -c " + filename + " --dry-run";
+}
+
+class stdout_capture {
+public:
+	stdout_capture(): m_original(std::cout.rdbuf(m_stream.rdbuf())) {}
+	~stdout_capture() { std::cout.rdbuf(m_original); }
+
+	std::string str() const { return m_stream.str(); }
+
+private:
+	std::ostringstream m_stream;
+	std::streambuf* m_original;
+};
+
+falco::app::run_result validate_content(const std::string& filename,
+                                        const std::string& content,
+                                        bool json_output,
+                                        std::string& output) {
+	{
+		std::ofstream file(filename);
+		if(!file.is_open()) {
+			return falco::app::run_result::fatal("Could not create test file " + filename);
+		}
+		file << content;
+	}
+
+	falco::app::state s = {};
+	s.options.validate_rules_filenames = {filename};
+	s.config->m_json_output = json_output;
+
+	falco::app::run_result result;
+	{
+		stdout_capture capture;
+		result = falco::app::actions::validate_rules_files(s);
+		output = capture.str();
+	}
+	EXPECT_EQ(std::remove(filename.c_str()), 0);
+	return result;
+}
+}  // namespace
+
+TEST(ActionValidateRulesFiles, suggests_dry_run_for_config_file) {
+	const std::string filename = "falco_config_for_rules_validation.yaml";
+	std::string output;
+	auto result = validate_content(filename,
+	                               "rules_files:\n  - /etc/falco/falco_rules.yaml\n",
+	                               false,
+	                               output);
+	EXPECT_FALSE(result.success);
+	EXPECT_FALSE(result.proceed);
+	EXPECT_NE(result.errstr.find(s_hint), std::string::npos);
+	EXPECT_NE(result.errstr.find(dry_run_command(filename)), std::string::npos);
+	EXPECT_NE(output.find(s_hint), std::string::npos);
+	EXPECT_NE(output.find(dry_run_command(filename)), std::string::npos);
+}
+
+TEST(ActionValidateRulesFiles, preserves_json_output_for_config_file) {
+	const std::string filename = "falco_config_for_json_rules_validation.yaml";
+	std::string output;
+	auto result = validate_content(filename,
+	                               "rules_files:\n  - /etc/falco/falco_rules.yaml\n",
+	                               true,
+	                               output);
+	auto json_output = nlohmann::json::parse(output, nullptr, false);
+	EXPECT_FALSE(result.success);
+	EXPECT_NE(result.errstr.find(s_hint), std::string::npos);
+	EXPECT_NE(result.errstr.find(dry_run_command(filename)), std::string::npos);
+	EXPECT_TRUE(json_output.is_object());
+	EXPECT_TRUE(json_output.contains("falco_load_results"));
+	EXPECT_EQ(output.find(s_hint), std::string::npos);
+	EXPECT_EQ(output.find(dry_run_command(filename)), std::string::npos);
+}
+
+TEST(ActionValidateRulesFiles, omits_config_hint_for_rules_sequence) {
+	std::string output;
+	auto result = validate_content("invalid_rules_for_validation.yaml",
+	                               "- rule: missing required fields\n",
+	                               false,
+	                               output);
+	EXPECT_FALSE(result.success);
+	EXPECT_EQ(result.errstr.find(s_hint), std::string::npos);
+	EXPECT_EQ(result.errstr.find("--dry-run"), std::string::npos);
+	EXPECT_EQ(output.find(s_hint), std::string::npos);
+	EXPECT_EQ(output.find("--dry-run"), std::string::npos);
+}

--- a/userspace/falco/app/actions/validate_rules_files.cpp
+++ b/userspace/falco/app/actions/validate_rules_files.cpp
@@ -19,11 +19,27 @@ limitations under the License.
 #include "helpers.h"
 
 #include <plugin_manager.h>
+#include <yaml-cpp/yaml.h>
 
 #include <string>
 
 using namespace falco::app;
 using namespace falco::app::actions;
+
+namespace {
+bool has_yaml_mapping_root(const std::string& content) {
+	try {
+		for(const auto& document : YAML::LoadAll(content)) {
+			if(document.IsMap()) {
+				return true;
+			}
+		}
+	} catch(const YAML::Exception&) {
+		// The existing rules validation result already reports YAML parsing errors.
+	}
+	return false;
+}
+}  // namespace
 
 falco::app::run_result falco::app::actions::validate_rules_files(falco::app::state& s) {
 	if(s.options.validate_rules_filenames.size() == 0) {
@@ -105,6 +121,12 @@ falco::app::run_result falco::app::actions::validate_rules_files(falco::app::sta
 			// printing the warnings.
 			summary += filename + ": Ok, with warnings";
 			falco_logger::log(falco_logger::level::WARNING, res->as_string(true, rc) + "\n");
+		}
+
+		if(!res->successful() && has_yaml_mapping_root(rc.at(filename).get())) {
+			summary +=
+			        "\nHint: --validate accepts Falco rules files only. To validate a Falco "
+			        "configuration file and its configured rules, use --dry-run.";
 		}
 	}
 

--- a/userspace/falco/app/actions/validate_rules_files.cpp
+++ b/userspace/falco/app/actions/validate_rules_files.cpp
@@ -19,11 +19,27 @@ limitations under the License.
 #include "helpers.h"
 
 #include <plugin_manager.h>
+#include <yaml-cpp/yaml.h>
 
 #include <string>
 
 using namespace falco::app;
 using namespace falco::app::actions;
+
+namespace {
+bool has_yaml_mapping_root(const std::string& content) {
+	try {
+		for(const auto& document : YAML::LoadAll(content)) {
+			if(document.IsMap()) {
+				return true;
+			}
+		}
+	} catch(const YAML::Exception&) {
+		// The existing rules validation result already reports YAML parsing errors.
+	}
+	return false;
+}
+}  // namespace
 
 falco::app::run_result falco::app::actions::validate_rules_files(falco::app::state& s) {
 	if(s.options.validate_rules_filenames.size() == 0) {
@@ -105,6 +121,14 @@ falco::app::run_result falco::app::actions::validate_rules_files(falco::app::sta
 			// printing the warnings.
 			summary += filename + ": Ok, with warnings";
 			falco_logger::log(falco_logger::level::WARNING, res->as_string(true, rc) + "\n");
+		}
+
+		if(!res->successful() && has_yaml_mapping_root(rc.at(filename).get())) {
+			summary +=
+			        "\nHint: --validate expects a rules file, that is a YAML list of rule, macro, "
+			        "and list items. If this is a Falco configuration file, validate it and its "
+			        "configured rules with `falco -c " +
+			        filename + " --dry-run` instead.";
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, please read our contributor guidelines in the https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind release

> If this PR prepares a chart release, uncomment:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area engine

/area tests

> /area proposals

> /area automation

> /area chart

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

When `--validate` receives a top-level YAML mapping such as `falco.yaml`, rules validation currently reports only a structural error. This change adds an actionable hint explaining that `--validate` accepts rules files and that `--dry-run` validates a Falco configuration together with its configured rules.

The hint is added in the `validate_rules_files` application action, so normal rule loading and embedded engine callers are unchanged. JSON stdout remains machine-parseable; the hint stays in the fatal error summary written to stderr.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Related to #3725

**Special notes for your reviewer**:

This is a draft because #3725 is assigned to @leogr; I would appreciate confirmation that the diagnostic wording and app-layer placement match the intended scope.

Validation:

- Repository `clang-format` 18.1.8 and `cmake-format` 0.6.13 hooks
- CI-matching minimal Linux build of `falco_unit_tests`
- All three focused `ActionValidateRulesFiles` regressions
- Full unit suite: 214/214 tests passed
- Manual CLI E2E: baseline returned the generic error; the patch retained exit code 1 and added the `--dry-run` hint to stdout and stderr
- Text, JSON-preservation, and non-config negative cases

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
feat(userspace/falco): suggest `--dry-run` when `--validate` receives a Falco configuration file
```
