### PR TITLE
update(chart): bump the falcosidekick and falco-talon subchart constraints

### DIFF
--- a/chart/falco/CHANGELOG.md
+++ b/chart/falco/CHANGELOG.md
@@ -5,6 +5,8 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## Unreleased
 
+* Bump the `falcosidekick` subchart dependency constraint to `0.14.*` (Falcosidekick 2.31.1; adds the GCP Workload Identity and Gateway API `HTTPRoute` options, both disabled by default, and switches the Helm test pod to the `curlimages/curl` image and the `/healthz` endpoint)
+* Bump the `falco-talon` subchart dependency constraint to `0.4.*` (Falco Talon 0.3.0; fixes the missing namespace in the Secret metadata, restarts Talon when its rules or `config.rulesOverride` change, and allows a folder annotation for the Grafana dashboards)
 * Always mount an emptyDir at `/etc/falco/config.d` in the Falco container, so the configuration snippets shipped in the Falco image are never merged on top of the chart configuration. Previously, with `driver.kind=modern_ebpf` (or `driver.loader.enabled=false`) and both falcoctl containers disabled, the image's `falco.container_plugin.yaml` added a second `container` entry to `load_plugins` and Falco failed to start with `found another plugin with name container`
 * Bump the falcoctl image to `0.14.1`
 * Bump the default `collectors.containerEngine.pluginRef` to `container:0.7.4` and `collectors.kubernetes.pluginRef` to `k8smeta:0.4.2`

--- a/chart/falco/Chart.yaml
+++ b/chart/falco/Chart.yaml
@@ -19,7 +19,7 @@ maintainers:
     email: cncf-falco-dev@lists.cncf.io
 dependencies:
   - name: falcosidekick
-    version: "0.12.*"
+    version: "0.14.*"
     condition: falcosidekick.enabled
     repository: https://falcosecurity.github.io/charts
   - name: k8s-metacollector
@@ -27,6 +27,6 @@ dependencies:
     repository: https://falcosecurity.github.io/charts
     condition: collectors.kubernetes.enabled
   - name: falco-talon
-    version: 0.3.*
+    version: 0.4.*
     repository: https://falcosecurity.github.io/charts
     condition: responseActions.enabled


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area chart

**What this PR does / why we need it**:

This PR bumps the subchart dependency constraints of the Falco chart:

- `falcosidekick`: `0.12.*` becomes `0.14.*` (resolves to `0.14.0`)
- `falco-talon`: `0.3.*` becomes `0.4.*` (resolves to `0.4.2`)

Both subcharts keep the same application versions (Falcosidekick `2.31.1` and Falco Talon `0.3.0`). The new chart lines only add opt-in options and template fixes:

- `falcosidekick`: GCP Workload Identity and Gateway API `HTTPRoute` support (both disabled by default), plus the `curlimages/curl` image and the `/healthz` endpoint for the Helm test pod
- `falco-talon`: the missing `namespace` in the config Secret, a `rules-checksum` annotation so that Talon restarts when its rules or `config.rulesOverride` change, and a folder annotation for the Grafana dashboards

`k8s-metacollector` is unchanged. The chart `version` is not bumped here since that will happen in the chart release PR.

**Which issue(s) this PR fixes**:

Related to #3967

**Special notes for your reviewer**:

- With the default values, the `helm template` output is identical before and after the bump
- With `falcosidekick.enabled=true` and/or `responseActions.enabled=true`, the only differences are the `helm.sh/chart` labels (and the `checksum/config` annotation derived from them), the test pod image and endpoint, the Talon Secret `namespace`, and the Talon `rules-checksum` annotation
- `make chart-check` passes locally, `ct lint` and `ct install` are left to the CI

**Does this PR introduce a user-facing change?**:

```release-note
update(chart): bump the falcosidekick subchart constraint to 0.14.* and the falco-talon subchart constraint to 0.4.*
```
