### PR TITLE
fix(chart): mount the container engine socket directories, not the socket files

### DIFF
--- a/chart/falco/CHANGELOG.md
+++ b/chart/falco/CHANGELOG.md
@@ -9,6 +9,7 @@ numbering uses [semantic versioning](http://semver.org).
 * Fix Grafana dashboard priority level mappings to match Falco's numeric encoding (0=emergency … 7=debug)
 - Add `revisionHistoryLimit` support to the DaemonSet controller and honor an explicit zero for both DaemonSet and Deployment controllers
 * Add `serviceAccount.labels` to set custom labels on the ServiceAccount
+* Mount the host directory that holds each container engine socket instead of the socket file, so Falco keeps working after a container runtime restart (regression of falcosecurity/charts#632, originally fixed by falcosecurity/charts#633). With the default values the pod now mounts `/var/run`, `/run/podman`, `/run/host-containerd`, `/run/containerd`, `/run/crio`, and `/run/k3s/containerd` instead of the six socket files
 
 ## v9.0.0
 

--- a/chart/falco/templates/_helpers.tpl
+++ b/chart/falco/templates/_helpers.tpl
@@ -457,9 +457,14 @@ This helper is used to add container plugin volumes to the falco pod.
 {{- $val := index $.Values.collectors.containerEngine.engines $engineName -}}
 {{- if and $val $val.enabled -}}
 {{- range $index, $socket := $val.sockets -}}
-{{- $mountPath := print "/host" $socket -}}
+{{/* Mount the directory holding the socket, not the socket itself. A file
+     bind mount pins the inode, so when the runtime restarts and recreates its
+     socket the pod keeps the old dead one and Falco stops enriching events
+     (issue #632, and again #1052). */}}
+{{- $socketDir := dir $socket -}}
+{{- $mountPath := print "/host" $socketDir -}}
 {{- if not (hasKey $seenPaths $mountPath) -}}
-{{ $volumes = append $volumes (dict "name" (printf "container-engine-socket-%d" $idx) "hostPath" (dict "path" $socket)) -}}
+{{ $volumes = append $volumes (dict "name" (printf "container-engine-socket-%d" $idx) "hostPath" (dict "path" $socketDir)) -}}
 {{- $idx = add $idx 1 -}}
 {{- $_ := set $seenPaths $mountPath true -}}
 {{- end -}}
@@ -488,7 +493,10 @@ This helper is used to add container plugin volumeMounts to the falco pod.
 {{- $val := index $.Values.collectors.containerEngine.engines $engineName -}}
 {{- if and $val $val.enabled -}}
 {{- range $index, $socket := $val.sockets -}}
-{{- $mountPath := print "/host" $socket -}}
+{{/* Kept in step with falco.containerPluginVolumes: the directory is mounted,
+     not the socket file, so the volume names line up. */}}
+{{- $socketDir := dir $socket -}}
+{{- $mountPath := print "/host" $socketDir -}}
 {{- if not (hasKey $seenPaths $mountPath) -}}
 {{ $volumeMounts = append $volumeMounts (dict "name" (printf "container-engine-socket-%d" $idx) "mountPath" $mountPath) -}}
 {{- $idx = add $idx 1 -}}

--- a/chart/falco/tests/unit/containerPlugin/volumeMounts_test.go
+++ b/chart/falco/tests/unit/containerPlugin/volumeMounts_test.go
@@ -28,17 +28,17 @@ func TestContainerPluginVolumeMounts(t *testing.T) {
 			expected: func(t *testing.T, volumeMounts []corev1.VolumeMount) {
 				require.Len(t, volumeMounts, 6)
 				require.Equal(t, "container-engine-socket-0", volumeMounts[0].Name)
-				require.Equal(t, "/host/var/run/docker.sock", volumeMounts[0].MountPath)
+				require.Equal(t, "/host/var/run", volumeMounts[0].MountPath)
 				require.Equal(t, "container-engine-socket-1", volumeMounts[1].Name)
-				require.Equal(t, "/host/run/podman/podman.sock", volumeMounts[1].MountPath)
+				require.Equal(t, "/host/run/podman", volumeMounts[1].MountPath)
 				require.Equal(t, "container-engine-socket-2", volumeMounts[2].Name)
-				require.Equal(t, "/host/run/host-containerd/containerd.sock", volumeMounts[2].MountPath)
+				require.Equal(t, "/host/run/host-containerd", volumeMounts[2].MountPath)
 				require.Equal(t, "container-engine-socket-3", volumeMounts[3].Name)
-				require.Equal(t, "/host/run/containerd/containerd.sock", volumeMounts[3].MountPath)
+				require.Equal(t, "/host/run/containerd", volumeMounts[3].MountPath)
 				require.Equal(t, "container-engine-socket-4", volumeMounts[4].Name)
-				require.Equal(t, "/host/run/crio/crio.sock", volumeMounts[4].MountPath)
+				require.Equal(t, "/host/run/crio", volumeMounts[4].MountPath)
 				require.Equal(t, "container-engine-socket-5", volumeMounts[5].Name)
-				require.Equal(t, "/host/run/k3s/containerd/containerd.sock", volumeMounts[5].MountPath)
+				require.Equal(t, "/host/run/k3s/containerd", volumeMounts[5].MountPath)
 			},
 		},
 		{
@@ -52,7 +52,7 @@ func TestContainerPluginVolumeMounts(t *testing.T) {
 			expected: func(t *testing.T, volumeMounts []corev1.VolumeMount) {
 				require.Len(t, volumeMounts, 1)
 				require.Equal(t, "container-engine-socket-0", volumeMounts[0].Name)
-				require.Equal(t, "/host/var/run/docker.sock", volumeMounts[0].MountPath)
+				require.Equal(t, "/host/var/run", volumeMounts[0].MountPath)
 			},
 		},
 		{
@@ -67,7 +67,7 @@ func TestContainerPluginVolumeMounts(t *testing.T) {
 			expected: func(t *testing.T, volumeMounts []corev1.VolumeMount) {
 				require.Len(t, volumeMounts, 1)
 				require.Equal(t, "container-engine-socket-0", volumeMounts[0].Name)
-				require.Equal(t, "/host/custom/docker.sock", volumeMounts[0].MountPath)
+				require.Equal(t, "/host/custom", volumeMounts[0].MountPath)
 			},
 		},
 		{
@@ -81,13 +81,13 @@ func TestContainerPluginVolumeMounts(t *testing.T) {
 			expected: func(t *testing.T, volumeMounts []corev1.VolumeMount) {
 				require.Len(t, volumeMounts, 4)
 				require.Equal(t, "container-engine-socket-0", volumeMounts[0].Name)
-				require.Equal(t, "/host/run/containerd/containerd.sock", volumeMounts[0].MountPath)
+				require.Equal(t, "/host/run/containerd", volumeMounts[0].MountPath)
 				require.Equal(t, "container-engine-socket-1", volumeMounts[1].Name)
-				require.Equal(t, "/host/run/crio/crio.sock", volumeMounts[1].MountPath)
+				require.Equal(t, "/host/run/crio", volumeMounts[1].MountPath)
 				require.Equal(t, "container-engine-socket-2", volumeMounts[2].Name)
-				require.Equal(t, "/host/run/k3s/containerd/containerd.sock", volumeMounts[2].MountPath)
+				require.Equal(t, "/host/run/k3s/containerd", volumeMounts[2].MountPath)
 				require.Equal(t, "container-engine-socket-3", volumeMounts[3].Name)
-				require.Equal(t, "/host/run/host-containerd/containerd.sock", volumeMounts[3].MountPath)
+				require.Equal(t, "/host/run/host-containerd", volumeMounts[3].MountPath)
 			},
 		},
 		{
@@ -102,7 +102,7 @@ func TestContainerPluginVolumeMounts(t *testing.T) {
 			expected: func(t *testing.T, volumeMounts []corev1.VolumeMount) {
 				require.Len(t, volumeMounts, 1)
 				require.Equal(t, "container-engine-socket-0", volumeMounts[0].Name)
-				require.Equal(t, "/host/custom/crio.sock", volumeMounts[0].MountPath)
+				require.Equal(t, "/host/custom", volumeMounts[0].MountPath)
 			},
 		},
 		{
@@ -116,7 +116,7 @@ func TestContainerPluginVolumeMounts(t *testing.T) {
 			expected: func(t *testing.T, volumeMounts []corev1.VolumeMount) {
 				require.Len(t, volumeMounts, 1)
 				require.Equal(t, "container-engine-socket-0", volumeMounts[0].Name)
-				require.Equal(t, "/host/run/host-containerd/containerd.sock", volumeMounts[0].MountPath)
+				require.Equal(t, "/host/run/host-containerd", volumeMounts[0].MountPath)
 			},
 		},
 		{
@@ -131,7 +131,7 @@ func TestContainerPluginVolumeMounts(t *testing.T) {
 			expected: func(t *testing.T, volumeMounts []corev1.VolumeMount) {
 				require.Len(t, volumeMounts, 1)
 				require.Equal(t, "container-engine-socket-0", volumeMounts[0].Name)
-				require.Equal(t, "/host/custom/containerd.sock", volumeMounts[0].MountPath)
+				require.Equal(t, "/host/custom", volumeMounts[0].MountPath)
 			},
 		},
 		{
@@ -142,27 +142,27 @@ func TestContainerPluginVolumeMounts(t *testing.T) {
 
 				// dockerV := findVolumeMount("docker-socket-0", volumeMounts)
 				// require.NotNil(t, dockerV)
-				// require.Equal(t, "/host/var/run/docker.sock", dockerV.MountPath)
+				// require.Equal(t, "/host/var/run", dockerV.MountPath)
 
 				// podmanV := findVolumeMount("podman-socket-0", volumeMounts)
 				// require.NotNil(t, podmanV)
-				// require.Equal(t, "/host/run/podman/podman.sock", podmanV.MountPath)
+				// require.Equal(t, "/host/run/podman", podmanV.MountPath)
 
 				// containerdV := findVolumeMount("containerd-socket-0", volumeMounts)
 				// require.NotNil(t, containerdV)
-				// require.Equal(t, "/host/run/host-containerd/containerd.sock", containerdV.MountPath)
+				// require.Equal(t, "/host/run/host-containerd", containerdV.MountPath)
 
 				// crioV0 := findVolumeMount("cri-socket-0", volumeMounts)
 				// require.NotNil(t, crioV0)
-				// require.Equal(t, "/host/run/containerd/containerd.sock", crioV0.MountPath)
+				// require.Equal(t, "/host/run/containerd", crioV0.MountPath)
 
 				// crioV1 := findVolumeMount("cri-socket-1", volumeMounts)
 				// require.NotNil(t, crioV1)
-				// require.Equal(t, "/host/run/crio/crio.sock", crioV1.MountPath)
+				// require.Equal(t, "/host/run/crio", crioV1.MountPath)
 
 				// crioV2 := findVolumeMount("cri-socket-2", volumeMounts)
 				// require.NotNil(t, crioV2)
-				// require.Equal(t, "/host/run/k3s/containerd/containerd.sock", crioV2.MountPath)
+				// require.Equal(t, "/host/run/k3s/containerd", crioV2.MountPath)
 			},
 		},
 		{
@@ -180,11 +180,11 @@ func TestContainerPluginVolumeMounts(t *testing.T) {
 
 				dockerV0 := findVolumeMount("container-engine-socket-0", volumeMounts)
 				require.NotNil(t, dockerV0)
-				require.Equal(t, "/host/var/run/docker.sock", dockerV0.MountPath)
+				require.Equal(t, "/host/var/run", dockerV0.MountPath)
 
 				dockerV1 := findVolumeMount("container-engine-socket-1", volumeMounts)
 				require.NotNil(t, dockerV1)
-				require.Equal(t, "/host/custom/docker.sock", dockerV1.MountPath)
+				require.Equal(t, "/host/custom", dockerV1.MountPath)
 			},
 		},
 		{
@@ -202,11 +202,11 @@ func TestContainerPluginVolumeMounts(t *testing.T) {
 
 				crioV0 := findVolumeMount("container-engine-socket-0", volumeMounts)
 				require.NotNil(t, crioV0)
-				require.Equal(t, "/host/run/crio/crio.sock", crioV0.MountPath)
+				require.Equal(t, "/host/run/crio", crioV0.MountPath)
 
 				crioV1 := findVolumeMount("container-engine-socket-1", volumeMounts)
 				require.NotNil(t, crioV1)
-				require.Equal(t, "/host/custom/crio.sock", crioV1.MountPath)
+				require.Equal(t, "/host/custom", crioV1.MountPath)
 			},
 		},
 		{

--- a/chart/falco/tests/unit/containerPlugin/volumeMounts_test.go
+++ b/chart/falco/tests/unit/containerPlugin/volumeMounts_test.go
@@ -210,6 +210,22 @@ func TestContainerPluginVolumeMounts(t *testing.T) {
 			},
 		},
 		{
+			name: "ContainerEnginesSocketsInSameDirectoryShareOneVolumeMount",
+			values: map[string]string{
+				"collectors.containerEngine.engines.docker.enabled":     "false",
+				"collectors.containerEngine.engines.containerd.enabled": "false",
+				"collectors.containerEngine.engines.cri.enabled":        "true",
+				"collectors.containerEngine.engines.cri.sockets[0]":     "/run/containerd/containerd.sock",
+				"collectors.containerEngine.engines.cri.sockets[1]":     "/run/containerd/other.sock",
+				"collectors.containerEngine.engines.podman.enabled":     "false",
+			},
+			expected: func(t *testing.T, volumeMounts []corev1.VolumeMount) {
+				require.Len(t, volumeMounts, 1)
+				require.Equal(t, "container-engine-socket-0", volumeMounts[0].Name)
+				require.Equal(t, "/host/run/containerd", volumeMounts[0].MountPath)
+			},
+		},
+		{
 			name: "noVolumeMountsWhenCollectorsDisabled",
 			values: map[string]string{
 				"collectors.enabled": "false",

--- a/chart/falco/tests/unit/containerPlugin/volumes_test.go
+++ b/chart/falco/tests/unit/containerPlugin/volumes_test.go
@@ -276,6 +276,22 @@ func TestContainerPluginVolumes(t *testing.T) {
 			},
 		},
 		{
+			name: "ContainerEnginesSocketsInSameDirectoryShareOneVolume",
+			values: map[string]string{
+				"collectors.containerEngine.engines.docker.enabled":     "false",
+				"collectors.containerEngine.engines.containerd.enabled": "false",
+				"collectors.containerEngine.engines.cri.enabled":        "true",
+				"collectors.containerEngine.engines.cri.sockets[0]":     "/run/containerd/containerd.sock",
+				"collectors.containerEngine.engines.cri.sockets[1]":     "/run/containerd/other.sock",
+				"collectors.containerEngine.engines.podman.enabled":     "false",
+			},
+			expected: func(t *testing.T, volumes []corev1.Volume) {
+				require.Len(t, volumes, 1)
+				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
+				require.Equal(t, "/run/containerd", volumes[0].HostPath.Path)
+			},
+		},
+		{
 			name: "noVolumesWhenCollectorsDisabled",
 			values: map[string]string{
 				"collectors.enabled": "false",

--- a/chart/falco/tests/unit/containerPlugin/volumes_test.go
+++ b/chart/falco/tests/unit/containerPlugin/volumes_test.go
@@ -29,17 +29,17 @@ func TestContainerPluginVolumes(t *testing.T) {
 			expected: func(t *testing.T, volumes []corev1.Volume) {
 				require.Len(t, volumes, 6)
 				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
-				require.Equal(t, "/var/run/docker.sock", volumes[0].HostPath.Path)
+				require.Equal(t, "/var/run", volumes[0].HostPath.Path)
 				require.Equal(t, "container-engine-socket-1", volumes[1].Name)
-				require.Equal(t, "/run/podman/podman.sock", volumes[1].HostPath.Path)
+				require.Equal(t, "/run/podman", volumes[1].HostPath.Path)
 				require.Equal(t, "container-engine-socket-2", volumes[2].Name)
-				require.Equal(t, "/run/host-containerd/containerd.sock", volumes[2].HostPath.Path)
+				require.Equal(t, "/run/host-containerd", volumes[2].HostPath.Path)
 				require.Equal(t, "container-engine-socket-3", volumes[3].Name)
-				require.Equal(t, "/run/containerd/containerd.sock", volumes[3].HostPath.Path)
+				require.Equal(t, "/run/containerd", volumes[3].HostPath.Path)
 				require.Equal(t, "container-engine-socket-4", volumes[4].Name)
-				require.Equal(t, "/run/crio/crio.sock", volumes[4].HostPath.Path)
+				require.Equal(t, "/run/crio", volumes[4].HostPath.Path)
 				require.Equal(t, "container-engine-socket-5", volumes[5].Name)
-				require.Equal(t, "/run/k3s/containerd/containerd.sock", volumes[5].HostPath.Path)
+				require.Equal(t, "/run/k3s/containerd", volumes[5].HostPath.Path)
 			},
 		},
 		{
@@ -53,7 +53,7 @@ func TestContainerPluginVolumes(t *testing.T) {
 			expected: func(t *testing.T, volumes []corev1.Volume) {
 				require.Len(t, volumes, 1)
 				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
-				require.Equal(t, "/var/run/docker.sock", volumes[0].HostPath.Path)
+				require.Equal(t, "/var/run", volumes[0].HostPath.Path)
 			},
 		},
 		{
@@ -68,7 +68,7 @@ func TestContainerPluginVolumes(t *testing.T) {
 			expected: func(t *testing.T, volumes []corev1.Volume) {
 				require.Len(t, volumes, 1)
 				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
-				require.Equal(t, "/custom/docker.sock", volumes[0].HostPath.Path)
+				require.Equal(t, "/custom", volumes[0].HostPath.Path)
 			},
 		},
 		{
@@ -82,13 +82,13 @@ func TestContainerPluginVolumes(t *testing.T) {
 			expected: func(t *testing.T, volumes []corev1.Volume) {
 				require.Len(t, volumes, 4)
 				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
-				require.Equal(t, "/run/containerd/containerd.sock", volumes[0].HostPath.Path)
+				require.Equal(t, "/run/containerd", volumes[0].HostPath.Path)
 				require.Equal(t, "container-engine-socket-1", volumes[1].Name)
-				require.Equal(t, "/run/crio/crio.sock", volumes[1].HostPath.Path)
+				require.Equal(t, "/run/crio", volumes[1].HostPath.Path)
 				require.Equal(t, "container-engine-socket-2", volumes[2].Name)
-				require.Equal(t, "/run/k3s/containerd/containerd.sock", volumes[2].HostPath.Path)
+				require.Equal(t, "/run/k3s/containerd", volumes[2].HostPath.Path)
 				require.Equal(t, "container-engine-socket-3", volumes[3].Name)
-				require.Equal(t, "/run/host-containerd/containerd.sock", volumes[3].HostPath.Path)
+				require.Equal(t, "/run/host-containerd", volumes[3].HostPath.Path)
 			},
 		},
 		{
@@ -103,7 +103,7 @@ func TestContainerPluginVolumes(t *testing.T) {
 			expected: func(t *testing.T, volumes []corev1.Volume) {
 				require.Len(t, volumes, 1)
 				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
-				require.Equal(t, "/custom/crio.sock", volumes[0].HostPath.Path)
+				require.Equal(t, "/custom", volumes[0].HostPath.Path)
 			},
 		},
 		{
@@ -117,7 +117,7 @@ func TestContainerPluginVolumes(t *testing.T) {
 			expected: func(t *testing.T, volumes []corev1.Volume) {
 				require.Len(t, volumes, 1)
 				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
-				require.Equal(t, "/run/host-containerd/containerd.sock", volumes[0].HostPath.Path)
+				require.Equal(t, "/run/host-containerd", volumes[0].HostPath.Path)
 			},
 		},
 		{
@@ -132,7 +132,7 @@ func TestContainerPluginVolumes(t *testing.T) {
 			expected: func(t *testing.T, volumes []corev1.Volume) {
 				require.Len(t, volumes, 1)
 				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
-				require.Equal(t, "/custom/containerd.sock", volumes[0].HostPath.Path)
+				require.Equal(t, "/custom", volumes[0].HostPath.Path)
 			},
 		},
 
@@ -147,17 +147,17 @@ func TestContainerPluginVolumes(t *testing.T) {
 			expected: func(t *testing.T, volumes []corev1.Volume) {
 				require.Len(t, volumes, 6)
 				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
-				require.Equal(t, "/var/run/docker.sock", volumes[0].HostPath.Path)
+				require.Equal(t, "/var/run", volumes[0].HostPath.Path)
 				require.Equal(t, "container-engine-socket-1", volumes[1].Name)
-				require.Equal(t, "/run/podman/podman.sock", volumes[1].HostPath.Path)
+				require.Equal(t, "/run/podman", volumes[1].HostPath.Path)
 				require.Equal(t, "container-engine-socket-2", volumes[2].Name)
-				require.Equal(t, "/run/host-containerd/containerd.sock", volumes[2].HostPath.Path)
+				require.Equal(t, "/run/host-containerd", volumes[2].HostPath.Path)
 				require.Equal(t, "container-engine-socket-3", volumes[3].Name)
-				require.Equal(t, "/run/containerd/containerd.sock", volumes[3].HostPath.Path)
+				require.Equal(t, "/run/containerd", volumes[3].HostPath.Path)
 				require.Equal(t, "container-engine-socket-4", volumes[4].Name)
-				require.Equal(t, "/run/crio/crio.sock", volumes[4].HostPath.Path)
+				require.Equal(t, "/run/crio", volumes[4].HostPath.Path)
 				require.Equal(t, "container-engine-socket-5", volumes[5].Name)
-				require.Equal(t, "/run/k3s/containerd/containerd.sock", volumes[5].HostPath.Path)
+				require.Equal(t, "/run/k3s/containerd", volumes[5].HostPath.Path)
 			},
 		},
 		{
@@ -177,9 +177,9 @@ func TestContainerPluginVolumes(t *testing.T) {
 			expected: func(t *testing.T, volumes []corev1.Volume) {
 				require.Len(t, volumes, 2)
 				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
-				require.Equal(t, "/var/run/docker.sock", volumes[0].HostPath.Path)
+				require.Equal(t, "/var/run", volumes[0].HostPath.Path)
 				require.Equal(t, "container-engine-socket-1", volumes[1].Name)
-				require.Equal(t, "/custom/docker.sock", volumes[1].HostPath.Path)
+				require.Equal(t, "/custom", volumes[1].HostPath.Path)
 			},
 		},
 		{
@@ -199,9 +199,9 @@ func TestContainerPluginVolumes(t *testing.T) {
 			expected: func(t *testing.T, volumes []corev1.Volume) {
 				require.Len(t, volumes, 2)
 				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
-				require.Equal(t, "/run/crio/crio.sock", volumes[0].HostPath.Path)
+				require.Equal(t, "/run/crio", volumes[0].HostPath.Path)
 				require.Equal(t, "container-engine-socket-1", volumes[1].Name)
-				require.Equal(t, "/custom/crio.sock", volumes[1].HostPath.Path)
+				require.Equal(t, "/custom", volumes[1].HostPath.Path)
 			},
 		},
 		{
@@ -221,9 +221,9 @@ func TestContainerPluginVolumes(t *testing.T) {
 			expected: func(t *testing.T, volumes []corev1.Volume) {
 				require.Len(t, volumes, 2)
 				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
-				require.Equal(t, "/run/podman/podman.sock", volumes[0].HostPath.Path)
+				require.Equal(t, "/run/podman", volumes[0].HostPath.Path)
 				require.Equal(t, "container-engine-socket-1", volumes[1].Name)
-				require.Equal(t, "/custom/podman.sock", volumes[1].HostPath.Path)
+				require.Equal(t, "/custom", volumes[1].HostPath.Path)
 			},
 		},
 		{
@@ -243,9 +243,9 @@ func TestContainerPluginVolumes(t *testing.T) {
 			expected: func(t *testing.T, volumes []corev1.Volume) {
 				require.Len(t, volumes, 2)
 				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
-				require.Equal(t, "/run/containerd/containerd.sock", volumes[0].HostPath.Path)
+				require.Equal(t, "/run/containerd", volumes[0].HostPath.Path)
 				require.Equal(t, "container-engine-socket-1", volumes[1].Name)
-				require.Equal(t, "/custom/containerd.sock", volumes[1].HostPath.Path)
+				require.Equal(t, "/custom", volumes[1].HostPath.Path)
 			},
 		},
 		{
@@ -266,13 +266,13 @@ func TestContainerPluginVolumes(t *testing.T) {
 			expected: func(t *testing.T, volumes []corev1.Volume) {
 				require.Len(t, volumes, 4)
 				require.Equal(t, "container-engine-socket-0", volumes[0].Name)
-				require.Equal(t, "/custom/docker/socket.sock", volumes[0].HostPath.Path)
+				require.Equal(t, "/custom/docker", volumes[0].HostPath.Path)
 				require.Equal(t, "container-engine-socket-1", volumes[1].Name)
-				require.Equal(t, "/run/podman/podman.sock", volumes[1].HostPath.Path)
+				require.Equal(t, "/run/podman", volumes[1].HostPath.Path)
 				require.Equal(t, "container-engine-socket-2", volumes[2].Name)
-				require.Equal(t, "/run/host-containerd/containerd.sock", volumes[2].HostPath.Path)
+				require.Equal(t, "/run/host-containerd", volumes[2].HostPath.Path)
 				require.Equal(t, "container-engine-socket-3", volumes[3].Name)
-				require.Equal(t, "/var/custom/crio.sock", volumes[3].HostPath.Path)
+				require.Equal(t, "/var/custom", volumes[3].HostPath.Path)
 			},
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area chart

**What this PR does / why we need it**:

Re-files https://github.com/falcosecurity/charts/pull/1058 by @arpitjain099 against the chart source. The commit is imported as-is (authorship preserved); only the `Chart.yaml` bump and the CHANGELOG hunk were left out, since the chart version is bumped by the chart release PR only.

`falco.containerPluginVolumes` and `falco.containerPluginVolumeMounts` mount each entry of `collectors.containerEngine.engines.*.sockets` as a **file** hostPath. A file bind mount pins the inode: when the container runtime restarts and recreates its socket, the Falco pod keeps the old dead one, and every container created after the restart shows `<NA>` for the container and k8s fields until the pod is restarted.

This is a regression of a 2024 fix that was lost when the container plugin volumes replaced the old per-engine volumes:

- original report: https://github.com/falcosecurity/charts/issues/632
- original fix (directory mount instead of the socket file): https://github.com/falcosecurity/charts/pull/633
- new report: https://github.com/falcosecurity/charts/issues/1052

Both helpers now mount `dir $socket` at `/host<dir>`, so `/host<socket>` still resolves for the plugin configuration, which passes the socket paths unchanged. Deduplication moves to the directory, so two sockets in the same directory share one volume. Volume names and their order are unchanged.

With the default values, the pod now mounts these six host directories instead of the six socket files:

- `/var/run`
- `/run/podman`
- `/run/host-containerd`
- `/run/containerd`
- `/run/crio`
- `/run/k3s/containerd`

N.B. This widens each hostPath from a socket file to its directory. The Falco container already runs privileged with the default values, so it is not a new privilege, but it is worth noting for people reviewing their pod security posture.

**Which issue(s) this PR fixes**:

Related to #3979 (transferred from https://github.com/falcosecurity/charts/issues/1052)

Re-files https://github.com/falcosecurity/charts/pull/1058

**Special notes for your reviewer**:

- `make chart-check` passes locally (helm v4.2.2, helm-docs v1.11.0, go 1.27)
- the unit tests in `chart/falco/tests/unit/containerPlugin` (`volumes_test.go`, `volumeMounts_test.go`) now assert the directories, and one more case covers two sockets in the same directory sharing one volume
- I verified the inode pinning with a plain bind mount: after unlinking and recreating the source file, the file bind mount still points at the old inode, while a directory bind mount sees the new file

**Does this PR introduce a user-facing change?**:

```release-note
fix(chart): mount the container engine socket directories instead of the socket files, so Falco keeps working after a container runtime restart
```
