### PR TITLE
fix(ci): bump setup-crane to v0.7 to retry crane download errors

### DIFF
--- a/.github/workflows/reusable_publish_docker.yaml
+++ b/.github/workflows/reusable_publish_docker.yaml
@@ -68,7 +68,7 @@ jobs:
           registry-type: public
 
       - name: Setup Crane
-        uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3
+        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
         with:
           version: v0.15.1
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area automation

**What this PR does / why we need it**:

The `Setup Crane` step of `publish-docker` pins `imjasonh/setup-crane` at v0.3 (2023), which pipes `curl` straight into `tar` with no retry: a truncated download of the crane tarball fails the job at once. That is what happened on `master` yesterday 👉 https://github.com/falcosecurity/falco/actions/runs/34395463985/job/102630096559 (`gzip: stdin: unexpected end of file`; the asset is still there and downloads fine).

v0.7 downloads to a file with `curl --retry 5 --retry-delay 1 --retry-all-errors` before extracting, and exposes the binary through `GITHUB_PATH`. The `version: v0.15.1` input is unchanged, and `crane` is only called from later `run:` steps of the same job, so nothing else moves.

The release workflow uses the same reusable workflow, so this should be cherry-picked to `release/0.45.x` before `0.45.0-rc2`.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

The same day also showed an unrelated, transient `429 toomanyrequests` from ghcr.io in `test-dev-packages-arm64` (unauthenticated `falcoctl artifact install` in the tests); nothing to fix here for that one.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
