### PR TITLE
feat(metrics): add num_evts to prometheus output

### DIFF
--- a/userspace/falco/app/actions/process_events.cpp
+++ b/userspace/falco/app/actions/process_events.cpp
@@ -386,6 +386,11 @@ static falco::app::run_result do_inspect(
 		}
 
 		num_evts++;
+		if(is_capture_mode) {
+			s.offline_num_evts->store(num_evts, std::memory_order_relaxed);
+		} else {
+			s.source_infos.at(source)->num_evts->store(num_evts, std::memory_order_relaxed);
+		}
 	}
 
 	return run_result::ok();

--- a/userspace/falco/app/state.h
+++ b/userspace/falco/app/state.h
@@ -58,6 +58,7 @@ struct state {
 		// source is a plugin one, the assigned inspector must have that
 		// plugin registered in its plugin manager
 		std::shared_ptr<sinsp> inspector;
+		std::shared_ptr<std::atomic<uint64_t>> num_evts{std::make_shared<std::atomic<uint64_t>>(0)};
 	};
 
 	state():
@@ -91,6 +92,8 @@ struct state {
 	// Used to load all plugins to get their info. In capture mode,
 	// this is also used to open the capture file and read its events
 	std::shared_ptr<sinsp> offline_inspector;
+	std::shared_ptr<std::atomic<uint64_t>> offline_num_evts{
+	        std::make_shared<std::atomic<uint64_t>>(0)};
 
 	// List of all the information mapped to each event source
 	// indexed by event source name

--- a/userspace/falco/falco_metrics.cpp
+++ b/userspace/falco/falco_metrics.cpp
@@ -148,6 +148,40 @@ std::string falco_metrics::falco_to_text_prometheus(
 		        {{"file_name", fs_path.filename()}, {"sha256", item.second}});
 	}
 
+	// # HELP falcosecurity_falco_num_evts_total https://falco.org/docs/metrics/
+	// # TYPE falcosecurity_falco_num_evts_total counter
+	// falcosecurity_falco_num_evts_total{source="syscall"} 1234
+	if(state.is_capture_mode()) {
+		auto metric = libs::metrics::libsinsp_metrics::new_metric(
+		        "num_evts",
+		        METRICS_V2_MISC,
+		        METRIC_VALUE_TYPE_U64,
+		        METRIC_VALUE_UNIT_COUNT,
+		        METRIC_VALUE_METRIC_TYPE_MONOTONIC,
+		        (uint64_t)state.offline_num_evts->load(std::memory_order_relaxed));
+		prometheus_text +=
+		        prometheus_metrics_converter.convert_metric_to_text_prometheus(metric,
+		                                                                       "falcosecurity",
+		                                                                       "falco",
+		                                                                       {{"source", ""}});
+	} else {
+		for(const auto& src : state.loaded_sources) {
+			auto metric = libs::metrics::libsinsp_metrics::new_metric(
+			        "num_evts",
+			        METRICS_V2_MISC,
+			        METRIC_VALUE_TYPE_U64,
+			        METRIC_VALUE_UNIT_COUNT,
+			        METRIC_VALUE_METRIC_TYPE_MONOTONIC,
+			        (uint64_t)state.source_infos.at(src)->num_evts->load(
+			                std::memory_order_relaxed));
+			prometheus_text += prometheus_metrics_converter.convert_metric_to_text_prometheus(
+			        metric,
+			        "falcosecurity",
+			        "falco",
+			        {{"source", src}});
+		}
+	}
+
 #endif
 	// # HELP falcosecurity_falco_outputs_queue_num_drops_total https://falco.org/docs/metrics/
 	// # TYPE falcosecurity_falco_outputs_queue_num_drops_total counter


### PR DESCRIPTION
Fixes #3584 

This PR implements the missing `falco.num_evts` in the Prometheus output sink, matching the behavior already present in the JSON/StatsD sinks.

### Changes
- **`userspace/falco/app/state.h`**: Injected an atomic counter `std::shared_ptr<std::atomic<uint64_t>> num_evts` into the `source_info` structure (and a fallback for offline mode) to allow thread-safe access from the asynchronous webserver.
- **`userspace/falco/app/actions/process_events.cpp`**: Hooked into the main inspection loop to dynamically update the atomic counter without incurring heavy lock overheads (`std::memory_order_relaxed`).
- **`userspace/falco/falco_metrics.cpp`**: Exposed the new counter as `falcosecurity_falco_num_evts_total` in the Prometheus metrics endpoint, preserving the `source` label granularity when running with multiple event sources.

```release-note
feat(metrics): add num_evts to prometheus output
```