### PR TITLE
update(ci): use Docker Hub OIDC connection

### DIFF
--- a/.github/workflows/reusable_publish_docker.yaml
+++ b/.github/workflows/reusable_publish_docker.yaml
@@ -50,10 +50,11 @@ jobs:
           for img in /tmp/falco-images/falco-*.tar; do docker load --input $img; done
 
       - name: Login to Docker Hub
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTION }}
         with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_SECRET }}
+          username: falcosecurity
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Hi all, long time no see :)

Docker Hub recently introduced OIDC connections with GitHub ( https://www.docker.com/blog/docker-oidc-connections-for-github-actions-available-for-docker-orgs/ ). I would like to propose adopting this instead of the legacy mechanism that used to be the only one available.

The security benefits of this should be obvious, essentially we'll be able to scope Docker Hub repo push by GitHub repo, branch and tags without any pesky credentials. In case you wish to pursue it and strengthen the supply chain security posture of Falco, if this PR is accepted I will open a number of corresponding PRs on other repositories that use Docker Hub, then get rid of the secret.

WARNING: in order to properly review this PR a maintainer will need to review a **configuration change on Docker Hub in the OIDC settings and a GitHub variable**. I went ahead and added them (non-destructively, deactivated) to allow you to review them. For owners on Docker Hub you can check out all the configuration in the Docker Hub org page under Identity & Auth > OIDC Connection and the corresponding variable in this repo. 

**The connection is currently deactivated! Once the PR is approved I will activate it**

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If NO, just write "NONE" in the release-note block below.

If YES, a release note is required, enter your release note in the block below. 
The convention is the same as for commit messages: https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md#commit-convention
If the PR introduces non-backward compatible changes, please add a line starting with "BREAKING CHANGE:" and describe what changed.
For example, `BREAKING CHANGE: the API interface of the rule engine has changed`.
Your note will be included in the changelog.
-->

```release-note
update(ci): use Docker Hub OIDC connection
```
