### PR TITLE
fix(chart): restore v9.1.0 release metadata

### DIFF
--- a/chart/falco/CHANGELOG.md
+++ b/chart/falco/CHANGELOG.md
@@ -9,6 +9,11 @@ numbering uses [semantic versioning](http://semver.org).
 * Fix Grafana dashboard priority level mappings to match Falco's numeric encoding (0=emergency … 7=debug)
 - Add `revisionHistoryLimit` support to the DaemonSet controller and honor an explicit zero for both DaemonSet and Deployment controllers
 
+## v9.1.0
+
+* Upgrade Falco to v0.44.1
+* Add `driver.modernEbpf.disableIterators` and missing `metrics.kernelIterEventCountersEnabled` for disabling BPF iterators and corresponding metrics support
+
 ## v9.0.0
 
 * Drop gRPC output and server support

--- a/chart/falco/Chart.yaml
+++ b/chart/falco/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: falco
 version: 9.1.0
-appVersion: "0.44.0"
+appVersion: "0.44.1"
 description: Falco
 keywords:
   - monitoring


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area chart

**What this PR does / why we need it**:

`master` is missing the `v9.1.0` chart changelog and still uses `appVersion: "0.44.0"`.

This forward-ports the release metadata from [c7b3ed16](https://github.com/falcosecurity/falco/commit/c7b3ed16a7836d496eaef27e204fdabe536725a3): restores the `v9.1.0` changelog section and sets `appVersion` to `0.44.1`. The Grafana dashboard fix stays under `Unreleased`, and the chart version stays `9.1.0`.

**Which issue(s) this PR fixes**:

Related to #3967.

**Special notes for your reviewer**:

N.B. This commit also needs to be cherry-picked to `release/0.45.x` after merging.

Validation: `make chart-check`.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
